### PR TITLE
Fix import queue persistence and status page

### DIFF
--- a/musicround/__init__.py
+++ b/musicround/__init__.py
@@ -357,16 +357,6 @@ def create_app(config=None):
     from musicround.errors import register_error_handlers
     register_error_handlers(app)
 
-    # Initialize import queue and background workers
-    from musicround.helpers.import_queue import ImportQueue, ImportWorker
-    worker_count = int(os.environ.get('IMPORT_WORKER_COUNT', '2'))
-    import_queue = ImportQueue()
-    workers = [ImportWorker(app, import_queue) for _ in range(worker_count)]
-    for w in workers:
-        w.start()
-    app.config['import_queue'] = import_queue
-    app.config['import_workers'] = workers
-    
     # Try to create database tables if they don't exist
     with app.app_context():
         try:
@@ -377,7 +367,49 @@ def create_app(config=None):
             run_migrations()
         except Exception as e:
             logger.error(f"Error creating database tables during app initialization: {e}")
+
+    # Initialize import queue and background workers after tables/migrations exist.
+    from musicround.helpers.import_queue import ImportQueue, ImportWorker
+    try:
+        worker_count = max(1, int(os.environ.get('IMPORT_WORKER_COUNT', '2')))
+    except ValueError:
+        logger.warning("Invalid IMPORT_WORKER_COUNT value; defaulting to 2")
+        worker_count = 2
+
+    import_queue = ImportQueue()
+    app.config['import_queue'] = import_queue
+
+    with app.app_context():
+        try:
+            abandoned_count = import_queue.mark_abandoned_processing_records()
+            if abandoned_count:
+                logger.warning(
+                    "Marked %s abandoned import job(s) as failed after restart",
+                    abandoned_count,
+                )
+            pending_count = import_queue.enqueue_pending_records()
+            if pending_count:
+                logger.info("Queued %s pending import job(s) from the database", pending_count)
+        except Exception as e:
+            logger.error(f"Error loading pending import jobs: {e}")
+
+    workers_enabled = os.environ.get('IMPORT_WORKERS_ENABLED', 'true').lower() not in (
+        '0',
+        'false',
+        'no',
+    )
+    workers_enabled = workers_enabled and 'PYTEST_CURRENT_TEST' not in os.environ
+
+    workers = []
+    if workers_enabled:
+        workers = [
+            ImportWorker(app, import_queue, worker_id=f"import-worker-{index + 1}")
+            for index in range(worker_count)
+        ]
+        for worker in workers:
+            worker.start()
+    app.config['import_workers'] = workers
+    logger.info("Started %s import worker(s)", len(workers))
     
     # Return the app
     return app
-

--- a/musicround/helpers/import_queue.py
+++ b/musicround/helpers/import_queue.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 import threading
 from dataclasses import dataclass, field
+from datetime import datetime
 from queue import PriorityQueue, Empty
-from typing import Optional
+from typing import Any, Optional
 from flask import current_app
 from flask_login import login_user, logout_user
+from sqlalchemy import update
+from sqlalchemy.exc import SQLAlchemyError
 
-from musicround.models import User, db
+from musicround.models import ImportJobRecord, User, db
 from musicround.helpers.import_helper import ImportHelper
 
 
@@ -22,21 +25,97 @@ class ImportJob:
     item_type: str = field(compare=False)
     item_id: str = field(compare=False)
     user_id: int = field(compare=False)
+    record_id: Optional[int] = field(default=None, compare=False)
 
 
 class ImportQueue:
-    """Priority queue for import jobs."""
+    """Priority queue for import jobs with database-backed job records."""
 
     def __init__(self) -> None:
         self._queue: PriorityQueue[tuple[int, int, ImportJob]] = PriorityQueue()
         self._counter = 0
         self._lock = threading.Lock()
 
+    @staticmethod
+    def normalize_priority(priority: Any, default: int = 10) -> int:
+        """Return a bounded integer priority. Lower numbers run first."""
+        try:
+            normalized = int(priority)
+        except (TypeError, ValueError):
+            normalized = default
+        return max(0, min(100, normalized))
+
     def add_job(self, job: ImportJob) -> None:
-        """Add a job to the queue."""
+        """Add a job to the in-memory work queue."""
+        job.priority = self.normalize_priority(job.priority)
         with self._lock:
             self._counter += 1
             self._queue.put((job.priority, self._counter, job))
+
+    def enqueue(
+        self,
+        service_name: str,
+        item_type: str,
+        item_id: str,
+        user_id: int,
+        priority: Any = 10,
+    ) -> ImportJobRecord:
+        """Create a persistent job record and enqueue it for local workers."""
+        normalized_priority = self.normalize_priority(priority)
+        record = ImportJobRecord(
+            service_name=service_name,
+            item_type=item_type,
+            item_id=item_id,
+            user_id=user_id,
+            priority=normalized_priority,
+            status="pending",
+        )
+        db.session.add(record)
+        db.session.commit()
+        self.enqueue_record(record)
+        return record
+
+    def enqueue_record(self, record: ImportJobRecord) -> None:
+        """Enqueue an existing pending job record."""
+        self.add_job(
+            ImportJob(
+                priority=record.priority,
+                service_name=record.service_name,
+                item_type=record.item_type,
+                item_id=record.item_id,
+                user_id=record.user_id,
+                record_id=record.id,
+            )
+        )
+
+    def mark_abandoned_processing_records(self) -> int:
+        """Fail jobs left processing by an earlier process restart."""
+        records = ImportJobRecord.query.filter_by(status="processing").all()
+        for record in records:
+            record.status = "failed"
+            record.completed_at = datetime.utcnow()
+            record.error_message = (
+                "Import worker restarted while this job was processing. "
+                "Queue the import again if it still needs to run."
+            )
+        if records:
+            db.session.commit()
+        return len(records)
+
+    def enqueue_pending_records(self) -> int:
+        """Load pending database jobs into the local priority queue."""
+        records = (
+            ImportJobRecord.query.filter_by(status="pending")
+            .order_by(
+                ImportJobRecord.priority.asc(),
+                ImportJobRecord.created_at.asc(),
+                ImportJobRecord.id.asc(),
+            )
+            .all()
+        )
+        for record in records:
+            self.enqueue_record(record)
+        return len(records)
 
     def get_job(self, timeout: Optional[float] = None) -> Optional[ImportJob]:
         """Retrieve the next job from the queue."""
@@ -50,14 +129,39 @@ class ImportQueue:
         """Signal that a previously fetched job is complete."""
         self._queue.task_done()
 
+    def qsize(self) -> int:
+        """Return the number of jobs waiting in the local queue."""
+        return self._queue.qsize()
+
+    def snapshot(self) -> list[dict[str, Any]]:
+        """Return a thread-safe snapshot of queued jobs for status pages."""
+        with self._lock:
+            queue_items = list(self._queue.queue)
+
+        return [
+            {
+                "priority": priority,
+                "counter": counter,
+                "service": job.service_name,
+                "type": job.item_type,
+                "item_id": job.item_id,
+                "user_id": job.user_id,
+                "record_id": job.record_id,
+            }
+            for priority, counter, job in sorted(queue_items)
+        ]
+
 
 class ImportWorker(threading.Thread):
     """Background worker thread for processing import jobs."""
 
-    def __init__(self, app, queue: ImportQueue) -> None:
+    _claim_lock = threading.Lock()
+
+    def __init__(self, app, queue: ImportQueue, worker_id: Optional[str] = None) -> None:
         super().__init__(daemon=True)
         self.app = app
         self.queue = queue
+        self.worker_id = worker_id or self.name
         self._stop_event = threading.Event()
 
     def stop(self) -> None:
@@ -68,31 +172,157 @@ class ImportWorker(threading.Thread):
         with self.app.app_context():
             while not self._stop_event.is_set():
                 job = self.queue.get_job(timeout=1.0)
+                from_local_queue = job is not None
+                if job is None:
+                    job = self._get_next_pending_job()
                 if job is None:
                     continue
-                self._process_job(job)
-                self.queue.task_done()
+                try:
+                    self._process_job(job)
+                finally:
+                    if from_local_queue:
+                        self.queue.task_done()
+
+    def _get_next_pending_job(self) -> Optional[ImportJob]:
+        try:
+            record = (
+                ImportJobRecord.query.filter_by(status="pending")
+                .order_by(
+                    ImportJobRecord.priority.asc(),
+                    ImportJobRecord.created_at.asc(),
+                    ImportJobRecord.id.asc(),
+                )
+                .first()
+            )
+        except SQLAlchemyError as exc:
+            db.session.rollback()
+            current_app.logger.warning("Could not poll import job table: %s", exc)
+            return None
+
+        if not record:
+            return None
+        return ImportJob(
+            priority=record.priority,
+            service_name=record.service_name,
+            item_type=record.item_type,
+            item_id=record.item_id,
+            user_id=record.user_id,
+            record_id=record.id,
+        )
 
     def _process_job(self, job: ImportJob) -> None:
-        user = User.query.get(job.user_id)
-        if not user:
-            current_app.logger.error("Import job for unknown user %s", job.user_id)
-            return
         with self.app.test_request_context():
+            record = self._claim_record(job)
+            if job.record_id and record is None:
+                return
+
+            user = User.query.get(job.user_id)
+            if not user:
+                current_app.logger.error("Import job for unknown user %s", job.user_id)
+                self._mark_failed(record, f"Unknown user id {job.user_id}")
+                return
+
             login_user(user)
             try:
                 current_app.logger.info(
-                    "Processing import job: service=%s type=%s id=%s user=%s priority=%s",
+                    "Processing import job: record=%s service=%s type=%s id=%s user=%s priority=%s",
+                    job.record_id,
                     job.service_name,
                     job.item_type,
                     job.item_id,
                     job.user_id,
                     job.priority,
                 )
-                ImportHelper.import_item(job.service_name, job.item_type, job.item_id)
+                result = ImportHelper.import_item(job.service_name, job.item_type, job.item_id)
+                imported_count, skipped_count, error_message = self._summarize_result(result)
+                self._mark_completed(record, imported_count, skipped_count, error_message)
                 db.session.commit()
             except Exception as exc:  # pylint: disable=broad-except
                 current_app.logger.error("Import job failed: %s", exc, exc_info=True)
                 db.session.rollback()
+                self._mark_failed(record, str(exc))
             finally:
                 logout_user()
+                db.session.remove()
+
+    def _claim_record(self, job: ImportJob) -> Optional[ImportJobRecord]:
+        if job.record_id is None:
+            return None
+
+        with self._claim_lock:
+            statement = (
+                update(ImportJobRecord)
+                .where(ImportJobRecord.id == job.record_id, ImportJobRecord.status == "pending")
+                .values(status="processing", started_at=datetime.utcnow())
+            )
+            result = db.session.execute(statement)
+            db.session.commit()
+
+        if result.rowcount != 1:
+            db.session.rollback()
+            return None
+
+        return ImportJobRecord.query.get(job.record_id)
+
+    def _mark_completed(
+        self,
+        record: Optional[ImportJobRecord],
+        imported_count: int,
+        skipped_count: int,
+        error_message: Optional[str],
+    ) -> None:
+        if not record:
+            return
+        record.status = "completed"
+        record.completed_at = datetime.utcnow()
+        record.imported_count = imported_count
+        record.skipped_count = skipped_count
+        record.error_message = error_message
+
+    def _mark_failed(self, record: Optional[ImportJobRecord], error_message: str) -> None:
+        if not record:
+            return
+        record.status = "failed"
+        record.completed_at = datetime.utcnow()
+        record.error_message = error_message
+        db.session.add(record)
+        db.session.commit()
+
+    @staticmethod
+    def _summarize_result(result: Any) -> tuple[int, int, Optional[str]]:
+        if isinstance(result, dict):
+            errors = result.get("errors") or []
+            if isinstance(errors, str):
+                errors = [errors]
+            skipped_count = result.get("skipped_count")
+            if skipped_count is None:
+                skipped_count = sum(
+                    int(result.get(key, 0) or 0)
+                    for key in (
+                        "skipped_existing_count",
+                        "skipped_no_preview_count",
+                        "skipped_no_match_count",
+                    )
+                )
+            return (
+                int(result.get("imported_count", 0) or 0),
+                int(skipped_count or 0),
+                "\n".join(str(error) for error in errors) or None,
+            )
+
+        if isinstance(result, list):
+            return (len(result), 0, None)
+
+        return (0, 0, None)
+
+
+def enqueue_import_job(
+    queue: ImportQueue,
+    service_name: str,
+    item_type: str,
+    item_id: str,
+    user_id: int,
+    priority: Any = 10,
+) -> ImportJobRecord:
+    """Create and enqueue an import job using the app-wide queue."""
+    return queue.enqueue(service_name, item_type, item_id, user_id, priority)

--- a/musicround/routes/import_routes.py
+++ b/musicround/routes/import_routes.py
@@ -155,19 +155,16 @@ def import_official_playlists():
             flash("Import queue not initialized.", "danger")
             return redirect(url_for('core.view_songs'))
         
-        # Create import job and add to queue
-        from musicround.helpers.import_queue import ImportJob
-        priority = int(request.form.get('priority', 10))
-        
-        job = ImportJob(
-            priority=priority,
+        from musicround.helpers.import_queue import enqueue_import_job
+        job_record = enqueue_import_job(
+            queue=queue,
+            priority=request.form.get('priority', 10),
             service_name='spotify',
             item_type='playlist',
             item_id=playlist_id,
             user_id=current_user.id,
         )
-        queue.add_job(job)
-        flash('Official Spotify playlist import queued successfully. You will be notified when it completes.', 'info')
+        flash(f'Official Spotify playlist import queued as job #{job_record.id}.', 'info')
             
         return redirect(url_for('core.view_songs'))
 
@@ -309,19 +306,16 @@ def direct_official_playlists():
             flash("Import queue not initialized.", "danger")
             return redirect(url_for('core.view_songs'))
         
-        # Create import job and add to queue
-        from musicround.helpers.import_queue import ImportJob
-        priority = int(request.form.get('priority', 10))
-        
-        job = ImportJob(
-            priority=priority,
+        from musicround.helpers.import_queue import enqueue_import_job
+        job_record = enqueue_import_job(
+            queue=queue,
+            priority=request.form.get('priority', 10),
             service_name='spotify',
             item_type='playlist',
             item_id=playlist_id,
             user_id=current_user.id,
         )
-        queue.add_job(job)
-        flash('Direct Spotify playlist import queued successfully. You will be notified when it completes.', 'info')
+        flash(f'Direct Spotify playlist import queued as job #{job_record.id}.', 'info')
         
         return redirect(url_for('core.view_songs'))
 
@@ -765,31 +759,14 @@ def queue_status():
         flash("Import queue not initialized.", "danger")
         return redirect(url_for('core.view_songs'))
     
-    # Access queue internals for display - this won't modify the queue
-    queue_size = queue._queue.qsize()
-    
-    # Extract information about jobs in the queue (without removing them)
-    # This is a bit of a hack but necessary to see what's in the PriorityQueue
-    # without removing items
-    queue_snapshot = []
-    if hasattr(queue._queue, 'queue'):
-        # Make a copy of the internal queue list
-        with queue._lock:  # Ensure thread safety while accessing the queue
-            queue_items = list(queue._queue.queue)
-            
-            for priority, counter, job in queue_items:
-                queue_snapshot.append({
-                    'priority': priority,
-                    'counter': counter,
-                    'service': job.service_name,
-                    'type': job.item_type,
-                    'item_id': job.item_id,
-                    'user_id': job.user_id
-                })
+    local_queue_size = queue.qsize()
+    queue_snapshot = queue.snapshot()
     
     # Get active and recent jobs from database if available
     active_jobs = []
+    pending_jobs = []
     recent_jobs = []
+    queue_size = local_queue_size
     
     # Check if ImportJobRecord is defined
     try:
@@ -800,6 +777,32 @@ def queue_status():
         
         # Get the active jobs (status='processing')
         active_jobs = ImportJobRecord.query.filter_by(status='processing').all()
+        pending_jobs = (
+            ImportJobRecord.query.filter_by(status='pending')
+            .order_by(
+                ImportJobRecord.priority.asc(),
+                ImportJobRecord.created_at.asc(),
+                ImportJobRecord.id.asc(),
+            )
+            .limit(50)
+            .all()
+        )
+        queue_size = ImportJobRecord.query.filter_by(status='pending').count()
+        snapshot_record_ids = {
+            job.get('record_id') for job in queue_snapshot if job.get('record_id')
+        }
+        for job in pending_jobs:
+            if job.id in snapshot_record_ids:
+                continue
+            queue_snapshot.append({
+                'priority': job.priority,
+                'counter': None,
+                'service': job.service_name,
+                'type': job.item_type,
+                'item_id': job.item_id,
+                'user_id': job.user_id,
+                'record_id': job.id,
+            })
     except (ImportError, AttributeError):
         # ImportJobRecord might not be defined yet, handle this case
         pass

--- a/musicround/routes/import_songs.py
+++ b/musicround/routes/import_songs.py
@@ -85,26 +85,21 @@ def import_playlist():
             flash("No playlist ID provided for import.", "danger")
             return redirect(request.referrer or url_for('core.search'))
 
-        try:
-            priority = int(request.form.get('priority', 10))
-        except (ValueError, TypeError):
-            priority = 10
         queue = current_app.config.get('import_queue')
         if not queue:
             flash("Import queue not initialized.", "danger")
             return redirect(url_for('core.view_songs'))
 
-        from musicround.helpers.import_queue import ImportJob
-
-        job = ImportJob(
-            priority=priority,
+        from musicround.helpers.import_queue import enqueue_import_job
+        job_record = enqueue_import_job(
+            queue=queue,
+            priority=request.form.get('priority', 10),
             service_name='spotify',
             item_type='playlist',
             item_id=playlist_id,
             user_id=current_user.id,
         )
-        queue.add_job(job)
-        flash('Playlist import queued.', 'info')
+        flash(f'Playlist import queued as job #{job_record.id}.', 'info')
         return redirect(url_for('core.view_songs'))
         
     return render_template('service_import.html',

--- a/musicround/templates/import_queue_status.html
+++ b/musicround/templates/import_queue_status.html
@@ -1,0 +1,129 @@
+{% extends 'base.html' %}
+
+{% block title %}Import Queue{% endblock %}
+
+{% block content %}
+<div class="max-w-7xl mx-auto px-4 py-8">
+    <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-6">
+        <div>
+            <h1 class="text-3xl font-bold text-navy-800 font-montserrat">Import Queue</h1>
+            <p class="text-gray-600 mt-1">Queued, active, and recent import jobs.</p>
+        </div>
+        <a href="{{ url_for('core.view_songs') }}" class="inline-flex items-center justify-center px-4 py-2 rounded-md bg-gray-100 hover:bg-gray-200 text-gray-800 border border-gray-300">
+            <i class="fas fa-music mr-2"></i> View Songs
+        </a>
+    </div>
+
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
+        <div class="bg-white rounded-lg shadow p-5">
+            <div class="text-sm text-gray-500">Queued</div>
+            <div class="text-3xl font-bold text-navy-800">{{ stats.queue_size }}</div>
+        </div>
+        <div class="bg-white rounded-lg shadow p-5">
+            <div class="text-sm text-gray-500">Active</div>
+            <div class="text-3xl font-bold text-teal-600">{{ stats.active_jobs }}</div>
+        </div>
+        <div class="bg-white rounded-lg shadow p-5">
+            <div class="text-sm text-gray-500">Completed Today</div>
+            <div class="text-3xl font-bold text-green-600">{{ stats.completed_today }}</div>
+        </div>
+        <div class="bg-white rounded-lg shadow p-5">
+            <div class="text-sm text-gray-500">Failed Today</div>
+            <div class="text-3xl font-bold text-orange-600">{{ stats.failed_today }}</div>
+        </div>
+    </div>
+
+    <div class="bg-white rounded-lg shadow mb-8 overflow-hidden">
+        <div class="px-5 py-4 border-b border-gray-200 flex items-center justify-between">
+            <h2 class="text-xl font-semibold text-navy-800">Waiting Jobs</h2>
+            <span class="text-sm text-gray-500">Lower priority numbers run first.</span>
+        </div>
+        <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-200">
+                <thead class="bg-gray-50">
+                    <tr>
+                        <th class="px-5 py-3 text-left text-xs font-semibold text-gray-500 uppercase">Job</th>
+                        <th class="px-5 py-3 text-left text-xs font-semibold text-gray-500 uppercase">Service</th>
+                        <th class="px-5 py-3 text-left text-xs font-semibold text-gray-500 uppercase">Type</th>
+                        <th class="px-5 py-3 text-left text-xs font-semibold text-gray-500 uppercase">Item ID</th>
+                        <th class="px-5 py-3 text-left text-xs font-semibold text-gray-500 uppercase">Priority</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-100">
+                    {% for job in queue_snapshot %}
+                    <tr>
+                        <td class="px-5 py-3 text-sm text-gray-700">#{{ job.record_id or '-' }}</td>
+                        <td class="px-5 py-3 text-sm text-gray-700">{{ job.service }}</td>
+                        <td class="px-5 py-3 text-sm text-gray-700">{{ job.type }}</td>
+                        <td class="px-5 py-3 text-sm font-mono text-gray-700">{{ job.item_id }}</td>
+                        <td class="px-5 py-3 text-sm text-gray-700">{{ job.priority }}</td>
+                    </tr>
+                    {% else %}
+                    <tr>
+                        <td colspan="5" class="px-5 py-8 text-center text-gray-500">No jobs waiting.</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <div class="bg-white rounded-lg shadow overflow-hidden">
+        <div class="px-5 py-4 border-b border-gray-200">
+            <h2 class="text-xl font-semibold text-navy-800">Recent Jobs</h2>
+        </div>
+        <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-200">
+                <thead class="bg-gray-50">
+                    <tr>
+                        <th class="px-5 py-3 text-left text-xs font-semibold text-gray-500 uppercase">Job</th>
+                        <th class="px-5 py-3 text-left text-xs font-semibold text-gray-500 uppercase">Status</th>
+                        <th class="px-5 py-3 text-left text-xs font-semibold text-gray-500 uppercase">Item</th>
+                        <th class="px-5 py-3 text-left text-xs font-semibold text-gray-500 uppercase">Counts</th>
+                        <th class="px-5 py-3 text-left text-xs font-semibold text-gray-500 uppercase">Duration</th>
+                        <th class="px-5 py-3 text-left text-xs font-semibold text-gray-500 uppercase">Created</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-100">
+                    {% for job in recent_jobs %}
+                    <tr>
+                        <td class="px-5 py-3 text-sm text-gray-700">#{{ job.id }}</td>
+                        <td class="px-5 py-3 text-sm">
+                            <span class="inline-flex px-2 py-1 rounded text-xs font-semibold
+                                {% if job.status == 'completed' %}bg-green-100 text-green-700
+                                {% elif job.status == 'failed' %}bg-orange-100 text-orange-700
+                                {% elif job.status == 'processing' %}bg-teal-100 text-teal-700
+                                {% else %}bg-gray-100 text-gray-700{% endif %}">
+                                {{ job.status }}
+                            </span>
+                        </td>
+                        <td class="px-5 py-3 text-sm text-gray-700">
+                            <div>{{ job.service_name }} {{ job.item_type }}</div>
+                            {% if job.item_url %}
+                            <a href="{{ job.item_url }}" class="text-teal-600 hover:text-teal-700 font-mono text-xs" target="_blank" rel="noopener">{{ job.item_id }}</a>
+                            {% else %}
+                            <div class="font-mono text-xs">{{ job.item_id }}</div>
+                            {% endif %}
+                            {% if job.error_message %}
+                            <div class="mt-1 text-xs text-orange-700 max-w-md break-words">{{ job.error_message }}</div>
+                            {% endif %}
+                        </td>
+                        <td class="px-5 py-3 text-sm text-gray-700">
+                            {{ job.imported_count or 0 }} imported, {{ job.skipped_count or 0 }} skipped
+                        </td>
+                        <td class="px-5 py-3 text-sm text-gray-700">
+                            {% if job.duration is not none %}{{ '%.1f'|format(job.duration) }}s{% else %}-{% endif %}
+                        </td>
+                        <td class="px-5 py-3 text-sm text-gray-700">{{ job.created_at|format_datetime if job.created_at else '-' }}</td>
+                    </tr>
+                    {% else %}
+                    <tr>
+                        <td colspan="6" class="px-5 py-8 text-center text-gray-500">No import jobs have been recorded yet.</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/tests/test_extra_coverage.py
+++ b/tests/test_extra_coverage.py
@@ -1,6 +1,6 @@
 """Additional coverage tests for generate helpers, routes, and import queue."""
 import pytest
-from musicround.models import db, User, Song, Round, Tag
+from musicround.models import db, ImportJobRecord, User, Song, Round, Tag
 
 
 def _login(app, client, username='extra_user', email='extra@example.com'):
@@ -251,8 +251,55 @@ class TestImportQueueStatusRoute:
         """Test queue-status endpoint is accessible for admin users."""
         _login_admin(app, client)
         response = client.get('/import/queue-status')
-        # The template may not exist in test env (500) or works (200)
-        assert response.status_code in (200, 302, 500)
+        assert response.status_code == 200
+        assert b'Import Queue' in response.data
+
+    def test_queue_status_shows_failed_job_details_for_admin(self, app, client):
+        """Test queue-status renders persisted failure details."""
+        _login_admin(app, client)
+        with app.app_context():
+            user = User.query.filter_by(username='extra_admin').first()
+            db.session.add(
+                ImportJobRecord(
+                    service_name='spotify',
+                    item_type='playlist',
+                    item_id='broken-playlist',
+                    user_id=user.id,
+                    status='failed',
+                    error_message='Preview import failed loudly',
+                    imported_count=2,
+                    skipped_count=1,
+                )
+            )
+            db.session.commit()
+
+        response = client.get('/import/queue-status')
+
+        assert response.status_code == 200
+        assert b'broken-playlist' in response.data
+        assert b'Preview import failed loudly' in response.data
+
+    def test_queue_status_shows_pending_database_job_for_admin(self, app, client):
+        """Test queue-status uses pending ImportJobRecord rows as source of truth."""
+        _login_admin(app, client)
+        with app.app_context():
+            user = User.query.filter_by(username='extra_admin').first()
+            db.session.add(
+                ImportJobRecord(
+                    service_name='spotify',
+                    item_type='playlist',
+                    item_id='pending-playlist',
+                    user_id=user.id,
+                    status='pending',
+                    priority=3,
+                )
+            )
+            db.session.commit()
+
+        response = client.get('/import/queue-status')
+
+        assert response.status_code == 200
+        assert b'pending-playlist' in response.data
 
 
 class TestUserRoutesExtended:

--- a/tests/test_import_queue.py
+++ b/tests/test_import_queue.py
@@ -2,10 +2,16 @@
 import pytest
 import threading
 import time
+from datetime import datetime
 from unittest.mock import patch
 
-from musicround.helpers.import_queue import ImportJob, ImportQueue, ImportWorker
-from musicround.models import User, db
+from musicround.helpers.import_queue import (
+    ImportJob,
+    ImportQueue,
+    ImportWorker,
+    enqueue_import_job,
+)
+from musicround.models import ImportJobRecord, User, db
 
 
 class TestImportJob:
@@ -158,6 +164,80 @@ class TestImportQueue:
         assert not errors
         assert len(results) == 5
 
+    def test_enqueue_creates_record_and_queue_snapshot(self, app):
+        """Test enqueue persists a pending job and exposes it in queue status data."""
+        with app.app_context():
+            user = User(username='queueuser', email='queue@example.com')
+            user.password = 'QueuePass123!'
+            db.session.add(user)
+            db.session.commit()
+
+            queue = ImportQueue()
+            record = enqueue_import_job(
+                queue=queue,
+                service_name='spotify',
+                item_type='playlist',
+                item_id='playlist123',
+                user_id=user.id,
+                priority='4',
+            )
+
+            assert record.id is not None
+            assert record.status == 'pending'
+            assert record.priority == 4
+            assert queue.qsize() == 1
+            snapshot = queue.snapshot()
+            assert snapshot[0]['record_id'] == record.id
+            assert snapshot[0]['item_id'] == 'playlist123'
+
+    def test_enqueue_pending_records_loads_database_jobs(self, app):
+        """Test startup can reload pending jobs from the database."""
+        with app.app_context():
+            user = User(username='pendinguser', email='pending@example.com')
+            user.password = 'QueuePass123!'
+            db.session.add(user)
+            db.session.flush()
+            record = ImportJobRecord(
+                service_name='deezer',
+                item_type='album',
+                item_id='album123',
+                user_id=user.id,
+                priority=2,
+                status='pending',
+            )
+            db.session.add(record)
+            db.session.commit()
+
+            queue = ImportQueue()
+            assert queue.enqueue_pending_records() == 1
+            job = queue.get_job(timeout=0.1)
+            assert job.record_id == record.id
+            assert job.item_id == 'album123'
+
+    def test_mark_abandoned_processing_records_fails_stale_jobs(self, app):
+        """Test processing jobs left behind by a restart get a visible failure."""
+        with app.app_context():
+            user = User(username='staleuser', email='stale@example.com')
+            user.password = 'QueuePass123!'
+            db.session.add(user)
+            db.session.flush()
+            record = ImportJobRecord(
+                service_name='spotify',
+                item_type='playlist',
+                item_id='stale',
+                user_id=user.id,
+                status='processing',
+                started_at=datetime(2026, 1, 1, 12, 0, 0),
+            )
+            db.session.add(record)
+            db.session.commit()
+
+            queue = ImportQueue()
+            assert queue.mark_abandoned_processing_records() == 1
+            updated = ImportJobRecord.query.get(record.id)
+            assert updated.status == 'failed'
+            assert 'restarted' in updated.error_message
+
 
 class TestImportWorker:
     """Tests for ImportWorker job processing."""
@@ -183,6 +263,68 @@ class TestImportWorker:
                 worker._process_job(job)
 
             mock_import.assert_called_once_with('deezer', 'track', '123')
+
+    def test_process_job_updates_record_status(self, app):
+        """Test that worker writes processing and completed state to ImportJobRecord."""
+        with app.app_context():
+            user = User(username='recordworker', email='recordworker@example.com')
+            user.password = 'WorkerPass123!'
+            db.session.add(user)
+            db.session.commit()
+
+            queue = ImportQueue()
+            record = enqueue_import_job(
+                queue=queue,
+                service_name='deezer',
+                item_type='playlist',
+                item_id='456',
+                user_id=user.id,
+                priority=1,
+            )
+            record_id = record.id
+            job = queue.get_job(timeout=0.1)
+            worker = ImportWorker(app, queue)
+
+            with patch('musicround.helpers.import_queue.ImportHelper.import_item') as mock_import:
+                mock_import.return_value = {'imported_count': 3, 'skipped_count': 1}
+                worker._process_job(job)
+
+            updated = ImportJobRecord.query.get(record_id)
+            assert updated.status == 'completed'
+            assert updated.started_at is not None
+            assert updated.completed_at is not None
+            assert updated.imported_count == 3
+            assert updated.skipped_count == 1
+
+    def test_process_job_persists_failure_details(self, app):
+        """Test failed imports leave an actionable ImportJobRecord error."""
+        with app.app_context():
+            user = User(username='failworker', email='failworker@example.com')
+            user.password = 'WorkerPass123!'
+            db.session.add(user)
+            db.session.commit()
+
+            queue = ImportQueue()
+            record = enqueue_import_job(
+                queue=queue,
+                service_name='spotify',
+                item_type='playlist',
+                item_id='bad',
+                user_id=user.id,
+                priority=1,
+            )
+            record_id = record.id
+            job = queue.get_job(timeout=0.1)
+            worker = ImportWorker(app, queue)
+
+            with patch('musicround.helpers.import_queue.ImportHelper.import_item') as mock_import:
+                mock_import.side_effect = RuntimeError('Spotify exploded')
+                worker._process_job(job)
+
+            updated = ImportJobRecord.query.get(record_id)
+            assert updated.status == 'failed'
+            assert updated.completed_at is not None
+            assert 'Spotify exploded' in updated.error_message
 
     def test_process_job_unknown_user_does_not_import(self, app):
         """Test that jobs for missing users are ignored."""


### PR DESCRIPTION
## Summary
- persist playlist import jobs as ImportJobRecord rows and update pending/processing/completed/failed state
- reload pending jobs on startup and fail abandoned processing jobs with an actionable reason
- render the admin import queue page from database-backed status, including pending and failed job details

## Local validation
- SECRET_KEY=test-secret-key-for-testing-only AUTOMATION_TOKEN=test-automation-token-for-testing IMPORT_WORKERS_ENABLED=false /tmp/qb-test-venv312/bin/python -m pytest tests/test_import_queue.py tests/test_extra_coverage.py::TestImportQueueStatusRoute -q
- SECRET_KEY=test-secret-key-for-testing-only AUTOMATION_TOKEN=test-automation-token-for-testing IMPORT_WORKERS_ENABLED=false /tmp/qb-test-venv312/bin/python -m pytest -q

Closes #54
Closes #62