### PR TITLE
Redact OAuth tokens from logs

### DIFF
--- a/musicround/__init__.py
+++ b/musicround/__init__.py
@@ -13,6 +13,7 @@ from musicround.config import Config
 from musicround.version import VERSION_INFO, get_version_str
 from datetime import datetime
 from musicround.helpers.auth_helpers import oauth # Import the oauth object
+from musicround.helpers.logging_utils import oauth_token_log_summary
 
 # Initialize SQLAlchemy
 db = SQLAlchemy()
@@ -203,11 +204,20 @@ def create_app(config=None):
         if current_user.is_authenticated:
             if name == 'spotify':
                 token_str = current_user.spotify_token
-                app.logger.debug(f"_app_fetch_token for Spotify (user {current_user.id}): Raw token string from DB: {token_str[:150] if token_str else 'None'}...")
+                app.logger.debug(
+                    "_app_fetch_token for Spotify (user %s): Stored token present=%s, length=%s",
+                    current_user.id,
+                    bool(token_str),
+                    len(token_str) if token_str else 0,
+                )
                 if token_str:
                     try:
                         token = json.loads(token_str)
-                        app.logger.debug(f"_app_fetch_token for Spotify (user {current_user.id}): Token after json.loads: {{'access_token': 'ACCESS_TOKEN_REDACTED', 'refresh_token': '{'REFRESH_TOKEN_REDACTED' if token.get('refresh_token') else 'None'}', 'expires_at': {token.get('expires_at')}, 'expires_in': {token.get('expires_in')}, 'scope': {token.get('scope')}, 'token_type': '{token.get('token_type')}'}}")
+                        app.logger.debug(
+                            "_app_fetch_token for Spotify (user %s): Token after json.loads: %s",
+                            current_user.id,
+                            oauth_token_log_summary(token),
+                        )
 
                         if 'refresh_token' not in token or not token.get('refresh_token'):
                             if hasattr(current_user, 'spotify_refresh_token') and current_user.spotify_refresh_token:
@@ -245,10 +255,17 @@ def create_app(config=None):
                         if 'expires_in' in token: 
                             del token['expires_in']
 
-                        app.logger.debug(f"_app_fetch_token for Spotify (user {current_user.id}): Final token prepared for Authlib: {{'access_token': 'ACCESS_TOKEN_REDACTED', 'refresh_token': '{'REFRESH_TOKEN_REDACTED' if token.get('refresh_token') else 'None'}', 'expires_at': {token.get('expires_at')}, 'token_type': '{token.get('token_type')}', 'scope': {token.get('scope')}}}")
+                        app.logger.debug(
+                            "_app_fetch_token for Spotify (user %s): Final token prepared for Authlib: %s",
+                            current_user.id,
+                            oauth_token_log_summary(token),
+                        )
                         return token
                     except json.JSONDecodeError:
-                        app.logger.error(f"_app_fetch_token for Spotify (user {current_user.id}): Failed to decode token JSON: {token_str[:100]}...")
+                        app.logger.error(
+                            "_app_fetch_token for Spotify (user %s): Failed to decode stored token JSON",
+                            current_user.id,
+                        )
                         return None
                     except Exception as e:
                         app.logger.error(f"_app_fetch_token for Spotify (user {current_user.id}): Error processing token: {str(e)}", exc_info=True)
@@ -264,7 +281,11 @@ def create_app(config=None):
         if name == 'spotify':
             if current_user.is_authenticated:
                 app.logger.info(f"_app_update_token for Spotify (user {current_user.id}): Received new token data to update. Keys: {list(token.keys()) if token else 'None'}")
-                app.logger.debug(f"_app_update_token for Spotify (user {current_user.id}): Full new token: {{'access_token': 'ACCESS_TOKEN_REDACTED', 'refresh_token': '{'REFRESH_TOKEN_REDACTED' if token.get('refresh_token') else 'None'}', 'expires_at': {token.get('expires_at')}, 'token_type': '{token.get('token_type')}', 'scope': {token.get('scope')}}}")
+                app.logger.debug(
+                    "_app_update_token for Spotify (user %s): New token metadata: %s",
+                    current_user.id,
+                    oauth_token_log_summary(token),
+                )
                 
                 current_user.spotify_token = json.dumps(token)
                 

--- a/musicround/config.py
+++ b/musicround/config.py
@@ -16,7 +16,6 @@ basedir = os.path.abspath(os.path.dirname(__file__))
 class Config:
     # Debug settings
     DEBUG = os.getenv("DEBUG", "True") == "True"
-    DEBUG2 = os.getenv("DEBUG2", "False") == "True"
     SECRET_KEY = os.getenv('SECRET_KEY')
     if not SECRET_KEY:
         raise ValueError("SECRET_KEY environment variable must be set. Generate a secure key with: python -c 'import secrets; print(secrets.token_hex(32))'")
@@ -89,6 +88,5 @@ class Config:
     OAUTH_GOOGLE_URL = os.getenv("OAUTH_GOOGLE_URL")
     OAUTH_AUTHENTIK_URL = os.getenv("OAUTH_AUTHENTIK_URL")
     OAUTH_DROPBOX_URL = os.getenv("OAUTH_DROPBOX_URL")
-
 
 

--- a/musicround/helpers/auth_helpers.py
+++ b/musicround/helpers/auth_helpers.py
@@ -7,6 +7,7 @@ from authlib.integrations.flask_client import OAuth
 from functools import wraps
 from datetime import datetime, timedelta
 import requests
+from musicround.helpers.logging_utils import oauth_token_log_summary
 
 # Initialize OAuth object
 oauth = OAuth()
@@ -139,8 +140,10 @@ def get_dropbox_user_info(token):
     Get Dropbox user info from the token
     """
     try:
-        # Add debug logging for token
-        current_app.logger.debug(f"Retrieving Dropbox user info with token: {token}")
+        current_app.logger.debug(
+            "Retrieving Dropbox user info with token metadata: %s",
+            oauth_token_log_summary(token),
+        )
         
         # Make sure we have an access token
         access_token = token.get("access_token")

--- a/musicround/helpers/dropbox_helper.py
+++ b/musicround/helpers/dropbox_helper.py
@@ -3,6 +3,7 @@ Helpers for Dropbox API integration
 """
 from flask import current_app, url_for, redirect, session
 from musicround.helpers.auth_helpers import get_oauth_redirect_uri
+from musicround.helpers.logging_utils import redact_authorization_header
 import requests
 import json
 import os
@@ -289,9 +290,12 @@ def upload_to_dropbox(access_token, dropbox_path, data, mode='binary'):
         if mode == 'text' and isinstance(data, str):
             data = data.encode('utf-8')
         
-        # Debug token information
-        token_preview = access_token[:10] + '...' if access_token else 'None'
-        current_app.logger.debug(f"Upload to Dropbox - Path: {dropbox_path}, Token preview: {token_preview}, Data size: {len(data) if data else 0} bytes")
+        current_app.logger.debug(
+            "Upload to Dropbox - Path: %s, Token present: %s, Data size: %s bytes",
+            dropbox_path,
+            bool(access_token),
+            len(data) if data else 0,
+        )
         
         headers = {
             'Authorization': f'Bearer {access_token}',
@@ -304,7 +308,7 @@ def upload_to_dropbox(access_token, dropbox_path, data, mode='binary'):
             'Content-Type': 'application/octet-stream'
         }
         
-        current_app.logger.debug(f"Dropbox API headers: {headers}")
+        current_app.logger.debug("Dropbox API headers: %s", redact_authorization_header(headers))
         
         response = requests.post(
             'https://content.dropboxapi.com/2/files/upload',
@@ -368,9 +372,11 @@ def create_shared_link(access_token, dropbox_path):
         dropbox_path = '/' + dropbox_path
     
     try:
-        # Debug token information
-        token_preview = access_token[:10] + '...' if access_token else 'None'
-        current_app.logger.debug(f"Creating shared link - Path: {dropbox_path}, Token preview: {token_preview}")
+        current_app.logger.debug(
+            "Creating shared link - Path: %s, Token present: %s",
+            dropbox_path,
+            bool(access_token),
+        )
         
         headers = {
             'Authorization': f'Bearer {access_token}',

--- a/musicround/helpers/logging_utils.py
+++ b/musicround/helpers/logging_utils.py
@@ -1,0 +1,42 @@
+"""Logging helpers that keep credentials out of application logs."""
+
+from collections.abc import Mapping
+
+
+def oauth_token_log_summary(token):
+    """Return non-sensitive OAuth token metadata for logs."""
+    if token is None:
+        return {"type": "none", "present": False}
+
+    if isinstance(token, Mapping):
+        return {
+            "type": "mapping",
+            "keys": sorted(str(key) for key in token.keys()),
+            "has_access_token": bool(token.get("access_token")),
+            "has_refresh_token": bool(token.get("refresh_token")),
+            "has_id_token": bool(token.get("id_token")),
+            "expires_at": token.get("expires_at"),
+            "expires_in": token.get("expires_in"),
+            "token_type": token.get("token_type"),
+            "scope": token.get("scope"),
+        }
+
+    if isinstance(token, str):
+        return {
+            "type": "string",
+            "present": bool(token),
+            "length": len(token),
+        }
+
+    return {
+        "type": type(token).__name__,
+        "present": True,
+    }
+
+
+def redact_authorization_header(headers):
+    """Return a copy of headers with Authorization values removed."""
+    redacted = dict(headers or {})
+    if "Authorization" in redacted:
+        redacted["Authorization"] = "[redacted]"
+    return redacted

--- a/musicround/routes/api.py
+++ b/musicround/routes/api.py
@@ -11,6 +11,7 @@ from sqlalchemy import or_
 from flask_login import login_required, current_user
 import requests  # Import requests for direct API calls
 from musicround.helpers.spotify_helper import get_spotify_token
+from musicround.helpers.logging_utils import redact_authorization_header
 
 api_bp = Blueprint('api', __name__, url_prefix='/api')
 
@@ -890,7 +891,8 @@ def list_dropbox_folders():
         }
         
         current_app.logger.debug(f"Sending request to Dropbox API: {json.dumps(data)}")
-        current_app.logger.debug(f"Using token: {token[:5]}...{token[-5:] if len(token) > 10 else ''}")
+        current_app.logger.debug("Dropbox list_folder token present: %s", bool(token))
+        current_app.logger.debug("Dropbox list_folder headers: %s", redact_authorization_header(headers))
         
         response = requests.post(
             'https://api.dropboxapi.com/2/files/list_folder',

--- a/musicround/routes/auth.py
+++ b/musicround/routes/auth.py
@@ -10,6 +10,7 @@ from datetime import datetime
 import requests
 import secrets
 from musicround.helpers.auth_helpers import oauth, find_or_create_user, update_oauth_tokens, get_spotify_user_info, get_oauth_redirect_uri
+from musicround.helpers.logging_utils import oauth_token_log_summary
 
 # Create blueprint
 auth_bp = Blueprint('auth', __name__)
@@ -48,7 +49,10 @@ def callback():
     """Handle Spotify OAuth callback for login using Authlib."""
     try:
         token = oauth.spotify.authorize_access_token()
-        current_app.logger.debug(f"Spotify token received for login: {token}")
+        current_app.logger.debug(
+            "Spotify token received for login: %s",
+            oauth_token_log_summary(token),
+        )
 
         # Fetch user info using the token
         spotify_info = get_spotify_user_info(token)

--- a/musicround/routes/rounds.py
+++ b/musicround/routes/rounds.py
@@ -811,7 +811,7 @@ def export_to_dropbox(round_id):
         
         # Access token for Dropbox API calls
         access_token = current_user.dropbox_token
-        current_app.logger.debug(f"Access token (first 10 chars): {access_token[:10] if access_token else 'None'}")
+        current_app.logger.debug("Dropbox access token present for export: %s", bool(access_token))
         
         # Prepare song list - check if the helper method works
         try:

--- a/musicround/routes/users.py
+++ b/musicround/routes/users.py
@@ -830,7 +830,10 @@ def update_bearer_token():
         session['token_source'] = 'manual' # Initial assumption
         session['bearer_token_added'] = datetime.now().timestamp()
         
-        current_app.logger.info(f"User {current_user.id} added a manual bearer token to session. Validating: {bearer_token[:10]}...")
+        current_app.logger.info(
+            "User %s added a manual bearer token to session. Validating token presence only.",
+            current_user.id,
+        )
         
         try:
             resp_me = oauth.spotify.get('https://api.spotify.com/v1/me', token={'access_token': bearer_token, 'token_type': 'Bearer'})

--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -1,0 +1,54 @@
+from musicround.helpers.logging_utils import (
+    oauth_token_log_summary,
+    redact_authorization_header,
+)
+
+
+def test_oauth_token_log_summary_keeps_token_values_out():
+    summary = oauth_token_log_summary(
+        {
+            "access_token": "spotify-access-secret",
+            "refresh_token": "spotify-refresh-secret",
+            "id_token": "spotify-id-secret",
+            "expires_at": 1234567890,
+            "expires_in": 3600,
+            "scope": "playlist-read-private",
+            "token_type": "Bearer",
+        }
+    )
+
+    rendered = repr(summary)
+
+    assert "spotify-access-secret" not in rendered
+    assert "spotify-refresh-secret" not in rendered
+    assert "spotify-id-secret" not in rendered
+    assert summary["has_access_token"] is True
+    assert summary["has_refresh_token"] is True
+    assert summary["has_id_token"] is True
+    assert summary["expires_in"] == 3600
+    assert summary["token_type"] == "Bearer"
+
+
+def test_oauth_token_log_summary_redacts_plain_token_strings():
+    summary = oauth_token_log_summary("plain-bearer-secret")
+
+    assert "plain-bearer-secret" not in repr(summary)
+    assert summary == {
+        "type": "string",
+        "present": True,
+        "length": len("plain-bearer-secret"),
+    }
+
+
+def test_redact_authorization_header_removes_bearer_value():
+    headers = {
+        "Authorization": "Bearer dropbox-access-secret",
+        "Content-Type": "application/json",
+    }
+
+    redacted = redact_authorization_header(headers)
+
+    assert redacted["Authorization"] == "[redacted]"
+    assert redacted["Content-Type"] == "application/json"
+    assert headers["Authorization"] == "Bearer dropbox-access-secret"
+    assert "dropbox-access-secret" not in repr(redacted)


### PR DESCRIPTION
## Summary
- add shared log helpers for OAuth token summaries and Authorization header redaction
- remove full/prefix token logging from Spotify, Dropbox, manual bearer, and Authlib token flows
- remove unused DEBUG2 config flag

Closes #105.

## Local validation
- `pytest tests/test_logging_utils.py tests/test_auth_helpers.py -q` -> 8 passed
- `pytest -q` -> 389 passed, 2 skipped
- `git diff --check` -> clean