### PR TITLE
Harden OAuth identity linking

### DIFF
--- a/migrations/ensure_oauth_provider_unique_indexes.py
+++ b/migrations/ensure_oauth_provider_unique_indexes.py
@@ -1,0 +1,77 @@
+"""Add unique indexes for OAuth provider account IDs."""
+
+import logging
+from sqlalchemy import inspect, text
+
+logger = logging.getLogger(__name__)
+
+PROVIDER_ID_COLUMNS = {
+    "google_id": "idx_user_google_id",
+    "authentik_id": "idx_user_authentik_id",
+    "dropbox_id": "idx_user_dropbox_id",
+}
+
+
+def _index_exists(inspector, index_name):
+    return any(index.get("name") == index_name for index in inspector.get_indexes("user"))
+
+
+def _find_duplicate_values(conn, column_name):
+    return conn.execute(
+        text(
+            f"""
+            SELECT {column_name}, COUNT(*) AS duplicate_count
+            FROM user
+            WHERE {column_name} IS NOT NULL AND {column_name} != ''
+            GROUP BY {column_name}
+            HAVING COUNT(*) > 1
+            LIMIT 10
+            """
+        )
+    ).fetchall()
+
+
+def run_migration():
+    """Create unique indexes after explicitly checking for duplicate values."""
+    from musicround import db
+
+    changes_made = False
+
+    try:
+        inspector = inspect(db.engine)
+        existing_columns = {column["name"] for column in inspector.get_columns("user")}
+
+        with db.engine.connect() as conn:
+            for column_name, index_name in PROVIDER_ID_COLUMNS.items():
+                if column_name not in existing_columns:
+                    logger.warning("Column %s is missing; skipping unique index %s", column_name, index_name)
+                    continue
+
+                if _index_exists(inspector, index_name):
+                    logger.info("Unique index %s already exists", index_name)
+                    continue
+
+                duplicates = _find_duplicate_values(conn, column_name)
+                if duplicates:
+                    logger.error(
+                        "Cannot add unique index %s because duplicate %s values exist: %s",
+                        index_name,
+                        column_name,
+                        [(row[0], row[1]) for row in duplicates],
+                    )
+                    return False
+
+                logger.info("Adding unique index %s on user.%s", index_name, column_name)
+                conn.execute(
+                    text(
+                        f"CREATE UNIQUE INDEX {index_name} ON user ({column_name}) "
+                        f"WHERE {column_name} IS NOT NULL AND {column_name} != ''"
+                    )
+                )
+                conn.commit()
+                changes_made = True
+
+        return True if changes_made else None
+    except Exception as exc:
+        logger.error("Error adding OAuth provider unique indexes: %s", exc)
+        return False

--- a/musicround/helpers/auth_helpers.py
+++ b/musicround/helpers/auth_helpers.py
@@ -104,7 +104,8 @@ def get_google_user_info(token):
             'name': profile.get('name'),
             'given_name': profile.get('given_name'),
             'family_name': profile.get('family_name'),
-            'picture': profile.get('picture')
+            'picture': profile.get('picture'),
+            'email_verified': profile.get('email_verified', False),
         }
         
         # Add 'sub' field explicitly for backwards compatibility
@@ -129,7 +130,8 @@ def get_authentik_user_info(token):
             'name': profile.get('name'),
             'given_name': profile.get('given_name', ''),
             'family_name': profile.get('family_name', ''),
-            'picture': profile.get('picture', '')
+            'picture': profile.get('picture', ''),
+            'email_verified': profile.get('email_verified', False),
         }
     except Exception as e:
         current_app.logger.error(f"Error getting Authentik user info: {str(e)}")
@@ -183,13 +185,21 @@ def get_dropbox_user_info(token):
             'name': profile.get('name', {}).get('display_name', ''),
             'given_name': profile.get('name', {}).get('given_name', ''),
             'family_name': profile.get('name', {}).get('surname', ''),
-            'picture': profile.get('profile_photo_url', '')
+            'picture': profile.get('profile_photo_url', ''),
+            'email_verified': profile.get('email_verified', False),
         }
         
         return user_info
     except Exception as e:
         current_app.logger.error(f"Error getting Dropbox user info: {str(e)}")
         return None
+
+def _oauth_email_is_verified(user_info):
+    """Return True only when the provider explicitly verified the email claim."""
+    verified = user_info.get('email_verified')
+    if isinstance(verified, str):
+        return verified.strip().lower() in {'1', 'true', 'yes'}
+    return verified is True
 
 def get_spotify_user_info(token):
     """
@@ -248,12 +258,20 @@ def find_or_create_user(user_info, auth_provider):
     else:
         return None
         
-    # If not found by provider ID, try email
+    # If not found by provider ID, try verified email.
     if user is None and user_info.get('email'):
         user = User.query.filter_by(email=user_info['email']).first()
         
-        # If user exists but doesn't have provider ID, update it
         if user:
+            if not _oauth_email_is_verified(user_info):
+                current_app.logger.warning(
+                    "Refusing to link %s OAuth identity %s to existing user %s because email is not verified",
+                    auth_provider,
+                    user_info.get('id'),
+                    user.username,
+                )
+                return None
+
             if auth_provider == 'google':
                 user.google_id = user_info['id']
             elif auth_provider == 'authentik':

--- a/musicround/models.py
+++ b/musicround/models.py
@@ -63,17 +63,17 @@ class User(db.Model, UserMixin):
     spotify_token_expiry = db.Column(db.DateTime)
     
     # OAuth provider info - Google
-    google_id = db.Column(db.String(100))      # Google user ID
+    google_id = db.Column(db.String(100), index=True, unique=True, nullable=True)      # Google user ID
     google_token = db.Column(db.Text)          # Store Google access token
     google_refresh_token = db.Column(db.Text)   # Store Google refresh token
     
     # OAuth provider info - Authentik
-    authentik_id = db.Column(db.String(100))    # Authentik user ID
+    authentik_id = db.Column(db.String(100), index=True, unique=True, nullable=True)    # Authentik user ID
     authentik_token = db.Column(db.Text)        # Store Authentik access token
     authentik_refresh_token = db.Column(db.Text) # Store Authentik refresh token
     
     # OAuth provider info - Dropbox
-    dropbox_id = db.Column(db.String(100))      # Dropbox user ID
+    dropbox_id = db.Column(db.String(100), index=True, unique=True, nullable=True)      # Dropbox user ID
     dropbox_token = db.Column(db.Text)          # Store Dropbox access token
     dropbox_refresh_token = db.Column(db.Text)  # Store Dropbox refresh token
     dropbox_token_expiry = db.Column(db.DateTime) # Dropbox token expiration

--- a/tests/test_auth_helpers.py
+++ b/tests/test_auth_helpers.py
@@ -5,7 +5,7 @@ A provider's refresh response doesn't always include a new refresh_token
 update_oauth_tokens must not clobber a still-valid stored refresh token with
 None just because a given response happened to omit it.
 """
-from musicround.helpers.auth_helpers import update_oauth_tokens
+from musicround.helpers.auth_helpers import find_or_create_user, update_oauth_tokens
 from musicround.models import User, db
 
 
@@ -51,3 +51,58 @@ class TestUpdateOauthTokensPreservesRefreshToken:
             user = _make_user(authentik_refresh_token='old-authentik-refresh')
             update_oauth_tokens(user, {'access_token': 'new-token'}, 'authentik')
             assert user.authentik_refresh_token == 'old-authentik-refresh'
+
+
+class TestFindOrCreateUserEmailLinking:
+    def test_verified_email_match_links_existing_user(self, app):
+        with app.app_context():
+            user = _make_user()
+
+            found = find_or_create_user(
+                {
+                    'id': 'google-sub-123',
+                    'email': user.email,
+                    'email_verified': True,
+                    'given_name': 'OAuth',
+                    'family_name': 'User',
+                },
+                'google',
+            )
+
+            assert found.id == user.id
+            assert User.query.get(user.id).google_id == 'google-sub-123'
+
+    def test_unverified_email_match_does_not_link_existing_user(self, app):
+        with app.app_context():
+            user = _make_user()
+
+            found = find_or_create_user(
+                {
+                    'id': 'google-sub-attacker',
+                    'email': user.email,
+                    'email_verified': False,
+                    'given_name': 'OAuth',
+                    'family_name': 'User',
+                },
+                'google',
+            )
+
+            assert found is None
+            assert User.query.get(user.id).google_id is None
+
+    def test_missing_email_verified_claim_does_not_link_existing_user(self, app):
+        with app.app_context():
+            user = _make_user()
+
+            found = find_or_create_user(
+                {
+                    'id': 'authentik-sub-attacker',
+                    'email': user.email,
+                    'given_name': 'OAuth',
+                    'family_name': 'User',
+                },
+                'authentik',
+            )
+
+            assert found is None
+            assert User.query.get(user.id).authentik_id is None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -58,6 +58,24 @@ class TestUserModel:
         assert fetched.active is True
         assert fetched.is_admin is False
 
+    @pytest.mark.parametrize('provider_id_field', ['google_id', 'authentik_id', 'dropbox_id'])
+    def test_oauth_provider_ids_are_unique(self, app, provider_id_field):
+        """OAuth provider IDs are login lookup keys and must be unique."""
+        from sqlalchemy.exc import IntegrityError
+
+        user_one = User(username=f'{provider_id_field}1', email=f'{provider_id_field}1@example.com')
+        user_two = User(username=f'{provider_id_field}2', email=f'{provider_id_field}2@example.com')
+        setattr(user_one, provider_id_field, 'provider-user-123')
+        setattr(user_two, provider_id_field, 'provider-user-123')
+
+        db.session.add(user_one)
+        db.session.commit()
+        db.session.add(user_two)
+
+        with pytest.raises(IntegrityError):
+            db.session.commit()
+        db.session.rollback()
+
     def test_password_hashing(self, app):
         """Test that passwords are hashed on assignment."""
         user = User(username='hashtest', email='hash@example.com')


### PR DESCRIPTION
## Summary
- only auto-link OAuth identities to existing accounts when the provider explicitly marks the email as verified
- persist email_verified claims from Google, Authentik, and Dropbox userinfo responses
- add unique model constraints and a duplicate-aware migration for Google/AuthentiK/Dropbox provider IDs

Closes #91.
Closes #103.

## Local validation
- focused auth/model tests -> 11 passed
- migration smoke with test DB path remapping -> passed
- `pytest -q` -> 395 passed, 2 skipped
- `git diff --check` -> clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OAuth accounts from Google, Authentik, and Dropbox now link more safely, requiring verified email information before matching to an existing account.
  * Provider account IDs are now enforced as unique, reducing duplicate account links.

* **Bug Fixes**
  * Prevents accidental linking of OAuth identities to the wrong user when email verification is missing or unverified.
  * Improved handling for existing provider IDs by avoiding duplicate values in user accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->