### PR TITLE
[codex] Preflight scheduled round emails

### DIFF
--- a/docs/developer-guide/mcp.md
+++ b/docs/developer-guide/mcp.md
@@ -57,7 +57,7 @@ The MCP server exposes these tools:
 | `inspect_round_package` | Check preview availability and length, expected generated MP3 length, MP3 quality, and PDF integrity. |
 | `round_repair_report` | Return package quality plus a human-readable blocked/repair report. |
 | `send_round_email` | Generate assets, block on failed package checks, and email only robust round bundles. |
-| `schedule_round_email` | Schedule a robust round bundle for later email delivery. |
+| `schedule_round_email` | Generate and inspect a robust round bundle, then schedule later email delivery. |
 | `list_scheduled_round_emails` | List pending or historical scheduled email exports. |
 | `process_due_scheduled_round_emails` | Send scheduled round emails that are due. |
 | `generate_tts_snippet` | Generate and assign custom intro, replay, or outro TTS MP3s. |
@@ -84,8 +84,9 @@ fields whose names contain `password`, `token`, or `secret` unless
 6. Send the completed bundle with `send_round_email`; it reruns the package
    checks and refuses to send if previews or generated assets look wrong.
    To defer delivery, call `schedule_round_email` with an ISO timestamp such as
-   `2026-07-09T19:00:00+02:00`, then run `process_due_scheduled_round_emails`
-   from a scheduler.
+   `2026-07-09T19:00:00+02:00`; it generates PDF/MP3 and must pass the package
+   gate before it creates the scheduled send. Then run
+   `process_due_scheduled_round_emails` from a scheduler.
 
 When `inspect_round_package`, `round_repair_report`, or `send_round_email`
 returns `needs_substitution`, read the failed `preview_checks` position or the

--- a/musicround/services/automation.py
+++ b/musicround/services/automation.py
@@ -1588,7 +1588,7 @@ def schedule_round_email(
     subject: str | None = None,
     body_text: str | None = None,
 ) -> dict[str, Any]:
-    """Schedule a round email for a future worker run."""
+    """Generate, inspect, and schedule a robust round email for a future worker run."""
     round_obj = db.session.get(Round, round_id)
     if not round_obj:
         raise AutomationError(f"Round {round_id} was not found.")
@@ -1599,6 +1599,24 @@ def schedule_round_email(
         raise AutomationError("No recipient was provided and the selected user has no email.")
 
     scheduled_at = _parse_datetime_utc(scheduled_for)
+    assets = generate_round_assets(round_id, user_id=user.id)
+    quality = inspect_round_package(round_id, user_id=user.id)
+    if not quality["ok"]:
+        report = quality.get("report") or _round_repair_report(quality)
+        message = "Round quality gate failed: " + "; ".join(quality["hints"])
+        raise AutomationError(
+            message,
+            details={
+                "scheduled": False,
+                "status": quality["status"],
+                "recipient": target,
+                "scheduled_for": _datetime_payload(scheduled_at),
+                "assets": assets,
+                "quality": quality,
+                "report": report,
+            },
+        )
+
     export = RoundExport(
         round_id=round_id,
         user_id=user.id,
@@ -1612,7 +1630,12 @@ def schedule_round_email(
     )
     db.session.add(export)
     db.session.commit()
-    return {"scheduled": True, "export": _round_export_summary(export)}
+    return {
+        "scheduled": True,
+        "export": _round_export_summary(export),
+        "assets": assets,
+        "quality": quality,
+    }
 
 
 def list_scheduled_round_emails(

--- a/tests/test_automation_service.py
+++ b/tests/test_automation_service.py
@@ -538,19 +538,65 @@ class TestAssetInspection:
                 song_ids=[song.id],
             )["round"]["id"]
 
-            result = automation.schedule_round_email(
-                round_id,
-                scheduled_for="2026-07-09T19:00:00+02:00",
-                user_id=user.id,
-                subject="Scheduled subject",
-            )
+            with (
+                patch(
+                    "musicround.services.automation.generate_round_assets",
+                    return_value={"pdf": {"path": "/tmp/round.pdf"}, "mp3": {"path": "/tmp/round.mp3"}},
+                ),
+                patch(
+                    "musicround.services.automation.inspect_round_package",
+                    return_value={"ok": True, "status": "ok"},
+                ),
+            ):
+                result = automation.schedule_round_email(
+                    round_id,
+                    scheduled_for="2026-07-09T19:00:00+02:00",
+                    user_id=user.id,
+                    subject="Scheduled subject",
+                )
 
             export = RoundExport.query.get(result["export"]["id"])
             assert result["scheduled"] is True
+            assert result["quality"]["status"] == "ok"
             assert export.status == "scheduled"
             assert export.destination == user.email
             assert export.subject == "Scheduled subject"
             assert result["export"]["scheduled_for"] == "2026-07-09T17:00:00Z"
+
+    def test_schedule_round_email_blocks_when_quality_fails(self, app):
+        with app.app_context():
+            user = _create_user()
+            song = _create_song(title="Scheduled Bad", artist="Artist")
+            round_id = automation.create_round(
+                name="Bad Thursday Round",
+                round_type="manual",
+                song_ids=[song.id],
+            )["round"]["id"]
+
+            with (
+                patch(
+                    "musicround.services.automation.generate_round_assets",
+                    return_value={"pdf": {"path": "/tmp/round.pdf"}, "mp3": {"path": "/tmp/round.mp3"}},
+                ),
+                patch(
+                    "musicround.services.automation.inspect_round_package",
+                    return_value={
+                        "ok": False,
+                        "status": "needs_substitution",
+                        "hints": ["missing preview"],
+                        "report": {"status": "needs_substitution"},
+                    },
+                ),
+            ):
+                with pytest.raises(automation.AutomationError, match="quality gate") as exc_info:
+                    automation.schedule_round_email(
+                        round_id,
+                        scheduled_for="2026-07-09T19:00:00+02:00",
+                        user_id=user.id,
+                    )
+
+            assert exc_info.value.details["scheduled"] is False
+            assert RoundExport.query.filter_by(round_id=round_id).count() == 0
 
     def test_list_scheduled_round_emails_returns_pending_exports(self, app):
         with app.app_context():
@@ -561,11 +607,21 @@ class TestAssetInspection:
                 round_type="manual",
                 song_ids=[song.id],
             )["round"]["id"]
-            automation.schedule_round_email(
-                round_id,
-                scheduled_for="2026-07-09T19:00:00+02:00",
-                user_id=user.id,
-            )
+            with (
+                patch(
+                    "musicround.services.automation.generate_round_assets",
+                    return_value={"pdf": {"path": "/tmp/round.pdf"}, "mp3": {"path": "/tmp/round.mp3"}},
+                ),
+                patch(
+                    "musicround.services.automation.inspect_round_package",
+                    return_value={"ok": True, "status": "ok"},
+                ),
+            ):
+                automation.schedule_round_email(
+                    round_id,
+                    scheduled_for="2026-07-09T19:00:00+02:00",
+                    user_id=user.id,
+                )
 
             result = automation.list_scheduled_round_emails(user_id=user.id)
 
@@ -582,11 +638,21 @@ class TestAssetInspection:
                 round_type="manual",
                 song_ids=[song.id],
             )["round"]["id"]
-            scheduled = automation.schedule_round_email(
-                round_id,
-                scheduled_for="2026-07-09T19:00:00+02:00",
-                user_id=user.id,
-            )
+            with (
+                patch(
+                    "musicround.services.automation.generate_round_assets",
+                    return_value={"pdf": {"path": "/tmp/round.pdf"}, "mp3": {"path": "/tmp/round.mp3"}},
+                ),
+                patch(
+                    "musicround.services.automation.inspect_round_package",
+                    return_value={"ok": True, "status": "ok"},
+                ),
+            ):
+                scheduled = automation.schedule_round_email(
+                    round_id,
+                    scheduled_for="2026-07-09T19:00:00+02:00",
+                    user_id=user.id,
+                )
 
             with patch(
                 "musicround.services.automation.email_round",


### PR DESCRIPTION
## Summary
- make scheduled email creation generate PDF/MP3 immediately
- require the package quality gate to pass before creating a scheduled send
- keep due-time processing as a final safety check before delivery

## Validation
- `git diff --check`
- `.venv/bin/python -m py_compile musicround/services/automation.py tests/test_automation_service.py`
