### PR TITLE
[codex] Add scheduled round email automation

### DIFF
--- a/docs/developer-guide/mcp.md
+++ b/docs/developer-guide/mcp.md
@@ -57,6 +57,9 @@ The MCP server exposes these tools:
 | `inspect_round_package` | Check preview availability and length, expected generated MP3 length, MP3 quality, and PDF integrity. |
 | `round_repair_report` | Return package quality plus a human-readable blocked/repair report. |
 | `send_round_email` | Generate assets, block on failed package checks, and email only robust round bundles. |
+| `schedule_round_email` | Schedule a robust round bundle for later email delivery. |
+| `list_scheduled_round_emails` | List pending or historical scheduled email exports. |
+| `process_due_scheduled_round_emails` | Send scheduled round emails that are due. |
 | `generate_tts_snippet` | Generate and assign custom intro, replay, or outro TTS MP3s. |
 
 `find_songs` includes `used_count`, `usage_frequency`, and `last_used` for each
@@ -80,6 +83,9 @@ fields whose names contain `password`, `token`, or `secret` unless
 5. Inspect the generated files and previews with `inspect_round_package`.
 6. Send the completed bundle with `send_round_email`; it reruns the package
    checks and refuses to send if previews or generated assets look wrong.
+   To defer delivery, call `schedule_round_email` with an ISO timestamp such as
+   `2026-07-09T19:00:00+02:00`, then run `process_due_scheduled_round_emails`
+   from a scheduler.
 
 When `inspect_round_package`, `round_repair_report`, or `send_round_email`
 returns `needs_substitution`, read the failed `preview_checks` position or the

--- a/migrations/add_round_export_schedule.py
+++ b/migrations/add_round_export_schedule.py
@@ -1,0 +1,45 @@
+"""Add scheduled email fields to RoundExport."""
+
+import logging
+
+from sqlalchemy import inspect, text
+
+
+def run_migration():
+    try:
+        from musicround import db
+
+        inspector = inspect(db.engine)
+        existing_columns = [column["name"] for column in inspector.get_columns("round_export")]
+        columns = {
+            "scheduled_for": "DATETIME",
+            "processed_at": "DATETIME",
+            "subject": "VARCHAR(500)",
+            "body_text": "TEXT",
+        }
+
+        changes_made = False
+        with db.engine.connect() as conn:
+            for column_name, column_type in columns.items():
+                if column_name in existing_columns:
+                    continue
+                conn.execute(
+                    text(f"ALTER TABLE round_export ADD COLUMN {column_name} {column_type}")
+                )
+                changes_made = True
+            if changes_made:
+                conn.commit()
+
+        if changes_made:
+            logging.info("Migration add_round_export_schedule completed successfully")
+            return True
+        logging.info("No changes were needed")
+        return None
+    except Exception as exc:
+        logging.error("Migration add_round_export_schedule failed: %s", exc)
+        return False
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    run_migration()

--- a/musicround/mcp_server.py
+++ b/musicround/mcp_server.py
@@ -391,6 +391,55 @@ def round_repair_report(
 
 
 @mcp.tool()
+def schedule_round_email(
+    round_id: int,
+    scheduled_for: str,
+    recipient: str | None = None,
+    user_id: int | None = None,
+    subject: str | None = None,
+    body_text: str | None = None,
+) -> dict[str, Any]:
+    """Schedule a round email for a future worker run."""
+    return _with_app_context(
+        automation.schedule_round_email,
+        round_id=round_id,
+        scheduled_for=scheduled_for,
+        recipient=recipient,
+        user_id=user_id,
+        subject=subject,
+        body_text=body_text,
+    )
+
+
+@mcp.tool()
+def list_scheduled_round_emails(
+    user_id: int | None = None,
+    include_processed: bool = False,
+    limit: int = 50,
+) -> dict[str, Any]:
+    """List scheduled round email exports."""
+    return _with_app_context(
+        automation.list_scheduled_round_emails,
+        user_id=user_id,
+        include_processed=include_processed,
+        limit=limit,
+    )
+
+
+@mcp.tool()
+def process_due_scheduled_round_emails(
+    now: str | None = None,
+    limit: int = 10,
+) -> dict[str, Any]:
+    """Send scheduled round emails that are due and still pending."""
+    return _with_app_context(
+        automation.process_due_scheduled_round_emails,
+        now=now,
+        limit=limit,
+    )
+
+
+@mcp.tool()
 def send_round_email(
     round_id: int,
     recipient: str | None = None,

--- a/musicround/models.py
+++ b/musicround/models.py
@@ -297,6 +297,10 @@ class RoundExport(db.Model):
     include_mp3s = db.Column(db.Boolean, default=False)  # Whether MP3s were included
     status = db.Column(db.String(20), default='success')  # 'success', 'failed'
     error_message = db.Column(db.Text, nullable=True)  # Error details if failed
+    scheduled_for = db.Column(db.DateTime, nullable=True)
+    processed_at = db.Column(db.DateTime, nullable=True)
+    subject = db.Column(db.String(500), nullable=True)
+    body_text = db.Column(db.Text, nullable=True)
     
     # Relationships
     round = db.relationship('Round', backref=db.backref('exports', lazy='dynamic'))
@@ -381,4 +385,3 @@ class ImportJobRecord(db.Model):
             elif self.item_type == 'track':
                 return f"https://www.deezer.com/track/{self.item_id}"
         return None
-

--- a/musicround/services/automation.py
+++ b/musicround/services/automation.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 import re
 import tempfile
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Iterable
 
 import requests
@@ -1545,12 +1545,167 @@ def round_repair_report(
     return {"quality": quality, "report": quality["report"]}
 
 
+def _parse_datetime_utc(value: str | datetime) -> datetime:
+    if isinstance(value, datetime):
+        parsed = value
+    else:
+        normalized = value.strip()
+        if normalized.endswith("Z"):
+            normalized = f"{normalized[:-1]}+00:00"
+        parsed = datetime.fromisoformat(normalized)
+    if parsed.tzinfo:
+        return parsed.astimezone(timezone.utc).replace(tzinfo=None)
+    return parsed
+
+
+def _datetime_payload(value: datetime | None) -> str | None:
+    return None if value is None else f"{value.isoformat()}Z"
+
+
+def _round_export_summary(export: RoundExport) -> dict[str, Any]:
+    return {
+        "id": export.id,
+        "round_id": export.round_id,
+        "round_name": export.round.name if export.round else None,
+        "user_id": export.user_id,
+        "export_type": export.export_type,
+        "destination": export.destination,
+        "status": export.status,
+        "scheduled_for": _datetime_payload(export.scheduled_for),
+        "processed_at": _datetime_payload(export.processed_at),
+        "timestamp": _datetime_payload(export.timestamp),
+        "subject": export.subject,
+        "body_text": export.body_text,
+        "error_message": export.error_message,
+    }
+
+
+def schedule_round_email(
+    round_id: int,
+    scheduled_for: str | datetime,
+    recipient: str | None = None,
+    user_id: int | None = None,
+    subject: str | None = None,
+    body_text: str | None = None,
+) -> dict[str, Any]:
+    """Schedule a round email for a future worker run."""
+    round_obj = db.session.get(Round, round_id)
+    if not round_obj:
+        raise AutomationError(f"Round {round_id} was not found.")
+
+    user = _find_user(user_id)
+    target = recipient or user.email
+    if not target:
+        raise AutomationError("No recipient was provided and the selected user has no email.")
+
+    scheduled_at = _parse_datetime_utc(scheduled_for)
+    export = RoundExport(
+        round_id=round_id,
+        user_id=user.id,
+        export_type="email",
+        destination=target,
+        include_mp3s=True,
+        status="scheduled",
+        scheduled_for=scheduled_at,
+        subject=subject,
+        body_text=body_text,
+    )
+    db.session.add(export)
+    db.session.commit()
+    return {"scheduled": True, "export": _round_export_summary(export)}
+
+
+def list_scheduled_round_emails(
+    user_id: int | None = None,
+    include_processed: bool = False,
+    limit: int = 50,
+) -> dict[str, Any]:
+    """List scheduled round email exports."""
+    if limit < 1 or limit > 200:
+        raise AutomationError("limit must be between 1 and 200.")
+
+    query = RoundExport.query.filter_by(export_type="email").filter(
+        RoundExport.scheduled_for.isnot(None)
+    )
+    if user_id is not None:
+        query = query.filter_by(user_id=user_id)
+    if not include_processed:
+        query = query.filter_by(status="scheduled")
+    exports = (
+        query.order_by(RoundExport.scheduled_for.asc(), RoundExport.id.asc())
+        .limit(limit)
+        .all()
+    )
+    return {
+        "count": len(exports),
+        "scheduled_exports": [_round_export_summary(item) for item in exports],
+    }
+
+
+def process_due_scheduled_round_emails(
+    now: str | datetime | None = None,
+    limit: int = 10,
+) -> dict[str, Any]:
+    """Send scheduled round emails that are due and still pending."""
+    if limit < 1 or limit > 100:
+        raise AutomationError("limit must be between 1 and 100.")
+
+    now_utc = _parse_datetime_utc(now) if now is not None else datetime.utcnow()
+    due_exports = (
+        RoundExport.query.filter_by(export_type="email", status="scheduled")
+        .filter(RoundExport.scheduled_for.isnot(None))
+        .filter(RoundExport.scheduled_for <= now_utc)
+        .order_by(RoundExport.scheduled_for.asc(), RoundExport.id.asc())
+        .limit(limit)
+        .all()
+    )
+
+    results = []
+    for export in due_exports:
+        export.status = "processing"
+        db.session.commit()
+        try:
+            delivery = email_round(
+                export.round_id,
+                recipient=export.destination,
+                user_id=export.user_id,
+                subject=export.subject,
+                body_text=export.body_text,
+                record_export=False,
+            )
+            export.status = "success"
+            export.processed_at = datetime.utcnow()
+            export.error_message = delivery.get("message")
+            db.session.commit()
+            results.append({"export": _round_export_summary(export), "delivery": delivery})
+        except Exception as exc:
+            export.status = "failed"
+            export.processed_at = datetime.utcnow()
+            export.error_message = str(exc)
+            db.session.commit()
+            details = getattr(exc, "details", None)
+            results.append(
+                {
+                    "export": _round_export_summary(export),
+                    "error": str(exc),
+                    "details": details,
+                }
+            )
+
+    return {
+        "processed_count": len(results),
+        "now": _datetime_payload(now_utc),
+        "results": results,
+    }
+
+
 def email_round(
     round_id: int,
     recipient: str | None = None,
     user_id: int | None = None,
     subject: str | None = None,
     body_text: str | None = None,
+    record_export: bool = True,
 ) -> dict[str, Any]:
     """Generate assets and send a round as an email attachment bundle."""
     user = _find_user(user_id)
@@ -1563,18 +1718,21 @@ def email_round(
     if not quality["ok"]:
         report = quality.get("report") or _round_repair_report(quality)
         message = "Round quality gate failed: " + "; ".join(quality["hints"])
-        db.session.add(
-            RoundExport(
-                round_id=round_id,
-                user_id=user.id,
-                export_type="email",
-                destination=target,
-                include_mp3s=True,
-                status="failed",
-                error_message=message,
+        if record_export:
+            db.session.add(
+                RoundExport(
+                    round_id=round_id,
+                    user_id=user.id,
+                    export_type="email",
+                    destination=target,
+                    include_mp3s=True,
+                    status="failed",
+                    error_message=message,
+                    subject=subject,
+                    body_text=body_text,
+                )
             )
-        )
-        db.session.commit()
+            db.session.commit()
         raise AutomationError(
             message,
             details={
@@ -1611,17 +1769,21 @@ def email_round(
         )
 
     success, message = send_email(target, email_subject, email_body, attachments)
-    export = RoundExport(
-        round_id=round_id,
-        user_id=user.id,
-        export_type="email",
-        destination=target,
-        include_mp3s=True,
-        status="success" if success else "failed",
-        error_message=None if success else message,
-    )
-    db.session.add(export)
-    db.session.commit()
+    if record_export:
+        export = RoundExport(
+            round_id=round_id,
+            user_id=user.id,
+            export_type="email",
+            destination=target,
+            include_mp3s=True,
+            status="success" if success else "failed",
+            error_message=None if success else message,
+            subject=subject,
+            body_text=body_text,
+            processed_at=datetime.utcnow(),
+        )
+        db.session.add(export)
+        db.session.commit()
     if not success:
         raise AutomationError(message)
     return {

--- a/tests/test_automation_service.py
+++ b/tests/test_automation_service.py
@@ -528,6 +528,80 @@ class TestAssetInspection:
             export = RoundExport.query.filter_by(round_id=round_id).one()
             assert export.status == "failed"
 
+    def test_schedule_round_email_stores_pending_export(self, app):
+        with app.app_context():
+            user = _create_user()
+            song = _create_song(title="Scheduled", artist="Artist")
+            round_id = automation.create_round(
+                name="Thursday Round",
+                round_type="manual",
+                song_ids=[song.id],
+            )["round"]["id"]
+
+            result = automation.schedule_round_email(
+                round_id,
+                scheduled_for="2026-07-09T19:00:00+02:00",
+                user_id=user.id,
+                subject="Scheduled subject",
+            )
+
+            export = RoundExport.query.get(result["export"]["id"])
+            assert result["scheduled"] is True
+            assert export.status == "scheduled"
+            assert export.destination == user.email
+            assert export.subject == "Scheduled subject"
+            assert result["export"]["scheduled_for"] == "2026-07-09T17:00:00Z"
+
+    def test_list_scheduled_round_emails_returns_pending_exports(self, app):
+        with app.app_context():
+            user = _create_user()
+            song = _create_song(title="Listed", artist="Artist")
+            round_id = automation.create_round(
+                name="Listed Round",
+                round_type="manual",
+                song_ids=[song.id],
+            )["round"]["id"]
+            automation.schedule_round_email(
+                round_id,
+                scheduled_for="2026-07-09T19:00:00+02:00",
+                user_id=user.id,
+            )
+
+            result = automation.list_scheduled_round_emails(user_id=user.id)
+
+            assert result["count"] == 1
+            assert result["scheduled_exports"][0]["round_id"] == round_id
+            assert result["scheduled_exports"][0]["status"] == "scheduled"
+
+    def test_process_due_scheduled_round_emails_sends_due_exports(self, app):
+        with app.app_context():
+            user = _create_user()
+            song = _create_song(title="Due", artist="Artist")
+            round_id = automation.create_round(
+                name="Due Round",
+                round_type="manual",
+                song_ids=[song.id],
+            )["round"]["id"]
+            scheduled = automation.schedule_round_email(
+                round_id,
+                scheduled_for="2026-07-09T19:00:00+02:00",
+                user_id=user.id,
+            )
+
+            with patch(
+                "musicround.services.automation.email_round",
+                return_value={"success": True, "message": "sent"},
+            ) as mock_email:
+                result = automation.process_due_scheduled_round_emails(
+                    now="2026-07-09T19:01:00+02:00"
+                )
+
+            assert result["processed_count"] == 1
+            mock_email.assert_called_once()
+            export = RoundExport.query.get(scheduled["export"]["id"])
+            assert export.status == "success"
+            assert export.processed_at is not None
+
 
 class TestTTSAutomation:
     """Tests for TTS snippet assignment."""


### PR DESCRIPTION
## Summary
- add scheduled email fields to round exports with a migration
- add automation/MCP tools to schedule, list, and process due round emails
- keep the quality gate in the scheduled delivery path so broken rounds remain blocked

## Validation
- `git diff --check`
- `.venv/bin/python -m py_compile musicround/models.py musicround/services/automation.py musicround/mcp_server.py tests/test_automation_service.py migrations/add_round_export_schedule.py`
