### PR TITLE
Avoid full round scan when deleting songs

### DIFF
--- a/musicround/routes/api.py
+++ b/musicround/routes/api.py
@@ -118,13 +118,19 @@ def song_detail(song_id):
         })
         
     elif request.method == 'DELETE':
-        # Check if the song is used in any rounds before deleting
-        rounds_with_song = []
-        
-        for round_obj in Round.query.all():
-            song_ids = round_obj.songs.split(',')
-            if str(song_id) in song_ids:
-                rounds_with_song.append(round_obj.id)
+        # Check for exact membership in the comma-separated round song list without
+        # loading every Round row into Python.
+        song_id_token = str(song_id)
+        rounds_with_song = [
+            round_id for (round_id,) in Round.query.with_entities(Round.id).filter(
+                db.or_(
+                    Round.songs == song_id_token,
+                    Round.songs.like(f'{song_id_token},%'),
+                    Round.songs.like(f'%,{song_id_token},%'),
+                    Round.songs.like(f'%,{song_id_token}'),
+                )
+            ).all()
+        ]
         
         if rounds_with_song:
             # The song is used in rounds, return error

--- a/musicround/routes/api.py
+++ b/musicround/routes/api.py
@@ -120,10 +120,10 @@ def song_detail(song_id):
     elif request.method == 'DELETE':
         # Check for exact membership in the comma-separated round song list without
         # loading every Round row into Python.
-        song_id_token = str(song_id)
+        song_id_token = str(song.id)
         rounds_with_song = [
             round_id for (round_id,) in Round.query.with_entities(Round.id).filter(
-                db.or_(
+                or_(
                     Round.songs == song_id_token,
                     Round.songs.like(f'{song_id_token},%'),
                     Round.songs.like(f'%,{song_id_token},%'),


### PR DESCRIPTION
## Summary
- replace the delete-song full `Round.query.all()` scan with a filtered `Round.id` query
- match exact song IDs in the comma-separated `Round.songs` field to avoid false partial matches

## Testing
- `python3 -m py_compile musicround/routes/api.py`

Triggered by the Jules performance finding in Gmail message `19ef0eb80721996c`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized database query performance when deleting songs and checking for associated round references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->