### PR TITLE
Harden OAuth identity follow-ups

### DIFF
--- a/migrations/ensure_oauth_provider_unique_indexes.py
+++ b/migrations/ensure_oauth_provider_unique_indexes.py
@@ -13,22 +13,45 @@ PROVIDER_ID_COLUMNS = {
 
 
 def _index_exists(inspector, index_name):
+    """Return whether the target index already exists on the user table."""
     return any(index.get("name") == index_name for index in inspector.get_indexes("user"))
 
 
 def _find_duplicate_values(conn, column_name):
+    """Return non-null provider IDs that would violate the new unique index."""
     return conn.execute(
         text(
             f"""
             SELECT {column_name}, COUNT(*) AS duplicate_count
             FROM user
-            WHERE {column_name} IS NOT NULL AND {column_name} != ''
+            WHERE {column_name} IS NOT NULL
             GROUP BY {column_name}
             HAVING COUNT(*) > 1
             LIMIT 10
             """
         )
     ).fetchall()
+
+
+def _normalize_empty_values(conn, column_name):
+    """Convert legacy blank provider IDs to NULL before adding uniqueness."""
+    query = text(f"UPDATE user SET {column_name} = NULL WHERE {column_name} = ''")
+    return conn.execute(query).rowcount
+
+
+def _create_unique_index(conn, column_name, index_name):
+    """Create a unique provider-ID index using syntax supported by the active DB."""
+    dialect_name = conn.dialect.name.lower()
+    if dialect_name in {"mysql", "mariadb"}:
+        conn.execute(text(f"CREATE UNIQUE INDEX {index_name} ON user ({column_name})"))
+        return
+
+    conn.execute(
+        text(
+            f"CREATE UNIQUE INDEX {index_name} ON user ({column_name}) "
+            f"WHERE {column_name} IS NOT NULL"
+        )
+    )
 
 
 def run_migration():
@@ -44,12 +67,19 @@ def run_migration():
         with db.engine.connect() as conn:
             for column_name, index_name in PROVIDER_ID_COLUMNS.items():
                 if column_name not in existing_columns:
-                    logger.warning("Column %s is missing; skipping unique index %s", column_name, index_name)
+                    logger.warning(
+                        "Column %s is missing; skipping unique index %s",
+                        column_name,
+                        index_name,
+                    )
                     continue
 
                 if _index_exists(inspector, index_name):
                     logger.info("Unique index %s already exists", index_name)
                     continue
+
+                if _normalize_empty_values(conn, column_name):
+                    changes_made = True
 
                 duplicates = _find_duplicate_values(conn, column_name)
                 if duplicates:
@@ -62,12 +92,7 @@ def run_migration():
                     return False
 
                 logger.info("Adding unique index %s on user.%s", index_name, column_name)
-                conn.execute(
-                    text(
-                        f"CREATE UNIQUE INDEX {index_name} ON user ({column_name}) "
-                        f"WHERE {column_name} IS NOT NULL AND {column_name} != ''"
-                    )
-                )
+                _create_unique_index(conn, column_name, index_name)
                 conn.commit()
                 changes_made = True
 

--- a/musicround/helpers/auth_helpers.py
+++ b/musicround/helpers/auth_helpers.py
@@ -180,8 +180,8 @@ def get_dropbox_user_info(token):
         
         # Create a standardized user info dictionary
         user_info = {
-            'id': profile.get('account_id', ''),
-            'email': profile.get('email', ''),
+            'id': _none_if_blank(profile.get('account_id')),
+            'email': _none_if_blank(profile.get('email')),
             'name': profile.get('name', {}).get('display_name', ''),
             'given_name': profile.get('name', {}).get('given_name', ''),
             'family_name': profile.get('name', {}).get('surname', ''),
@@ -194,12 +194,27 @@ def get_dropbox_user_info(token):
         current_app.logger.error(f"Error getting Dropbox user info: {str(e)}")
         return None
 
+
+def _none_if_blank(value):
+    """Normalize missing provider identifiers so they never match nullable DB rows."""
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
 def _oauth_email_is_verified(user_info):
     """Return True only when the provider explicitly verified the email claim."""
     verified = user_info.get('email_verified')
     if isinstance(verified, str):
         return verified.strip().lower() in {'1', 'true', 'yes'}
     return verified is True
+
+
+def _oauth_email_can_link(user_info, auth_provider):
+    """Return whether an OAuth email can safely attach to an existing account."""
+    return auth_provider == 'spotify' or _oauth_email_is_verified(user_info)
+
 
 def get_spotify_user_info(token):
     """
@@ -245,41 +260,48 @@ def find_or_create_user(user_info, auth_provider):
     from musicround.models import db, User
     if not user_info:
         return None
+
+    provider_id = _none_if_blank(user_info.get('id'))
+    if not provider_id:
+        current_app.logger.warning("Refusing %s OAuth login without provider ID", auth_provider)
+        return None
+
+    email = _none_if_blank(user_info.get('email'))
         
     # First try to find user by provider-specific ID
     if auth_provider == 'google':
-        user = User.query.filter_by(google_id=user_info['id']).first()
+        user = User.query.filter_by(google_id=provider_id).first()
     elif auth_provider == 'authentik':
-        user = User.query.filter_by(authentik_id=user_info['id']).first()
+        user = User.query.filter_by(authentik_id=provider_id).first()
     elif auth_provider == 'dropbox':
-        user = User.query.filter_by(dropbox_id=user_info['id']).first()
+        user = User.query.filter_by(dropbox_id=provider_id).first()
     elif auth_provider == 'spotify':
-        user = User.query.filter_by(spotify_id=user_info['id']).first()
+        user = User.query.filter_by(spotify_id=provider_id).first()
     else:
         return None
         
     # If not found by provider ID, try verified email.
-    if user is None and user_info.get('email'):
-        user = User.query.filter_by(email=user_info['email']).first()
+    if user is None and email:
+        user = User.query.filter_by(email=email).first()
         
         if user:
-            if not _oauth_email_is_verified(user_info):
+            if not _oauth_email_can_link(user_info, auth_provider):
                 current_app.logger.warning(
                     "Refusing to link %s OAuth identity %s to existing user %s because email is not verified",
                     auth_provider,
-                    user_info.get('id'),
+                    provider_id,
                     user.username,
                 )
                 return None
 
             if auth_provider == 'google':
-                user.google_id = user_info['id']
+                user.google_id = provider_id
             elif auth_provider == 'authentik':
-                user.authentik_id = user_info['id']
+                user.authentik_id = provider_id
             elif auth_provider == 'dropbox':
-                user.dropbox_id = user_info['id']
+                user.dropbox_id = provider_id
             elif auth_provider == 'spotify':
-                user.spotify_id = user_info['id']
+                user.spotify_id = provider_id
                 
             db.session.commit()
             current_app.logger.info(f"Updated existing user {user.username} with {auth_provider} ID")
@@ -295,8 +317,7 @@ def find_or_create_user(user_info, auth_provider):
             return None
             
         # Generate a username from email
-        email = user_info.get('email', '')
-        base_username = email.split('@')[0] if email else f"{auth_provider}_{user_info['id']}"
+        base_username = email.split('@')[0] if email else f"{auth_provider}_{provider_id}"
         
         # Ensure username is unique
         username = base_username
@@ -308,7 +329,7 @@ def find_or_create_user(user_info, auth_provider):
         # Create new user
         user = User(
             username=username,
-            email=user_info.get('email', ''),
+            email=email or '',
             first_name=user_info.get('given_name', ''),
             last_name=user_info.get('family_name', ''),
             auth_provider=auth_provider,
@@ -318,13 +339,13 @@ def find_or_create_user(user_info, auth_provider):
         
         # Set provider-specific fields
         if auth_provider == 'google':
-            user.google_id = user_info['id']
+            user.google_id = provider_id
         elif auth_provider == 'authentik':
-            user.authentik_id = user_info['id']
+            user.authentik_id = provider_id
         elif auth_provider == 'dropbox':
-            user.dropbox_id = user_info['id']
+            user.dropbox_id = provider_id
         elif auth_provider == 'spotify':
-            user.spotify_id = user_info['id']
+            user.spotify_id = provider_id
             
         db.session.add(user)
         try:

--- a/musicround/models.py
+++ b/musicround/models.py
@@ -63,17 +63,17 @@ class User(db.Model, UserMixin):
     spotify_token_expiry = db.Column(db.DateTime)
     
     # OAuth provider info - Google
-    google_id = db.Column(db.String(100), index=True, unique=True, nullable=True)      # Google user ID
+    google_id = db.Column(db.String(100), unique=True, nullable=True)      # Google user ID
     google_token = db.Column(db.Text)          # Store Google access token
     google_refresh_token = db.Column(db.Text)   # Store Google refresh token
     
     # OAuth provider info - Authentik
-    authentik_id = db.Column(db.String(100), index=True, unique=True, nullable=True)    # Authentik user ID
+    authentik_id = db.Column(db.String(100), unique=True, nullable=True)    # Authentik user ID
     authentik_token = db.Column(db.Text)        # Store Authentik access token
     authentik_refresh_token = db.Column(db.Text) # Store Authentik refresh token
     
     # OAuth provider info - Dropbox
-    dropbox_id = db.Column(db.String(100), index=True, unique=True, nullable=True)      # Dropbox user ID
+    dropbox_id = db.Column(db.String(100), unique=True, nullable=True)      # Dropbox user ID
     dropbox_token = db.Column(db.Text)          # Store Dropbox access token
     dropbox_refresh_token = db.Column(db.Text)  # Store Dropbox refresh token
     dropbox_token_expiry = db.Column(db.DateTime) # Dropbox token expiration

--- a/tests/test_auth_helpers.py
+++ b/tests/test_auth_helpers.py
@@ -106,3 +106,38 @@ class TestFindOrCreateUserEmailLinking:
 
             assert found is None
             assert User.query.get(user.id).authentik_id is None
+
+    def test_missing_provider_id_does_not_match_nullable_oauth_id(self, app):
+        with app.app_context():
+            user = _make_user()
+
+            found = find_or_create_user(
+                {
+                    'id': '',
+                    'email': user.email,
+                    'email_verified': True,
+                    'given_name': 'OAuth',
+                    'family_name': 'User',
+                },
+                'google',
+            )
+
+            assert found is None
+            assert User.query.get(user.id).google_id is None
+
+    def test_spotify_email_match_links_without_verified_claim(self, app):
+        with app.app_context():
+            user = _make_user()
+
+            found = find_or_create_user(
+                {
+                    'id': 'spotify-user-123',
+                    'email': user.email,
+                    'given_name': 'Spotify',
+                    'family_name': 'User',
+                },
+                'spotify',
+            )
+
+            assert found.id == user.id
+            assert User.query.get(user.id).spotify_id == 'spotify-user-123'


### PR DESCRIPTION
## Summary
- reject OAuth logins that do not include a non-empty provider identifier before any nullable provider-ID lookup
- allow Spotify email-based account linking despite the missing `email_verified` claim while keeping verified-email checks for other providers
- normalize blank legacy OAuth provider IDs to NULL before creating unique indexes and avoid MySQL-only-incompatible partial-index SQL
- remove redundant `index=True` declarations from unique OAuth provider ID columns

## Validation
- `git diff --check`
- `/tmp/QuizzicalBeats-pr80/.venv/bin/python -m py_compile musicround/helpers/auth_helpers.py migrations/ensure_oauth_provider_unique_indexes.py musicround/models.py`
- `SECRET_KEY=test AUTOMATION_TOKEN=test /tmp/QuizzicalBeats-pr80/.venv/bin/python -m pytest tests/test_auth_helpers.py tests/test_models.py -q` (63 passed)

Follow-up for post-merge review comments on #111.
