### PR TITLE
Require login for mutating song APIs

### DIFF
--- a/musicround/routes/api.py
+++ b/musicround/routes/api.py
@@ -18,6 +18,9 @@ api_bp = Blueprint('api', __name__, url_prefix='/api')
 @api_bp.route('/songs/<int:song_id>', methods=['GET', 'PUT', 'DELETE'])
 def song_detail(song_id):
     """API endpoint for getting, updating, and deleting song details"""
+    if request.method in {'PUT', 'DELETE'} and not current_user.is_authenticated:
+        return current_app.login_manager.unauthorized()
+
     song = Song.query.get_or_404(song_id)
     
     if request.method == 'GET':
@@ -154,6 +157,7 @@ def song_detail(song_id):
         })
 
 @api_bp.route('/songs/<int:song_id>/refresh-metadata', methods=['POST'])
+@login_required
 def refresh_song_metadata(song_id):
     """API endpoint for refreshing song metadata"""
     song = Song.query.get_or_404(song_id)
@@ -302,6 +306,7 @@ def list_tags():
     })
 
 @api_bp.route('/tags', methods=['POST'])
+@login_required
 def create_tag():
     """Create a new tag"""
     data = request.get_json()
@@ -340,6 +345,7 @@ def get_song_tags(song_id):
     })
 
 @api_bp.route('/songs/<int:song_id>/tags', methods=['POST'])
+@login_required
 def add_tag_to_song(song_id):
     """Add a tag to a song"""
     song = Song.query.get_or_404(song_id)
@@ -383,6 +389,7 @@ def add_tag_to_song(song_id):
     })
 
 @api_bp.route('/songs/<int:song_id>/tags/<int:tag_id>', methods=['DELETE'])
+@login_required
 def remove_tag_from_song(song_id, tag_id):
     """Remove a tag from a song"""
     song = Song.query.get_or_404(song_id)

--- a/tests/test_additional_branches.py
+++ b/tests/test_additional_branches.py
@@ -103,6 +103,8 @@ class TestSongApiExtendedBranches:
 
     def test_update_song_isrc(self, app, client):
         """Test PUT updates ISRC field."""
+        _create_user(app, 'song_branch_isrc', 'song_branch_isrc@example.com')
+        _login(app, client, 'song_branch_isrc')
         song_id = self._make_song(app)
         response = client.put(
             f'/api/songs/{song_id}',
@@ -113,6 +115,8 @@ class TestSongApiExtendedBranches:
 
     def test_update_song_invalid_popularity(self, app, client):
         """Test PUT with invalid popularity value is handled gracefully."""
+        _create_user(app, 'song_branch_popularity', 'song_branch_popularity@example.com')
+        _login(app, client, 'song_branch_popularity')
         song_id = self._make_song(app)
         response = client.put(
             f'/api/songs/{song_id}',
@@ -123,6 +127,8 @@ class TestSongApiExtendedBranches:
 
     def test_update_song_spotify_id(self, app, client):
         """Test PUT updates spotify_id."""
+        _create_user(app, 'song_branch_spotify', 'song_branch_spotify@example.com')
+        _login(app, client, 'song_branch_spotify')
         song_id = self._make_song(app)
         response = client.put(
             f'/api/songs/{song_id}',
@@ -133,6 +139,8 @@ class TestSongApiExtendedBranches:
 
     def test_update_song_deezer_id(self, app, client):
         """Test PUT updates deezer_id."""
+        _create_user(app, 'song_branch_deezer', 'song_branch_deezer@example.com')
+        _login(app, client, 'song_branch_deezer')
         song_id = self._make_song(app)
         response = client.put(
             f'/api/songs/{song_id}',
@@ -143,6 +151,8 @@ class TestSongApiExtendedBranches:
 
     def test_update_song_preview_url(self, app, client):
         """Test PUT updates preview_url."""
+        _create_user(app, 'song_branch_preview', 'song_branch_preview@example.com')
+        _login(app, client, 'song_branch_preview')
         song_id = self._make_song(app)
         response = client.put(
             f'/api/songs/{song_id}',
@@ -153,6 +163,8 @@ class TestSongApiExtendedBranches:
 
     def test_update_song_cover_url(self, app, client):
         """Test PUT updates cover_url."""
+        _create_user(app, 'song_branch_cover', 'song_branch_cover@example.com')
+        _login(app, client, 'song_branch_cover')
         song_id = self._make_song(app)
         response = client.put(
             f'/api/songs/{song_id}',
@@ -163,6 +175,8 @@ class TestSongApiExtendedBranches:
 
     def test_add_tag_no_data(self, app, client):
         """Test POST /api/songs/<id>/tags with no data returns 400."""
+        _create_user(app, 'song_branch_tag_empty', 'song_branch_tag_empty@example.com')
+        _login(app, client, 'song_branch_tag_empty')
         song_id = self._make_song(app, title='No Tag Data Song')
         response = client.post(
             f'/api/songs/{song_id}/tags',
@@ -173,6 +187,8 @@ class TestSongApiExtendedBranches:
 
     def test_add_tag_already_on_song(self, app, client):
         """Test POST /api/songs/<id>/tags when tag already exists on song."""
+        _create_user(app, 'song_branch_tag_existing', 'song_branch_tag_existing@example.com')
+        _login(app, client, 'song_branch_tag_existing')
         song_id = self._make_song(app, title='Already Tagged Song')
         with app.app_context():
             tag = Tag(name='AlreadyAddedTag')
@@ -195,6 +211,8 @@ class TestSongApiExtendedBranches:
 
     def test_remove_tag_not_on_song(self, app, client):
         """Test DELETE /api/songs/<id>/tags/<tag_id> when tag not on song."""
+        _create_user(app, 'song_branch_tag_remove', 'song_branch_tag_remove@example.com')
+        _login(app, client, 'song_branch_tag_remove')
         song_id = self._make_song(app, title='Untagged Song')
         with app.app_context():
             tag = Tag(name='NotOnSongTag')

--- a/tests/test_api_extended.py
+++ b/tests/test_api_extended.py
@@ -49,6 +49,15 @@ class TestTagsApi:
         assert 'tag' in data
         assert data['tag']['name'] == 'NewTag'
 
+    def test_create_tag_requires_login(self, app, client):
+        """Test POST /api/tags requires authentication."""
+        response = client.post(
+            '/api/tags',
+            data=json.dumps({'name': 'AnonymousTag'}),
+            content_type='application/json',
+        )
+        assert response.status_code in (302, 401, 403)
+
     def test_create_tag_duplicate(self, app, client):
         """Test POST /api/tags returns existing tag if duplicate name."""
         _create_user_and_login(app, client, 'tagdup', 'tagdup@example.com')
@@ -116,6 +125,16 @@ class TestSongTagsApi:
         )
         assert response.status_code in (200, 201)
 
+    def test_add_tag_to_song_requires_login(self, app, client):
+        """Test POST /api/songs/<id>/tags requires authentication."""
+        song_id = _create_song(app, 'AnonymousTagSong', 'Artist')
+        response = client.post(
+            f'/api/songs/{song_id}/tags',
+            data=json.dumps({'tag_name': 'ShouldNotApply'}),
+            content_type='application/json',
+        )
+        assert response.status_code in (302, 401, 403)
+
     def test_add_tag_by_name(self, app, client):
         """Test POST /api/songs/<id>/tags creates and adds tag by name."""
         _create_user_and_login(app, client, 'tagbynameuser', 'tagbyname@example.com')
@@ -156,6 +175,27 @@ class TestSongTagsApi:
 
         response = client.delete(f'/api/songs/{song_id}/tags/{tag_id}')
         assert response.status_code in (200, 204)
+
+    def test_remove_tag_from_song_requires_login(self, app, client):
+        """Test DELETE /api/songs/<id>/tags/<tag_id> requires authentication."""
+        with app.app_context():
+            tag = Tag(name='AnonymousRemoveTag')
+            song = Song(title='AnonymousRemoveSong', artist='A', genre='Pop')
+            db.session.add_all([tag, song])
+            db.session.commit()
+            song.tags.append(tag)
+            db.session.commit()
+            song_id = song.id
+            tag_id = tag.id
+
+        response = client.delete(f'/api/songs/{song_id}/tags/{tag_id}')
+        assert response.status_code in (302, 401, 403)
+
+    def test_refresh_metadata_requires_login(self, app, client):
+        """Test POST /api/songs/<id>/refresh-metadata requires authentication."""
+        song_id = _create_song(app, 'AnonymousRefreshSong', 'Artist')
+        response = client.post(f'/api/songs/{song_id}/refresh-metadata')
+        assert response.status_code in (302, 401, 403)
 
 
 class TestSongSearchApi:

--- a/tests/test_song_api.py
+++ b/tests/test_song_api.py
@@ -72,6 +72,7 @@ class TestSongDetailPut:
 
     def test_update_song_title(self, app, client):
         """Test PUT updates song title."""
+        _login(app, client)
         song_id = _create_song(app, title='Original Title')
         response = client.put(
             f'/api/songs/{song_id}',
@@ -84,6 +85,7 @@ class TestSongDetailPut:
 
     def test_update_song_artist(self, app, client):
         """Test PUT updates song artist."""
+        _login(app, client)
         song_id = _create_song(app, artist='Original Artist')
         response = client.put(
             f'/api/songs/{song_id}',
@@ -96,6 +98,7 @@ class TestSongDetailPut:
 
     def test_update_song_genre(self, app, client):
         """Test PUT updates song genre."""
+        _login(app, client)
         song_id = _create_song(app, genre='Rock')
         response = client.put(
             f'/api/songs/{song_id}',
@@ -108,6 +111,7 @@ class TestSongDetailPut:
 
     def test_update_song_year(self, app, client):
         """Test PUT updates song year."""
+        _login(app, client)
         song_id = _create_song(app, year=2000)
         response = client.put(
             f'/api/songs/{song_id}',
@@ -120,6 +124,7 @@ class TestSongDetailPut:
 
     def test_update_song_popularity(self, app, client):
         """Test PUT updates song popularity."""
+        _login(app, client)
         song_id = _create_song(app)
         response = client.put(
             f'/api/songs/{song_id}',
@@ -132,6 +137,7 @@ class TestSongDetailPut:
 
     def test_update_song_not_found(self, app, client):
         """Test PUT on non-existent song returns 404."""
+        _login(app, client)
         response = client.put(
             '/api/songs/99999',
             data=json.dumps({'title': 'Test'}),
@@ -141,6 +147,7 @@ class TestSongDetailPut:
 
     def test_update_song_persists_to_db(self, app, client):
         """Test PUT changes are persisted to the database."""
+        _login(app, client)
         song_id = _create_song(app, title='Before Update', artist='Orig')
         client.put(
             f'/api/songs/{song_id}',
@@ -153,6 +160,7 @@ class TestSongDetailPut:
 
     def test_update_song_partial_update(self, app, client):
         """Test PUT with partial data only updates specified fields."""
+        _login(app, client)
         song_id = _create_song(app, title='Keep Title', artist='Keep Artist', genre='Keep Genre')
         client.put(
             f'/api/songs/{song_id}',
@@ -171,11 +179,13 @@ class TestSongDetailDelete:
 
     def test_delete_song_not_found(self, app, client):
         """Test DELETE on non-existent song returns 404."""
+        _login(app, client)
         response = client.delete('/api/songs/99999')
         assert response.status_code == 404
 
     def test_delete_song_success(self, app, client):
         """Test DELETE successfully removes a song."""
+        _login(app, client)
         song_id = _create_song(app, title='Delete Me Song')
         response = client.delete(f'/api/songs/{song_id}')
         assert response.status_code == 200
@@ -189,6 +199,7 @@ class TestSongDetailDelete:
 
     def test_delete_song_in_use_fails(self, app, client):
         """Test DELETE on a song used in a round returns 400."""
+        _login(app, client)
         song_id = _create_song(app, title='In-Use Song')
         with app.app_context():
             round_ = Round(
@@ -202,3 +213,19 @@ class TestSongDetailDelete:
         assert response.status_code == 400
         data = response.get_json()
         assert 'error' in data
+
+    def test_update_song_requires_login(self, app, client):
+        """Test PUT requires authentication."""
+        song_id = _create_song(app, title='Anonymous Update Target')
+        response = client.put(
+            f'/api/songs/{song_id}',
+            data=json.dumps({'title': 'Should Not Apply'}),
+            content_type='application/json',
+        )
+        assert response.status_code in (302, 401, 403)
+
+    def test_delete_song_requires_login(self, app, client):
+        """Test DELETE requires authentication."""
+        song_id = _create_song(app, title='Anonymous Delete Target')
+        response = client.delete(f'/api/songs/{song_id}')
+        assert response.status_code in (302, 401, 403)


### PR DESCRIPTION
## Summary
- require authentication for PUT/DELETE song detail mutations
- require authentication for metadata refresh and tag mutation routes
- keep read-only song/tag endpoints public
- update authenticated success tests and add unauthenticated rejection coverage

Closes #81.

## Local validation
- focused API auth tests -> 44 passed
- `pytest -q` -> 408 passed, 2 skipped
- `git diff --check` -> clean