### PR TITLE
[codex] Add round sanity gate and repair MCP tools

### DIFF
--- a/docs/developer-guide/mcp.md
+++ b/docs/developer-guide/mcp.md
@@ -53,6 +53,7 @@ The MCP server exposes these tools:
 | `inspect_round_mp3` | Check round MP3 duration, loudness, silence, and clipping indicators. |
 | `inspect_round_pdf` | Check round PDF existence and basic structural validity. |
 | `inspect_round_package` | Check preview availability and length, expected generated MP3 length, MP3 quality, and PDF integrity. |
+| `round_repair_report` | Return package quality plus a human-readable blocked/repair report. |
 | `send_round_email` | Generate assets, block on failed package checks, and email only robust round bundles. |
 | `generate_tts_snippet` | Generate and assign custom intro, replay, or outro TTS MP3s. |
 
@@ -78,10 +79,11 @@ fields whose names contain `password`, `token`, or `secret` unless
 6. Send the completed bundle with `send_round_email`; it reruns the package
    checks and refuses to send if previews or generated assets look wrong.
 
-When `inspect_round_package` or `send_round_email` returns
-`needs_substitution`, read the failed `preview_checks` position, call
-`suggest_replacement_songs`, then call `replace_round_song`. Regenerate assets
-after any replacement because the generated MP3/PDF flags are invalidated.
+When `inspect_round_package`, `round_repair_report`, or `send_round_email`
+returns `needs_substitution`, read the failed `preview_checks` position or the
+report's `failed_positions`, call `suggest_replacement_songs`, then call
+`replace_round_song`. Regenerate assets after any replacement because the
+generated MP3/PDF flags are invalidated.
 
 For Spotify imports, pass a `user_id` for a user with connected Spotify tokens.
 For email, either pass an explicit recipient or use a selected user that has an

--- a/docs/developer-guide/mcp.md
+++ b/docs/developer-guide/mcp.md
@@ -50,7 +50,8 @@ The MCP server exposes these tools:
 | `generate_round_assets` | Generate the round PDF and/or MP3. |
 | `inspect_round_mp3` | Check round MP3 duration, loudness, silence, and clipping indicators. |
 | `inspect_round_pdf` | Check round PDF existence and basic structural validity. |
-| `send_round_email` | Generate assets and email the finished round bundle. |
+| `inspect_round_package` | Check preview availability and length, expected generated MP3 length, MP3 quality, and PDF integrity. |
+| `send_round_email` | Generate assets, block on failed package checks, and email only robust round bundles. |
 | `generate_tts_snippet` | Generate and assign custom intro, replay, or outro TTS MP3s. |
 
 `find_songs` includes `used_count`, `usage_frequency`, and `last_used` for each
@@ -68,9 +69,12 @@ fields whose names contain `password`, `token`, or `secret` unless
 2. Add missing tracks with `add_song` or import platform content with
    `import_catalog_item`.
 3. Create the round with `compile_round` or `create_round_from_playlist`.
+   Playlist imports return `needs_more_songs` instead of creating a partial
+   round when fewer than the requested eight tracks resolve.
 4. Generate PDF and MP3 files with `generate_round_assets`.
-5. Inspect the generated files with `inspect_round_pdf` and `inspect_round_mp3`.
-6. Send the completed bundle with `send_round_email`.
+5. Inspect the generated files and previews with `inspect_round_package`.
+6. Send the completed bundle with `send_round_email`; it reruns the package
+   checks and refuses to send if previews or generated assets look wrong.
 
 For Spotify imports, pass a `user_id` for a user with connected Spotify tokens.
 For email, either pass an explicit recipient or use a selected user that has an

--- a/docs/developer-guide/mcp.md
+++ b/docs/developer-guide/mcp.md
@@ -46,6 +46,8 @@ The MCP server exposes these tools:
 | `import_catalog_item` | Import a Spotify or Deezer track, album, or playlist. |
 | `compile_round` | Create a named round from explicit song IDs or selection criteria. |
 | `rename_round` | Set or clear a round name. |
+| `suggest_replacement_songs` | Suggest catalog songs for one failed round position. |
+| `replace_round_song` | Replace one song at a 1-based round position and invalidate generated assets. |
 | `create_round_from_playlist` | Import a playlist and turn the imported songs into a round. |
 | `generate_round_assets` | Generate the round PDF and/or MP3. |
 | `inspect_round_mp3` | Check round MP3 duration, loudness, silence, and clipping indicators. |
@@ -75,6 +77,11 @@ fields whose names contain `password`, `token`, or `secret` unless
 5. Inspect the generated files and previews with `inspect_round_package`.
 6. Send the completed bundle with `send_round_email`; it reruns the package
    checks and refuses to send if previews or generated assets look wrong.
+
+When `inspect_round_package` or `send_round_email` returns
+`needs_substitution`, read the failed `preview_checks` position, call
+`suggest_replacement_songs`, then call `replace_round_song`. Regenerate assets
+after any replacement because the generated MP3/PDF flags are invalidated.
 
 For Spotify imports, pass a `user_id` for a user with connected Spotify tokens.
 For email, either pass an explicit recipient or use a selected user that has an

--- a/musicround/mcp_server.py
+++ b/musicround/mcp_server.py
@@ -222,14 +222,19 @@ def create_round_from_playlist(
     user_id: int | None = None,
 ) -> dict[str, Any]:
     """Import a Spotify or Deezer playlist and turn it into a quiz round."""
-    return _with_app_context(
-        automation.create_round_from_playlist,
-        service_name=service_name,
-        playlist_id_or_url=playlist_id_or_url,
-        name=name,
-        count=count,
-        user_id=user_id,
-    )
+    try:
+        return _with_app_context(
+            automation.create_round_from_playlist,
+            service_name=service_name,
+            playlist_id_or_url=playlist_id_or_url,
+            name=name,
+            count=count,
+            user_id=user_id,
+        )
+    except automation.AutomationError as exc:
+        if exc.details:
+            return exc.details
+        raise
 
 
 @mcp.tool()
@@ -262,6 +267,27 @@ def inspect_round_pdf(path: str | None = None, round_id: int | None = None) -> d
 
 
 @mcp.tool()
+def inspect_round_package(
+    round_id: int,
+    user_id: int | None = None,
+    expected_song_count: int = 8,
+    min_preview_seconds: float = 20.0,
+    max_preview_seconds: float = 35.0,
+    duration_tolerance_seconds: float = 6.0,
+) -> dict[str, Any]:
+    """Check previews, generated MP3 length, MP3 quality, and PDF integrity before sending."""
+    return _with_app_context(
+        automation.inspect_round_package,
+        round_id=round_id,
+        user_id=user_id,
+        expected_song_count=expected_song_count,
+        min_preview_seconds=min_preview_seconds,
+        max_preview_seconds=max_preview_seconds,
+        duration_tolerance_seconds=duration_tolerance_seconds,
+    )
+
+
+@mcp.tool()
 def send_round_email(
     round_id: int,
     recipient: str | None = None,
@@ -270,14 +296,19 @@ def send_round_email(
     body_text: str | None = None,
 ) -> dict[str, Any]:
     """Generate assets and email the completed round bundle."""
-    return _with_app_context(
-        automation.email_round,
-        round_id=round_id,
-        recipient=recipient,
-        user_id=user_id,
-        subject=subject,
-        body_text=body_text,
-    )
+    try:
+        return _with_app_context(
+            automation.email_round,
+            round_id=round_id,
+            recipient=recipient,
+            user_id=user_id,
+            subject=subject,
+            body_text=body_text,
+        )
+    except automation.AutomationError as exc:
+        if exc.details:
+            return exc.details
+        raise
 
 
 @mcp.tool()

--- a/musicround/mcp_server.py
+++ b/musicround/mcp_server.py
@@ -214,6 +214,48 @@ def rename_round(round_id: int, name: str | None) -> dict[str, Any]:
 
 
 @mcp.tool()
+def suggest_replacement_songs(
+    round_id: int,
+    position: int,
+    limit: int = 10,
+    query: str | None = None,
+    require_deezer_id: bool = True,
+    verify_previews: bool = False,
+    min_preview_seconds: float = 20.0,
+) -> dict[str, Any]:
+    """Suggest replacement songs for one failed round position."""
+    return _with_app_context(
+        automation.suggest_replacement_songs,
+        round_id=round_id,
+        position=position,
+        limit=limit,
+        query=query,
+        require_deezer_id=require_deezer_id,
+        verify_previews=verify_previews,
+        min_preview_seconds=min_preview_seconds,
+    )
+
+
+@mcp.tool()
+def replace_round_song(
+    round_id: int,
+    position: int,
+    replacement_song_id: int,
+    inspect_after: bool = False,
+    user_id: int | None = None,
+) -> dict[str, Any]:
+    """Replace one song at a 1-based round position and invalidate generated assets."""
+    return _with_app_context(
+        automation.replace_round_song,
+        round_id=round_id,
+        position=position,
+        replacement_song_id=replacement_song_id,
+        inspect_after=inspect_after,
+        user_id=user_id,
+    )
+
+
+@mcp.tool()
 def create_round_from_playlist(
     service_name: str,
     playlist_id_or_url: str,

--- a/musicround/mcp_server.py
+++ b/musicround/mcp_server.py
@@ -330,6 +330,27 @@ def inspect_round_package(
 
 
 @mcp.tool()
+def round_repair_report(
+    round_id: int,
+    user_id: int | None = None,
+    expected_song_count: int = 8,
+    min_preview_seconds: float = 20.0,
+    max_preview_seconds: float = 35.0,
+    duration_tolerance_seconds: float = 6.0,
+) -> dict[str, Any]:
+    """Return package quality plus a human-readable repair report."""
+    return _with_app_context(
+        automation.round_repair_report,
+        round_id=round_id,
+        user_id=user_id,
+        expected_song_count=expected_song_count,
+        min_preview_seconds=min_preview_seconds,
+        max_preview_seconds=max_preview_seconds,
+        duration_tolerance_seconds=duration_tolerance_seconds,
+    )
+
+
+@mcp.tool()
 def send_round_email(
     round_id: int,
     recipient: str | None = None,

--- a/musicround/services/automation.py
+++ b/musicround/services/automation.py
@@ -1004,6 +1004,120 @@ def _round_audio_components(
     return components, issues
 
 
+def _round_repair_report(quality: dict[str, Any]) -> dict[str, Any]:
+    round_label = quality.get("round_name") or f"Round {quality.get('round_id')}"
+    status = quality.get("status", "blocked")
+    ok = bool(quality.get("ok"))
+    issues = quality.get("issues", [])
+    remediation = quality.get("remediation", [])
+    preview_checks = quality.get("preview_checks", [])
+
+    if ok:
+        headline = f"{round_label} is ready to send."
+        summary = (
+            f"{quality.get('resolved_song_count', quality.get('song_count', 0))} songs, "
+            "all previews and generated assets passed the package gate."
+        )
+    else:
+        headline = f"{round_label} is blocked: {status}."
+        summary = (
+            f"{len(issues)} issue(s) found. Expected "
+            f"{quality.get('expected_song_count')} songs, found "
+            f"{quality.get('resolved_song_count', quality.get('song_count'))} playable songs."
+        )
+
+    blockers: list[str] = []
+    for issue in issues:
+        song = issue.get("song")
+        prefix = ""
+        if song:
+            prefix = f"{song.get('artist')} - {song.get('title')}: "
+        blockers.append(f"{prefix}{issue.get('message')}")
+
+    failed_positions = []
+    for check in preview_checks:
+        if check.get("ok"):
+            continue
+        failed_positions.append(
+            {
+                "position": check.get("position"),
+                "song_id": check.get("song_id"),
+                "artist": check.get("artist"),
+                "title": check.get("title"),
+                "issue_code": check.get("issue_code"),
+                "message": (
+                    f"Position {check.get('position')}: "
+                    f"{check.get('artist')} - {check.get('title')}"
+                ),
+            }
+        )
+
+    actions = []
+    seen_actions = set()
+    for item in remediation:
+        action = item.get("action")
+        if action == "replace_position":
+            text = (
+                f"Replace position {item.get('position')} "
+                f"({item.get('artist')} - {item.get('title')}) and regenerate assets."
+            )
+        elif action == "add_missing_track":
+            text = (
+                f"Add {item.get('expected_song_count') - item.get('actual_song_count')} "
+                "missing song(s), then regenerate assets."
+            )
+        elif action == "remove_extra_track":
+            text = "Remove extra song(s), then regenerate assets."
+        elif action == "replace_unresolved_positions":
+            positions = ", ".join(str(position) for position in item.get("positions", []))
+            text = f"Replace unresolved position(s) {positions}, then regenerate assets."
+        elif action == "regenerate_assets":
+            text = "Regenerate PDF and MP3, then rerun the package inspection."
+        else:
+            text = item.get("message") or f"Run remediation action {action}."
+        if text not in seen_actions:
+            seen_actions.add(text)
+            actions.append({"action": action, "message": text, "details": item})
+
+    if status == "needs_substitution" and failed_positions:
+        next_step = (
+            "Call suggest_replacement_songs for each failed position, then "
+            "replace_round_song, regenerate assets, and rerun inspect_round_package."
+        )
+    elif status == "needs_more_songs":
+        next_step = (
+            "Complete the round to exactly the expected number of playable songs, "
+            "regenerate assets, and rerun inspect_round_package."
+        )
+    elif status == "render_failed":
+        next_step = "Regenerate assets or fix the renderer inputs, then rerun inspect_round_package."
+    elif ok:
+        next_step = "Send the round email."
+    else:
+        next_step = "Resolve the listed blockers and rerun inspect_round_package."
+
+    markdown_lines = [f"# {headline}", "", summary]
+    if blockers:
+        markdown_lines.extend(["", "## Blockers"])
+        markdown_lines.extend(f"- {blocker}" for blocker in blockers)
+    if actions:
+        markdown_lines.extend(["", "## Repair actions"])
+        markdown_lines.extend(f"- {action['message']}" for action in actions)
+    markdown_lines.extend(["", "## Next step", next_step])
+
+    return {
+        "headline": headline,
+        "summary": summary,
+        "status": status,
+        "ok": ok,
+        "blockers": blockers,
+        "failed_positions": failed_positions,
+        "actions": actions,
+        "next_step": next_step,
+        "markdown": "\n".join(markdown_lines),
+    }
+
+
 def inspect_round_package(
     round_id: int,
     user_id: int | None = None,
@@ -1250,7 +1364,7 @@ def inspect_round_package(
     else:
         status = "blocked"
 
-    return {
+    result = {
         "round_id": round_id,
         "round_name": round_obj.name,
         "status": status,
@@ -1268,6 +1382,28 @@ def inspect_round_package(
         "remediation": remediation,
         "ok": not issues,
     }
+    result["report"] = _round_repair_report(result)
+    return result
+
+
+def round_repair_report(
+    round_id: int,
+    user_id: int | None = None,
+    expected_song_count: int = 8,
+    min_preview_seconds: float = 20.0,
+    max_preview_seconds: float = 35.0,
+    duration_tolerance_seconds: float = 6.0,
+) -> dict[str, Any]:
+    """Return the package quality payload plus a human-readable repair report."""
+    quality = inspect_round_package(
+        round_id=round_id,
+        user_id=user_id,
+        expected_song_count=expected_song_count,
+        min_preview_seconds=min_preview_seconds,
+        max_preview_seconds=max_preview_seconds,
+        duration_tolerance_seconds=duration_tolerance_seconds,
+    )
+    return {"quality": quality, "report": quality["report"]}
 
 
 def email_round(
@@ -1286,6 +1422,7 @@ def email_round(
     assets = generate_round_assets(round_id, user_id=user.id)
     quality = inspect_round_package(round_id, user_id=user.id)
     if not quality["ok"]:
+        report = quality.get("report") or _round_repair_report(quality)
         message = "Round quality gate failed: " + "; ".join(quality["hints"])
         db.session.add(
             RoundExport(
@@ -1307,6 +1444,7 @@ def email_round(
                 "recipient": target,
                 "assets": assets,
                 "quality": quality,
+                "report": report,
             },
         )
 

--- a/musicround/services/automation.py
+++ b/musicround/services/automation.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import os
 import re
+import tempfile
 from datetime import datetime
 from typing import Any, Iterable
 
+import requests
 from flask import current_app
 from flask_login import login_user, logout_user
 from pydub import AudioSegment
@@ -16,13 +18,28 @@ from sqlalchemy import or_
 from musicround import db
 from musicround.helpers.email_helper import send_email
 from musicround.helpers.import_helper import ImportHelper
-from musicround.helpers.utils import generate_tts_mp3
+from musicround.helpers.utils import generate_tts_mp3, get_mp3_path
 from musicround import models as datastore_models
 from musicround.models import Round, RoundExport, Song, Tag, User
 
 
 class AutomationError(ValueError):
     """Raised when an automation request cannot be completed."""
+
+    def __init__(self, message: str, details: dict[str, Any] | None = None) -> None:
+        super().__init__(message)
+        self.details = details or {}
+
+
+def _round_song_ids(round_obj: Round) -> list[int]:
+    return [int(song_id) for song_id in round_obj.songs.split(",") if song_id]
+
+
+def _ordered_round_songs(round_obj: Round) -> list[Song]:
+    ids = _round_song_ids(round_obj)
+    songs = Song.query.filter(Song.id.in_(ids)).all()
+    songs_by_id = {song.id: song for song in songs}
+    return [songs_by_id[song_id] for song_id in ids if song_id in songs_by_id]
 
 
 def _song_summary(song: Song) -> dict[str, Any]:
@@ -46,10 +63,8 @@ def _song_summary(song: Song) -> dict[str, Any]:
 
 
 def _round_summary(round_obj: Round) -> dict[str, Any]:
-    ids = [int(song_id) for song_id in round_obj.songs.split(",") if song_id]
-    songs = Song.query.filter(Song.id.in_(ids)).all()
-    songs_by_id = {song.id: song for song in songs}
-    ordered = [songs_by_id[song_id] for song_id in ids if song_id in songs_by_id]
+    ids = _round_song_ids(round_obj)
+    ordered = _ordered_round_songs(round_obj)
     return {
         "id": round_obj.id,
         "name": round_obj.name,
@@ -652,8 +667,38 @@ def create_round_from_playlist(
         ) or _deezer_playlist_song_ids(playlist_id, count)
     if not song_ids:
         raise AutomationError("Playlist import did not return song IDs to build a round.")
+    if len(song_ids) < count:
+        message = (
+            f"Playlist import resolved {len(song_ids)} songs; "
+            f"expected exactly {count} for a complete quiz round."
+        )
+        raise AutomationError(
+            message,
+            details={
+                "success": False,
+                "status": "needs_more_songs",
+                "service": service_name.lower(),
+                "playlist_id": playlist_id,
+                "expected_song_count": count,
+                "resolved_song_count": len(song_ids),
+                "missing_count": count - len(song_ids),
+                "import": imported,
+                "hints": [message],
+                "remediation": [
+                    {
+                        "action": "add_or_replace_playlist_tracks",
+                        "message": message,
+                        "expected_song_count": count,
+                        "resolved_song_count": len(song_ids),
+                    }
+                ],
+            },
+        )
     round_result = create_round(
-        name=name, round_type="manual", count=count, song_ids=song_ids[:count]
+        name=name,
+        round_type="manual",
+        count=count,
+        song_ids=song_ids[:count],
     )
     return {"import": imported, "round": round_result["round"]}
 
@@ -714,6 +759,378 @@ def generate_round_assets(
     return assets
 
 
+def _quality_issue(
+    code: str,
+    message: str,
+    song: Song | None = None,
+    details: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    issue: dict[str, Any] = {"code": code, "severity": "error", "message": message}
+    if song:
+        issue["song"] = {
+            "id": song.id,
+            "title": song.title,
+            "artist": song.artist,
+            "deezer_id": song.deezer_id,
+            "spotify_id": song.spotify_id,
+        }
+    if details:
+        issue["details"] = details
+    return issue
+
+
+def _download_preview_audio(
+    song: Song, temp_dir: str
+) -> tuple[str | None, AudioSegment | None, dict[str, Any] | None]:
+    if not song.deezer_id:
+        return None, None, _quality_issue(
+            "missing_deezer_id",
+            f"{song.artist} - {song.title} has no Deezer ID, so the MP3 generator will skip it.",
+            song,
+        )
+
+    deezer_client = current_app.config.get("deezer")
+    if not deezer_client:
+        return None, None, _quality_issue(
+            "deezer_client_missing",
+            "The Deezer client is not configured, so preview availability cannot be verified.",
+            song,
+        )
+
+    try:
+        track = deezer_client.get_track(song.deezer_id)
+    except Exception as exc:
+        return None, None, _quality_issue(
+            "deezer_lookup_failed",
+            f"Could not fetch Deezer metadata for {song.artist} - {song.title}: {exc}",
+            song,
+        )
+
+    preview_url = track.get("preview") if isinstance(track, dict) else None
+    if not preview_url:
+        return None, None, _quality_issue(
+            "missing_preview_url",
+            f"{song.artist} - {song.title} has no Deezer preview URL.",
+            song,
+        )
+
+    try:
+        response = requests.get(preview_url, stream=True, timeout=30)
+        response.raise_for_status()
+        preview_path = os.path.join(temp_dir, f"preview_{song.id}.mp3")
+        with open(preview_path, "wb") as preview_file:
+            for chunk in response.iter_content(chunk_size=8192):
+                if chunk:
+                    preview_file.write(chunk)
+        return preview_url, AudioSegment.from_file(preview_path), None
+    except Exception as exc:
+        return preview_url, None, _quality_issue(
+            "preview_download_failed",
+            f"Could not download or decode preview for {song.artist} - {song.title}: {exc}",
+            song,
+            {"preview_url": preview_url},
+        )
+
+
+def _round_audio_components(
+    user: User, song_count: int
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    issues: list[dict[str, Any]] = []
+    components: dict[str, Any] = {"custom_audio_ms": {}, "number_audio_ms": []}
+
+    for mp3_type in ("intro", "replay", "outro"):
+        try:
+            segment = AudioSegment.from_mp3(get_mp3_path(user, mp3_type))
+            components["custom_audio_ms"][mp3_type] = len(segment)
+        except Exception as exc:
+            issues.append(
+                _quality_issue(
+                    "custom_audio_failed",
+                    f"Could not load {mp3_type} audio for duration validation: {exc}",
+                )
+            )
+
+    for index in range(song_count):
+        path = os.path.join(current_app.root_path, "static", "audio", f"{index + 1}.mp3")
+        try:
+            components["number_audio_ms"].append(len(AudioSegment.from_mp3(path)))
+        except Exception as exc:
+            issues.append(
+                _quality_issue(
+                    "number_audio_failed",
+                    f"Could not load number announcement {index + 1}: {exc}",
+                )
+            )
+
+    return components, issues
+
+
+def inspect_round_package(
+    round_id: int,
+    user_id: int | None = None,
+    expected_song_count: int = 8,
+    min_preview_seconds: float = 20.0,
+    max_preview_seconds: float = 35.0,
+    duration_tolerance_seconds: float = 6.0,
+) -> dict[str, Any]:
+    """Validate a generated round bundle before it is allowed to leave by email."""
+    round_obj = db.session.get(Round, round_id)
+    if not round_obj:
+        raise AutomationError(f"Round {round_id} was not found.")
+
+    user = _find_user(user_id)
+    song_ids = _round_song_ids(round_obj)
+    songs = _ordered_round_songs(round_obj)
+    issues: list[dict[str, Any]] = []
+    preview_checks: list[dict[str, Any]] = []
+    remediation: list[dict[str, Any]] = []
+    total_preview_ms = 0
+
+    actual_song_count = len(song_ids)
+    if actual_song_count != expected_song_count:
+        code = "actual_song_count_mismatch"
+        message = (
+            f"Round {round_id} has {actual_song_count} stored songs; "
+            f"expected exactly {expected_song_count}."
+        )
+        issues.append(
+            _quality_issue(
+                code,
+                message,
+                details={
+                    "expected_song_count": expected_song_count,
+                    "actual_song_count": actual_song_count,
+                },
+            )
+        )
+        remediation.append(
+            {
+                "action": "add_missing_track"
+                if actual_song_count < expected_song_count
+                else "remove_extra_track",
+                "message": message,
+                "expected_song_count": expected_song_count,
+                "actual_song_count": actual_song_count,
+            }
+        )
+
+    resolved_song_count = len(songs)
+    if resolved_song_count != actual_song_count:
+        resolved_song_ids = {song.id for song in songs}
+        unresolved_positions = [
+            index + 1
+            for index, song_id in enumerate(song_ids)
+            if song_id not in resolved_song_ids
+        ]
+        message = (
+            f"Round {round_id} resolves to {resolved_song_count} playable songs "
+            f"from {actual_song_count} stored IDs."
+        )
+        issues.append(
+            _quality_issue(
+                "resolved_song_count_mismatch",
+                message,
+                details={
+                    "expected_song_count": expected_song_count,
+                    "actual_song_count": actual_song_count,
+                    "resolved_song_count": resolved_song_count,
+                    "unresolved_positions": unresolved_positions,
+                },
+            )
+        )
+        remediation.append(
+            {
+                "action": "replace_unresolved_positions",
+                "message": message,
+                "positions": unresolved_positions,
+                "expected_song_count": expected_song_count,
+                "resolved_song_count": resolved_song_count,
+            }
+        )
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        for index, song in enumerate(songs, start=1):
+            preview_url, audio, issue = _download_preview_audio(song, temp_dir)
+            check = {
+                "position": index,
+                "song_id": song.id,
+                "title": song.title,
+                "artist": song.artist,
+                "preview_url": preview_url,
+                "duration_seconds": None,
+                "issue_code": None,
+                "remediation": None,
+                "ok": False,
+            }
+            if issue:
+                issues.append(issue)
+                check["issue_code"] = issue["code"]
+                check["remediation"] = "replace_position"
+                remediation.append(
+                    {
+                        "action": "replace_position",
+                        "position": index,
+                        "song_id": song.id,
+                        "artist": song.artist,
+                        "title": song.title,
+                        "issue_code": issue["code"],
+                        "message": issue["message"],
+                    }
+                )
+            elif audio:
+                duration_seconds = len(audio) / 1000
+                total_preview_ms += len(audio)
+                check["duration_seconds"] = round(duration_seconds, 3)
+                check["ok"] = True
+                if duration_seconds < min_preview_seconds:
+                    check["ok"] = False
+                    issue = _quality_issue(
+                        "preview_too_short",
+                        (
+                            f"{song.artist} - {song.title} preview is "
+                            f"{duration_seconds:.1f}s; expected at least "
+                            f"{min_preview_seconds:.1f}s."
+                        ),
+                        song,
+                        {"duration_seconds": round(duration_seconds, 3)},
+                    )
+                    issues.append(issue)
+                    check["issue_code"] = issue["code"]
+                    check["remediation"] = "replace_position"
+                    remediation.append(
+                        {
+                            "action": "replace_position",
+                            "position": index,
+                            "song_id": song.id,
+                            "artist": song.artist,
+                            "title": song.title,
+                            "issue_code": issue["code"],
+                            "message": issue["message"],
+                        }
+                    )
+                elif duration_seconds > max_preview_seconds:
+                    check["ok"] = False
+                    issue = _quality_issue(
+                        "preview_too_long",
+                        (
+                            f"{song.artist} - {song.title} preview is "
+                            f"{duration_seconds:.1f}s; expected at most "
+                            f"{max_preview_seconds:.1f}s."
+                        ),
+                        song,
+                        {"duration_seconds": round(duration_seconds, 3)},
+                    )
+                    issues.append(issue)
+                    check["issue_code"] = issue["code"]
+                    check["remediation"] = "replace_position"
+                    remediation.append(
+                        {
+                            "action": "replace_position",
+                            "position": index,
+                            "song_id": song.id,
+                            "artist": song.artist,
+                            "title": song.title,
+                            "issue_code": issue["code"],
+                            "message": issue["message"],
+                        }
+                    )
+            preview_checks.append(check)
+
+    components, component_issues = _round_audio_components(user, len(songs))
+    issues.extend(component_issues)
+    expected_ms = None
+    if not component_issues:
+        custom_audio_ms = components["custom_audio_ms"]
+        expected_ms = (
+            custom_audio_ms.get("intro", 0)
+            + custom_audio_ms.get("replay", 0)
+            + custom_audio_ms.get("outro", 0)
+            + 2 * sum(components["number_audio_ms"])
+            + 2 * total_preview_ms
+        )
+
+    pdf_result: dict[str, Any] | None = None
+    mp3_result: dict[str, Any] | None = None
+    try:
+        pdf_result = inspect_pdf_quality(round_id=round_id)
+        for warning in pdf_result.get("warnings", []):
+            issues.append(_quality_issue("pdf_quality_warning", warning))
+    except Exception as exc:
+        issues.append(_quality_issue("pdf_inspection_failed", str(exc)))
+
+    try:
+        mp3_result = inspect_mp3_quality(round_id=round_id)
+        for warning in mp3_result.get("warnings", []):
+            issues.append(_quality_issue("mp3_quality_warning", warning))
+    except Exception as exc:
+        issues.append(_quality_issue("mp3_inspection_failed", str(exc)))
+
+    if expected_ms is not None and mp3_result and mp3_result.get("duration_seconds") is not None:
+        expected_seconds = expected_ms / 1000
+        actual_seconds = float(mp3_result["duration_seconds"])
+        delta_seconds = actual_seconds - expected_seconds
+        if abs(delta_seconds) > duration_tolerance_seconds:
+            issue = _quality_issue(
+                "round_mp3_duration_mismatch",
+                (
+                    f"Generated MP3 is {actual_seconds:.1f}s, expected about "
+                    f"{expected_seconds:.1f}s from intro, replay, outro, number "
+                    "announcements, and two plays of every preview."
+                ),
+                details={
+                    "actual_seconds": round(actual_seconds, 3),
+                    "expected_seconds": round(expected_seconds, 3),
+                    "delta_seconds": round(delta_seconds, 3),
+                    "tolerance_seconds": duration_tolerance_seconds,
+                },
+            )
+            issues.append(issue)
+            remediation.append(
+                {
+                    "action": "regenerate_assets",
+                    "issue_code": issue["code"],
+                    "message": issue["message"],
+                }
+            )
+
+    issue_codes = {issue["code"] for issue in issues}
+    if not issues:
+        status = "ok"
+    elif issue_codes & {"actual_song_count_mismatch", "resolved_song_count_mismatch"}:
+        status = "needs_more_songs" if len(songs) < expected_song_count else "blocked"
+    elif issue_codes & {
+        "missing_deezer_id",
+        "missing_preview_url",
+        "preview_too_short",
+        "preview_too_long",
+        "preview_download_failed",
+    }:
+        status = "needs_substitution"
+    elif issue_codes & {"pdf_inspection_failed", "mp3_inspection_failed", "round_mp3_duration_mismatch"}:
+        status = "render_failed"
+    else:
+        status = "blocked"
+
+    return {
+        "round_id": round_id,
+        "round_name": round_obj.name,
+        "status": status,
+        "expected_song_count": expected_song_count,
+        "actual_song_count": actual_song_count,
+        "resolved_song_count": resolved_song_count,
+        "song_count": len(songs),
+        "preview_checks": preview_checks,
+        "components": components,
+        "expected_duration_seconds": None if expected_ms is None else round(expected_ms / 1000, 3),
+        "pdf": pdf_result,
+        "mp3": mp3_result,
+        "issues": issues,
+        "hints": [issue["message"] for issue in issues],
+        "remediation": remediation,
+        "ok": not issues,
+    }
+
+
 def email_round(
     round_id: int,
     recipient: str | None = None,
@@ -728,6 +1145,32 @@ def email_round(
         raise AutomationError("No recipient was provided and the selected user has no email.")
 
     assets = generate_round_assets(round_id, user_id=user.id)
+    quality = inspect_round_package(round_id, user_id=user.id)
+    if not quality["ok"]:
+        message = "Round quality gate failed: " + "; ".join(quality["hints"])
+        db.session.add(
+            RoundExport(
+                round_id=round_id,
+                user_id=user.id,
+                export_type="email",
+                destination=target,
+                include_mp3s=True,
+                status="failed",
+                error_message=message,
+            )
+        )
+        db.session.commit()
+        raise AutomationError(
+            message,
+            details={
+                "success": False,
+                "status": quality["status"],
+                "recipient": target,
+                "assets": assets,
+                "quality": quality,
+            },
+        )
+
     round_obj = db.session.get(Round, round_id)
     title = round_obj.name if round_obj and round_obj.name else f"Quizzical Beats Round {round_id}"
     email_subject = subject or title
@@ -765,7 +1208,13 @@ def email_round(
     db.session.commit()
     if not success:
         raise AutomationError(message)
-    return {"success": True, "message": message, "recipient": target, "assets": assets}
+    return {
+        "success": True,
+        "message": message,
+        "recipient": target,
+        "assets": assets,
+        "quality": quality,
+    }
 
 
 def inspect_mp3_quality(path: str | None = None, round_id: int | None = None) -> dict[str, Any]:

--- a/musicround/services/automation.py
+++ b/musicround/services/automation.py
@@ -617,6 +617,145 @@ def rename_round(round_id: int, name: str | None) -> dict[str, Any]:
     return {"round": _round_summary(round_obj)}
 
 
+def _song_position(round_obj: Round, position: int) -> tuple[list[int], int]:
+    song_ids = _round_song_ids(round_obj)
+    if position < 1 or position > len(song_ids):
+        raise AutomationError(
+            f"Position {position} is outside this round. Allowed positions are 1-{len(song_ids)}."
+        )
+    return song_ids, position - 1
+
+
+def replace_round_song(
+    round_id: int,
+    position: int,
+    replacement_song_id: int,
+    inspect_after: bool = False,
+    user_id: int | None = None,
+) -> dict[str, Any]:
+    """Replace one song at a 1-based round position and mark generated assets stale."""
+    round_obj = db.session.get(Round, round_id)
+    if not round_obj:
+        raise AutomationError(f"Round {round_id} was not found.")
+
+    song_ids, index = _song_position(round_obj, position)
+    replacement = db.session.get(Song, replacement_song_id)
+    if not replacement:
+        raise AutomationError(f"Song {replacement_song_id} was not found.")
+
+    old_song_id = song_ids[index]
+    old_song = db.session.get(Song, old_song_id)
+    song_ids[index] = replacement.id
+    round_obj.songs = ",".join(str(song_id) for song_id in song_ids)
+    round_obj.reset_generated_status()
+    round_obj.updated_at = datetime.utcnow()
+    db.session.commit()
+
+    result: dict[str, Any] = {
+        "round": _round_summary(round_obj),
+        "position": position,
+        "replaced_song": _song_summary(old_song) if old_song else {"id": old_song_id},
+        "replacement_song": _song_summary(replacement),
+        "assets_invalidated": True,
+    }
+    if inspect_after:
+        result["quality"] = inspect_round_package(round_id, user_id=user_id)
+    return result
+
+
+def suggest_replacement_songs(
+    round_id: int,
+    position: int,
+    limit: int = 10,
+    query: str | None = None,
+    require_deezer_id: bool = True,
+    verify_previews: bool = False,
+    min_preview_seconds: float = 20.0,
+) -> dict[str, Any]:
+    """Suggest catalog songs that can replace a failed round position."""
+    if limit < 1 or limit > 50:
+        raise AutomationError("limit must be between 1 and 50.")
+
+    round_obj = db.session.get(Round, round_id)
+    if not round_obj:
+        raise AutomationError(f"Round {round_id} was not found.")
+
+    song_ids, index = _song_position(round_obj, position)
+    original_song = db.session.get(Song, song_ids[index])
+    excluded_ids = set(song_ids)
+
+    song_query = Song.query.filter(~Song.id.in_(excluded_ids))
+    if require_deezer_id:
+        song_query = song_query.filter(Song.deezer_id.isnot(None))
+    if query:
+        pattern = f"%{query.strip()}%"
+        song_query = song_query.filter(or_(Song.title.ilike(pattern), Song.artist.ilike(pattern)))
+
+    candidates = song_query.limit(250).all()
+
+    def _candidate_score(song: Song) -> tuple[int, int, int, int, str, str]:
+        genre_match = 1 if original_song and song.genre and song.genre == original_song.genre else 0
+        original_year = original_song.year if original_song and original_song.year else None
+        year_distance = abs(song.year - original_year) if song.year and original_year else 9999
+        preview_signal = 1 if song.preview_url or song.deezer_preview_url or song.spotify_preview_url else 0
+        used_count = song.used_count or 0
+        return (-genre_match, year_distance, -preview_signal, used_count, song.artist or "", song.title or "")
+
+    suggestions = []
+    for song in sorted(candidates, key=_candidate_score):
+        suggestion = _song_summary(song)
+        suggestion["same_genre"] = bool(original_song and song.genre and song.genre == original_song.genre)
+        suggestion["year_distance"] = (
+            abs(song.year - original_song.year)
+            if original_song and song.year and original_song.year
+            else None
+        )
+        suggestion["preview_check"] = {
+            "required": verify_previews,
+            "ok": None,
+            "duration_seconds": None,
+            "issue_code": None,
+        }
+        suggestions.append(suggestion)
+
+    if verify_previews:
+        verified = []
+        with tempfile.TemporaryDirectory() as temp_dir:
+            for suggestion in suggestions:
+                song = db.session.get(Song, suggestion["id"])
+                preview_url, audio, issue = _download_preview_audio(song, temp_dir)
+                suggestion["preview_url"] = preview_url or suggestion["preview_url"]
+                if issue:
+                    suggestion["preview_check"]["ok"] = False
+                    suggestion["preview_check"]["issue_code"] = issue["code"]
+                    continue
+                duration_seconds = len(audio) / 1000 if audio else 0
+                suggestion["preview_check"]["duration_seconds"] = round(duration_seconds, 3)
+                suggestion["preview_check"]["ok"] = duration_seconds >= min_preview_seconds
+                if duration_seconds < min_preview_seconds:
+                    suggestion["preview_check"]["issue_code"] = "preview_too_short"
+                    continue
+                verified.append(suggestion)
+                if len(verified) >= limit:
+                    break
+        suggestions = verified
+
+    return {
+        "round_id": round_id,
+        "round_name": round_obj.name,
+        "position": position,
+        "original_song": _song_summary(original_song) if original_song else {"id": song_ids[index]},
+        "count": min(len(suggestions), limit),
+        "suggestions": suggestions[:limit],
+        "filters": {
+            "query": query,
+            "require_deezer_id": require_deezer_id,
+            "verify_previews": verify_previews,
+            "excluded_song_ids": sorted(excluded_ids),
+        },
+    }
+
+
 def _spotify_playlist_song_ids(playlist_id: str, limit: int, user_id: int | None) -> list[int]:
     from musicround.routes.generate import get_songs_from_spotify_playlist
 

--- a/tests/test_automation_service.py
+++ b/tests/test_automation_service.py
@@ -353,6 +353,10 @@ class TestAssetInspection:
             assert any(issue["code"] == "missing_preview_url" for issue in result["issues"])
             assert result["preview_checks"][0]["issue_code"] == "missing_preview_url"
             assert result["remediation"][0]["action"] == "replace_position"
+            assert result["report"]["status"] == "needs_substitution"
+            assert result["report"]["failed_positions"][0]["position"] == 1
+            assert "suggest_replacement_songs" in result["report"]["next_step"]
+            assert "Position 1" in result["report"]["markdown"]
 
     def test_inspect_round_package_warns_for_short_preview(self, app):
         with app.app_context():
@@ -465,6 +469,7 @@ class TestAssetInspection:
 
             assert not mock_send.called
             assert exc_info.value.details["status"] == "needs_substitution"
+            assert exc_info.value.details["report"]["status"] == "needs_substitution"
             export = RoundExport.query.filter_by(round_id=round_id).one()
             assert export.status == "failed"
 

--- a/tests/test_automation_service.py
+++ b/tests/test_automation_service.py
@@ -112,6 +112,83 @@ class TestRoundAutomation:
             assert exc_info.value.details["expected_song_count"] == 8
             assert exc_info.value.details["resolved_song_count"] == 1
 
+    def test_replace_round_song_updates_position_and_invalidates_assets(self, app):
+        with app.app_context():
+            song_one = _create_song(title="One", artist="A")
+            song_two = _create_song(title="Two", artist="B")
+            replacement = _create_song(title="Replacement", artist="C")
+            round_id = automation.create_round(
+                name="Repair Me",
+                round_type="manual",
+                song_ids=[song_one.id, song_two.id],
+            )["round"]["id"]
+            round_obj = db.session.get(Round, round_id)
+            round_obj.mp3_generated = True
+            round_obj.pdf_generated = True
+            db.session.commit()
+
+            result = automation.replace_round_song(
+                round_id,
+                position=2,
+                replacement_song_id=replacement.id,
+            )
+
+            assert result["position"] == 2
+            assert result["replaced_song"]["id"] == song_two.id
+            assert result["replacement_song"]["id"] == replacement.id
+            assert result["round"]["song_ids"] == [song_one.id, replacement.id]
+            refreshed_round = db.session.get(Round, round_id)
+            assert refreshed_round.mp3_generated is False
+            assert refreshed_round.pdf_generated is False
+
+    def test_suggest_replacement_songs_prefers_similar_unused_candidates(self, app):
+        with app.app_context():
+            original = _create_song(
+                title="Broken",
+                artist="A",
+                genre="Rock",
+                year=1990,
+                deezer_id=100,
+            )
+            in_round = _create_song(
+                title="Already In Round",
+                artist="B",
+                genre="Rock",
+                year=1991,
+                deezer_id=101,
+            )
+            best = _create_song(
+                title="Best",
+                artist="C",
+                genre="Rock",
+                year=1992,
+                deezer_id=102,
+            )
+            _create_song(
+                title="Different",
+                artist="D",
+                genre="Pop",
+                year=2010,
+                deezer_id=103,
+            )
+            round_id = automation.create_round(
+                name="Needs Candidate",
+                round_type="manual",
+                song_ids=[original.id, in_round.id],
+            )["round"]["id"]
+
+            result = automation.suggest_replacement_songs(
+                round_id,
+                position=1,
+                limit=3,
+            )
+
+            suggestion_ids = [song["id"] for song in result["suggestions"]]
+            assert best.id == suggestion_ids[0]
+            assert original.id not in suggestion_ids
+            assert in_round.id not in suggestion_ids
+            assert result["suggestions"][0]["same_genre"] is True
+
 
 class TestAssetInspection:
     """Tests for generated asset quality checks."""

--- a/tests/test_automation_service.py
+++ b/tests/test_automation_service.py
@@ -356,7 +356,7 @@ class TestAssetInspection:
             assert result["report"]["status"] == "needs_substitution"
             assert result["report"]["failed_positions"][0]["position"] == 1
             assert "suggest_replacement_songs" in result["report"]["next_step"]
-            assert "Position 1" in result["report"]["markdown"]
+            assert "Replace position 1" in result["report"]["markdown"]
 
     def test_inspect_round_package_warns_for_short_preview(self, app):
         with app.app_context():

--- a/tests/test_automation_service.py
+++ b/tests/test_automation_service.py
@@ -6,11 +6,12 @@ import tempfile
 from unittest.mock import patch
 
 import pytest
+from pydub import AudioSegment
 
 os.environ.setdefault("SECRET_KEY", "test-secret-key-for-testing-only")
 os.environ.setdefault("AUTOMATION_TOKEN", "test-automation-token-for-testing")
 
-from musicround.models import Song, SongTag, Tag, User, db
+from musicround.models import Round, RoundExport, Song, SongTag, Tag, User, db
 from musicround.services import automation
 
 
@@ -86,6 +87,31 @@ class TestRoundAutomation:
             assert renamed["round"]["name"] == "Final Name"
             assert Song.query.get(song_one.id).used_count == 1
 
+    def test_create_round_from_playlist_fails_when_too_few_tracks_resolve(self, app):
+        with app.app_context():
+            song = _create_song(title="Only Resolved", artist="A")
+
+            with (
+                patch(
+                    "musicround.services.automation.import_catalog_item",
+                    return_value={"item_id": "playlist123", "result": {}},
+                ),
+                patch(
+                    "musicround.services.automation._spotify_playlist_song_ids",
+                    return_value=[song.id],
+                ),
+            ):
+                with pytest.raises(automation.AutomationError) as exc_info:
+                    automation.create_round_from_playlist(
+                        "spotify",
+                        "playlist123",
+                        count=8,
+                    )
+
+            assert exc_info.value.details["status"] == "needs_more_songs"
+            assert exc_info.value.details["expected_song_count"] == 8
+            assert exc_info.value.details["resolved_song_count"] == 1
+
 
 class TestAssetInspection:
     """Tests for generated asset quality checks."""
@@ -118,6 +144,252 @@ class TestAssetInspection:
         assert result["duration_seconds"] > 0
         assert result["channels"] >= 1
         assert "ok" in result
+
+    def test_inspect_round_package_requires_exact_song_count(self, app):
+        with app.app_context():
+            user = _create_user()
+            song = _create_song(title="Only One", artist="Artist", deezer_id="123")
+            round_id = automation.create_round(
+                name="Too Short",
+                round_type="manual",
+                song_ids=[song.id],
+            )["round"]["id"]
+
+            with (
+                patch(
+                    "musicround.services.automation._download_preview_audio",
+                    return_value=("https://example.test/preview.mp3", AudioSegment.silent(duration=30000), None),
+                ),
+                patch(
+                    "musicround.services.automation._round_audio_components",
+                    return_value=(
+                        {"custom_audio_ms": {"intro": 1000, "replay": 1000, "outro": 1000}, "number_audio_ms": [1000]},
+                        [],
+                    ),
+                ),
+                patch(
+                    "musicround.services.automation.inspect_pdf_quality",
+                    return_value={"warnings": [], "ok": True},
+                ),
+                patch(
+                    "musicround.services.automation.inspect_mp3_quality",
+                    return_value={"warnings": [], "ok": True, "duration_seconds": 65},
+                ),
+            ):
+                result = automation.inspect_round_package(round_id, user_id=user.id)
+
+            assert result["ok"] is False
+            assert result["status"] == "needs_more_songs"
+            assert result["expected_song_count"] == 8
+            assert result["actual_song_count"] == 1
+            assert any(
+                issue["code"] == "actual_song_count_mismatch"
+                for issue in result["issues"]
+            )
+
+    def test_inspect_round_package_requires_resolved_songs(self, app):
+        with app.app_context():
+            user = _create_user()
+            song = _create_song(title="Real", artist="Artist", deezer_id="123")
+            round_id = automation.create_round(
+                name="Unresolved Song",
+                round_type="manual",
+                song_ids=[song.id],
+            )["round"]["id"]
+            round_obj = db.session.get(Round, round_id)
+            round_obj.songs = f"{song.id},999999"
+            db.session.commit()
+
+            with (
+                patch(
+                    "musicround.services.automation._download_preview_audio",
+                    return_value=("https://example.test/preview.mp3", AudioSegment.silent(duration=30000), None),
+                ),
+                patch(
+                    "musicround.services.automation._round_audio_components",
+                    return_value=(
+                        {"custom_audio_ms": {"intro": 1000, "replay": 1000, "outro": 1000}, "number_audio_ms": [1000]},
+                        [],
+                    ),
+                ),
+                patch(
+                    "musicround.services.automation.inspect_pdf_quality",
+                    return_value={"warnings": [], "ok": True},
+                ),
+                patch(
+                    "musicround.services.automation.inspect_mp3_quality",
+                    return_value={"warnings": [], "ok": True, "duration_seconds": 65},
+                ),
+            ):
+                result = automation.inspect_round_package(
+                    round_id, user_id=user.id, expected_song_count=2
+                )
+
+            assert result["ok"] is False
+            assert result["status"] == "needs_more_songs"
+            assert result["actual_song_count"] == 2
+            assert result["resolved_song_count"] == 1
+            assert any(
+                issue["code"] == "resolved_song_count_mismatch"
+                for issue in result["issues"]
+            )
+
+    def test_inspect_round_package_warns_for_missing_preview(self, app):
+        with app.app_context():
+            user = _create_user()
+            song = _create_song(title="No Preview", artist="Artist", deezer_id="123")
+            created = automation.create_round(
+                name="Missing Preview",
+                round_type="manual",
+                song_ids=[song.id],
+            )
+            round_id = created["round"]["id"]
+            app.config["deezer"] = type(
+                "DeezerStub",
+                (),
+                {"get_track": lambda self, track_id: {"preview": None}},
+            )()
+
+            with (
+                patch(
+                    "musicround.services.automation._round_audio_components",
+                    return_value=(
+                        {"custom_audio_ms": {"intro": 1000, "replay": 1000, "outro": 1000}, "number_audio_ms": [1000]},
+                        [],
+                    ),
+                ),
+                patch(
+                    "musicround.services.automation.inspect_pdf_quality",
+                    return_value={"warnings": [], "ok": True},
+                ),
+                patch(
+                    "musicround.services.automation.inspect_mp3_quality",
+                    return_value={"warnings": [], "ok": True, "duration_seconds": 5},
+                ),
+            ):
+                result = automation.inspect_round_package(
+                    round_id, user_id=user.id, expected_song_count=1
+                )
+
+            assert result["ok"] is False
+            assert result["status"] == "needs_substitution"
+            assert any(issue["code"] == "missing_preview_url" for issue in result["issues"])
+            assert result["preview_checks"][0]["issue_code"] == "missing_preview_url"
+            assert result["remediation"][0]["action"] == "replace_position"
+
+    def test_inspect_round_package_warns_for_short_preview(self, app):
+        with app.app_context():
+            user = _create_user()
+            song = _create_song(title="Short", artist="Artist", deezer_id="123")
+            round_id = automation.create_round(
+                name="Short Preview",
+                round_type="manual",
+                song_ids=[song.id],
+            )["round"]["id"]
+
+            with (
+                patch(
+                    "musicround.services.automation._download_preview_audio",
+                    return_value=("https://example.test/short.mp3", AudioSegment.silent(duration=10000), None),
+                ),
+                patch(
+                    "musicround.services.automation._round_audio_components",
+                    return_value=(
+                        {"custom_audio_ms": {"intro": 1000, "replay": 1000, "outro": 1000}, "number_audio_ms": [1000]},
+                        [],
+                    ),
+                ),
+                patch(
+                    "musicround.services.automation.inspect_pdf_quality",
+                    return_value={"warnings": [], "ok": True},
+                ),
+                patch(
+                    "musicround.services.automation.inspect_mp3_quality",
+                    return_value={"warnings": [], "ok": True, "duration_seconds": 25},
+                ),
+            ):
+                result = automation.inspect_round_package(
+                    round_id, user_id=user.id, expected_song_count=1
+                )
+
+            assert result["ok"] is False
+            assert result["status"] == "needs_substitution"
+            assert any(issue["code"] == "preview_too_short" for issue in result["issues"])
+
+    def test_inspect_round_package_warns_for_mp3_duration_mismatch(self, app):
+        with app.app_context():
+            user = _create_user()
+            song = _create_song(title="Long Enough", artist="Artist", deezer_id="123")
+            round_id = automation.create_round(
+                name="Mismatch",
+                round_type="manual",
+                song_ids=[song.id],
+            )["round"]["id"]
+
+            with (
+                patch(
+                    "musicround.services.automation._download_preview_audio",
+                    return_value=("https://example.test/preview.mp3", AudioSegment.silent(duration=30000), None),
+                ),
+                patch(
+                    "musicround.services.automation._round_audio_components",
+                    return_value=(
+                        {"custom_audio_ms": {"intro": 1000, "replay": 1000, "outro": 1000}, "number_audio_ms": [1000]},
+                        [],
+                    ),
+                ),
+                patch(
+                    "musicround.services.automation.inspect_pdf_quality",
+                    return_value={"warnings": [], "ok": True},
+                ),
+                patch(
+                    "musicround.services.automation.inspect_mp3_quality",
+                    return_value={"warnings": [], "ok": True, "duration_seconds": 40},
+                ),
+            ):
+                result = automation.inspect_round_package(
+                    round_id, user_id=user.id, expected_song_count=1
+                )
+
+            assert result["expected_duration_seconds"] == 65
+            assert result["status"] == "render_failed"
+            assert any(
+                issue["code"] == "round_mp3_duration_mismatch"
+                for issue in result["issues"]
+            )
+
+    def test_email_round_blocks_when_package_quality_fails(self, app):
+        with app.app_context():
+            user = _create_user()
+            song = _create_song(title="Bad", artist="Artist")
+            round_id = automation.create_round(
+                name="Blocked",
+                round_type="manual",
+                song_ids=[song.id],
+            )["round"]["id"]
+
+            with (
+                patch(
+                    "musicround.services.automation.generate_round_assets",
+                    return_value={"pdf": {"path": "/tmp/no.pdf"}, "mp3": {"path": "/tmp/no.mp3"}},
+                ),
+                patch(
+                    "musicround.services.automation.inspect_round_package",
+                    return_value={
+                        "ok": False,
+                        "status": "needs_substitution",
+                        "hints": ["missing preview"],
+                    },
+                ),
+                patch("musicround.services.automation.send_email") as mock_send,
+            ):
+                with pytest.raises(automation.AutomationError, match="quality gate") as exc_info:
+                    automation.email_round(round_id, user_id=user.id)
+
+            assert not mock_send.called
+            assert exc_info.value.details["status"] == "needs_substitution"
+            export = RoundExport.query.filter_by(round_id=round_id).one()
+            assert export.status == "failed"
 
 
 class TestTTSAutomation:


### PR DESCRIPTION
## Summary
- add a package quality gate for quiz rounds before email export
- block partial playlist imports and partial/short preview round bundles with structured repair payloads
- add MCP tools for replacement suggestions, positional replacement, and human-readable repair reports

## Validation
- `git diff --check`
- `.venv/bin/python -m py_compile musicround/services/automation.py musicround/mcp_server.py tests/test_automation_service.py`

## Notes
- Local pytest collection/execution currently hangs before test output in this checkout; focused pytest attempts were capped at 75s and exited by timeout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added round inspection and repair guidance before sending emails.
  * Added song replacement suggestions and in-place song swapping for problematic rounds.
  * Playlist imports now clearly report when too few tracks are available.

* **Bug Fixes**
  * Email sending now stops if a round package fails quality checks.
  * Round exports now surface clearer failure details and repair steps.
  * Improved handling of incomplete or invalid audio previews and mismatched generated package lengths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->