### PR TITLE
Remove stale DEBUG2 env examples

### DIFF
--- a/.env.demo
+++ b/.env.demo
@@ -3,7 +3,6 @@
 
 # Debug settings
 DEBUG=True
-DEBUG2=False
 SECRET_KEY=your-secret-key-here-make-it-long-and-random
 
 # API Keys

--- a/.env.example
+++ b/.env.example
@@ -19,7 +19,6 @@ AUTOMATION_TOKEN=
 # ============================================================================
 # WARNING: Set DEBUG=False in production environments!
 DEBUG=False
-DEBUG2=False
 
 # ============================================================================
 # DATABASE CONFIGURATION


### PR DESCRIPTION
## Summary
- remove stale `DEBUG2=False` from `.env.demo` and `.env.example`
- close the follow-up from #109 that noted hidden starter env files still documented the removed setting

## Validation
- `rg --hidden --glob '!.git/*' -n "DEBUG2|debug2" .` returned no matches
- `git diff --check`
