### PR TITLE
Remove stale DEBUG2 documentation

### DIFF
--- a/docs/admin-guide/configuration.md
+++ b/docs/admin-guide/configuration.md
@@ -11,7 +11,6 @@ Quizzical Beats uses environment variables for configuration. These can be set i
 ```bash
 # Debug settings
 DEBUG=True
-DEBUG2=False
 SECRET_KEY=your-secret-key-here-make-it-long-and-random
 ```
 


### PR DESCRIPTION
## Summary
- remove the stale `DEBUG2` entry from the admin configuration guide
- keep documentation aligned with the token-redaction change from #108, which removed `DEBUG2` from runtime configuration

## Validation
- `rg -n "DEBUG2|debug2" .` returned no matches
- `git diff --check`
