### PR TITLE
Harden import queue worker follow-ups

### DIFF
--- a/musicround/helpers/import_queue.py
+++ b/musicround/helpers/import_queue.py
@@ -212,18 +212,20 @@ class ImportWorker(threading.Thread):
 
     def _process_job(self, job: ImportJob) -> None:
         with self.app.test_request_context():
-            record = self._claim_record(job)
-            if job.record_id and record is None:
-                return
-
-            user = User.query.get(job.user_id)
-            if not user:
-                current_app.logger.error("Import job for unknown user %s", job.user_id)
-                self._mark_failed(record, f"Unknown user id {job.user_id}")
-                return
-
-            login_user(user)
+            logged_in = False
             try:
+                record = self._claim_record(job)
+                if job.record_id and record is None:
+                    return
+
+                user = User.query.get(job.user_id)
+                if not user:
+                    current_app.logger.error("Import job for unknown user %s", job.user_id)
+                    self._mark_failed(record, f"Unknown user id {job.user_id}")
+                    return
+
+                login_user(user)
+                logged_in = True
                 current_app.logger.info(
                     "Processing import job: record=%s service=%s type=%s id=%s user=%s priority=%s",
                     job.record_id,
@@ -242,7 +244,8 @@ class ImportWorker(threading.Thread):
                 db.session.rollback()
                 self._mark_failed(record, str(exc))
             finally:
-                logout_user()
+                if logged_in:
+                    logout_user()
                 db.session.remove()
 
     def _claim_record(self, job: ImportJob) -> Optional[ImportJobRecord]:
@@ -250,13 +253,25 @@ class ImportWorker(threading.Thread):
             return None
 
         with self._claim_lock:
-            statement = (
-                update(ImportJobRecord)
-                .where(ImportJobRecord.id == job.record_id, ImportJobRecord.status == "pending")
-                .values(status="processing", started_at=datetime.utcnow())
-            )
-            result = db.session.execute(statement)
-            db.session.commit()
+            try:
+                statement = (
+                    update(ImportJobRecord)
+                    .where(
+                        ImportJobRecord.id == job.record_id,
+                        ImportJobRecord.status == "pending",
+                    )
+                    .values(status="processing", started_at=datetime.utcnow())
+                )
+                result = db.session.execute(statement)
+                db.session.commit()
+            except SQLAlchemyError as exc:
+                db.session.rollback()
+                current_app.logger.warning(
+                    "Could not claim import job record %s: %s",
+                    job.record_id,
+                    exc,
+                )
+                return None
 
         if result.rowcount != 1:
             db.session.rollback()

--- a/musicround/helpers/import_queue.py
+++ b/musicround/helpers/import_queue.py
@@ -212,6 +212,7 @@ class ImportWorker(threading.Thread):
 
     def _process_job(self, job: ImportJob) -> None:
         with self.app.test_request_context():
+            record = None
             logged_in = False
             try:
                 record = self._claim_record(job)
@@ -263,6 +264,9 @@ class ImportWorker(threading.Thread):
                     .values(status="processing", started_at=datetime.utcnow())
                 )
                 result = db.session.execute(statement)
+                if result.rowcount != 1:
+                    db.session.rollback()
+                    return None
                 db.session.commit()
             except SQLAlchemyError as exc:
                 db.session.rollback()
@@ -272,10 +276,6 @@ class ImportWorker(threading.Thread):
                     exc,
                 )
                 return None
-
-        if result.rowcount != 1:
-            db.session.rollback()
-            return None
 
         return ImportJobRecord.query.get(job.record_id)
 

--- a/musicround/routes/import_routes.py
+++ b/musicround/routes/import_routes.py
@@ -811,6 +811,14 @@ def queue_status():
                 'user_id': job.user_id,
                 'record_id': job.id,
             })
+        queue_snapshot.sort(
+            key=lambda job: (
+                job.get('priority', 0),
+                job.get('counter') is None,
+                job.get('counter') or 0,
+                job.get('record_id') or 0,
+            )
+        )
     except (ImportError, AttributeError):
         # ImportJobRecord might not be defined yet, handle this case
         pass

--- a/tests/test_extra_coverage.py
+++ b/tests/test_extra_coverage.py
@@ -301,6 +301,39 @@ class TestImportQueueStatusRoute:
         assert response.status_code == 200
         assert b'pending-playlist' in response.data
 
+    def test_queue_status_orders_database_jobs_by_priority(self, app, client):
+        """Test appended database jobs keep priority order in the status page."""
+        _login_admin(app, client)
+        with app.app_context():
+            user = User.query.filter_by(username='extra_admin').first()
+            db.session.add_all(
+                [
+                    ImportJobRecord(
+                        service_name='spotify',
+                        item_type='playlist',
+                        item_id='low-priority-playlist',
+                        user_id=user.id,
+                        status='pending',
+                        priority=9,
+                    ),
+                    ImportJobRecord(
+                        service_name='spotify',
+                        item_type='playlist',
+                        item_id='high-priority-playlist',
+                        user_id=user.id,
+                        status='pending',
+                        priority=1,
+                    ),
+                ]
+            )
+            db.session.commit()
+
+        response = client.get('/import/queue-status')
+        page = response.data.decode()
+
+        assert response.status_code == 200
+        assert page.index('high-priority-playlist') < page.index('low-priority-playlist')
+
 
 class TestUserRoutesExtended:
     """Additional user route tests for more coverage."""

--- a/tests/test_import_queue.py
+++ b/tests/test_import_queue.py
@@ -368,6 +368,29 @@ class TestImportWorker:
             mock_import.assert_not_called()
             mock_remove.assert_called_once()
 
+    def test_process_job_handles_claim_exception_without_unbound_record(self, app):
+        """Test claim exceptions keep the original worker failure path intact."""
+        with app.app_context():
+            worker = ImportWorker(app, ImportQueue())
+            job = ImportJob(
+                priority=1,
+                service_name='deezer',
+                item_type='track',
+                item_id='123',
+                user_id=1,
+                record_id=42,
+            )
+
+            with (
+                patch.object(worker, '_claim_record', side_effect=RuntimeError('claim exploded')),
+                patch('musicround.helpers.import_queue.db.session.remove') as mock_remove,
+                patch('musicround.helpers.import_queue.ImportHelper.import_item') as mock_import,
+            ):
+                worker._process_job(job)
+
+            mock_import.assert_not_called()
+            mock_remove.assert_called_once()
+
     def test_claim_record_handles_database_errors(self, app):
         """Test claim failures leave the worker alive and rollback the session."""
         with app.app_context():
@@ -390,4 +413,29 @@ class TestImportWorker:
             ):
                 assert worker._claim_record(job) is None
 
+            mock_rollback.assert_called_once()
+
+    def test_claim_record_does_not_commit_unclaimed_record(self, app):
+        """Test a raced claim rolls back instead of committing a no-op update."""
+        with app.app_context():
+            worker = ImportWorker(app, ImportQueue())
+            job = ImportJob(
+                priority=1,
+                service_name='deezer',
+                item_type='track',
+                item_id='123',
+                user_id=1,
+                record_id=42,
+            )
+
+            with (
+                patch('musicround.helpers.import_queue.db.session.execute') as mock_execute,
+                patch('musicround.helpers.import_queue.db.session.commit') as mock_commit,
+                patch('musicround.helpers.import_queue.db.session.rollback') as mock_rollback,
+            ):
+                mock_execute.return_value.rowcount = 0
+
+                assert worker._claim_record(job) is None
+
+            mock_commit.assert_not_called()
             mock_rollback.assert_called_once()

--- a/tests/test_import_queue.py
+++ b/tests/test_import_queue.py
@@ -5,6 +5,8 @@ import time
 from datetime import datetime
 from unittest.mock import patch
 
+from sqlalchemy.exc import SQLAlchemyError
+
 from musicround.helpers.import_queue import (
     ImportJob,
     ImportQueue,
@@ -342,3 +344,50 @@ class TestImportWorker:
                 worker._process_job(job)
 
             mock_import.assert_not_called()
+
+    def test_process_job_removes_session_when_claim_returns_none(self, app):
+        """Test skipped claimed jobs still clear the worker-scoped session."""
+        with app.app_context():
+            worker = ImportWorker(app, ImportQueue())
+            job = ImportJob(
+                priority=1,
+                service_name='deezer',
+                item_type='track',
+                item_id='123',
+                user_id=1,
+                record_id=42,
+            )
+
+            with (
+                patch.object(worker, '_claim_record', return_value=None),
+                patch('musicround.helpers.import_queue.db.session.remove') as mock_remove,
+                patch('musicround.helpers.import_queue.ImportHelper.import_item') as mock_import,
+            ):
+                worker._process_job(job)
+
+            mock_import.assert_not_called()
+            mock_remove.assert_called_once()
+
+    def test_claim_record_handles_database_errors(self, app):
+        """Test claim failures leave the worker alive and rollback the session."""
+        with app.app_context():
+            worker = ImportWorker(app, ImportQueue())
+            job = ImportJob(
+                priority=1,
+                service_name='deezer',
+                item_type='track',
+                item_id='123',
+                user_id=1,
+                record_id=42,
+            )
+
+            with (
+                patch(
+                    'musicround.helpers.import_queue.db.session.execute',
+                    side_effect=SQLAlchemyError('database unavailable'),
+                ),
+                patch('musicround.helpers.import_queue.db.session.rollback') as mock_rollback,
+            ):
+                assert worker._claim_record(job) is None
+
+            mock_rollback.assert_called_once()


### PR DESCRIPTION
## Summary\n- ensure worker-scoped DB sessions are removed when a claimed job is skipped or an unknown user returns early\n- handle DB claim errors without killing the worker loop\n- keep queue-status pending jobs ordered by priority after adding database-backed jobs\n\n## Validation\n- `git diff --check`\n- `SECRET_KEY=test AUTOMATION_TOKEN=test /tmp/QuizzicalBeats-pr80/.venv/bin/python -m pytest tests/test_import_queue.py::TestImportWorker tests/test_extra_coverage.py::TestImportQueueStatusRoute::test_queue_status_orders_database_jobs_by_priority -q`