### PR TITLE
Harden error page debug output

### DIFF
--- a/musicround/errors.py
+++ b/musicround/errors.py
@@ -1,5 +1,5 @@
 import traceback
-from flask import render_template, session, request, current_app, jsonify
+from flask import render_template, request, current_app, jsonify
 from flask_wtf.csrf import CSRFError
 from flask_login import current_user
 import json
@@ -7,6 +7,31 @@ import openai
 
 # Import the csrf instance from the package
 from musicround import csrf
+
+SENSITIVE_FORM_FIELD_PARTS = (
+    'password',
+    'passwd',
+    'token',
+    'secret',
+    'api_key',
+    'apikey',
+    'access_key',
+    'private_key',
+)
+REDACTED_VALUE = '[redacted]'
+
+
+def redact_sensitive_form_data(form_data):
+    """Return form data with credentials and secret-like fields redacted."""
+    redacted = {}
+    for key, value in form_data.items():
+        normalized_key = key.lower()
+        if any(part in normalized_key for part in SENSITIVE_FORM_FIELD_PARTS):
+            redacted[key] = REDACTED_VALUE
+        else:
+            redacted[key] = value
+    return redacted
+
 
 def generate_friendly_error_message(error_info, app=None):
     """
@@ -169,15 +194,18 @@ def handle_error(error, code, default_message):
     """
     Common error handler that renders the error.html template with appropriate context
     """
-    # Get the error message
-    message = getattr(error, 'description', str(error)) or default_message
+    show_admin_debug = (
+        current_user.is_authenticated
+        and getattr(current_user, 'is_admin', False)
+    )
+    raw_message = getattr(error, 'description', str(error)) or default_message
+    message = raw_message if (show_admin_debug or code < 500) else default_message
     
-    # Prepare debug info for logged-in users
+    # Prepare debug info for admins only.
     debug_info = None
     tb = None
     
-    # Use Flask-Login instead of checking for access_token in session
-    if current_user.is_authenticated:
+    if show_admin_debug:
         # Include request details in debug info
         debug_info = {
             'error_type': error.__class__.__name__,
@@ -188,8 +216,9 @@ def handle_error(error, code, default_message):
         }
         
         # Include POST data if it's form data (not for file uploads)
-        if request.form and 'multipart/form-data' not in request.content_type:
-            debug_info['request_form'] = request.form.to_dict()
+        request_content_type = request.content_type or ''
+        if request.form and 'multipart/form-data' not in request_content_type:
+            debug_info['request_form'] = redact_sensitive_form_data(request.form.to_dict())
             
         # Include JSON data if applicable
         if request.is_json:
@@ -205,9 +234,14 @@ def handle_error(error, code, default_message):
         debug_info_str = json.dumps(debug_info, indent=2)
     
     # We'll pass the error info to the template so JavaScript can request a friendly message
+    error_type = (
+        error.__class__.__name__
+        if (show_admin_debug or code < 500)
+        else default_message
+    )
     error_info_for_js = json.dumps({
-        'error_type': error.__class__.__name__,
-        'error_message': str(error),
+        'error_type': error_type,
+        'error_message': message,
         'code': code
     })
     

--- a/musicround/templates/error.html
+++ b/musicround/templates/error.html
@@ -62,7 +62,7 @@
                 </details>
             </div>
             
-            {% if 'access_token' in session and (debug_info or traceback) %}
+            {% if debug_info or traceback %}
             <!-- Debug info section -->
             <div class="mt-6 bg-gray-50 border border-gray-200 rounded-lg p-4 mb-6">
                 <!-- Copy all button at the top -->
@@ -223,4 +223,3 @@ TRACEBACK:
     });
 </script>
 {% endblock %}
-

--- a/tests/test_error_security.py
+++ b/tests/test_error_security.py
@@ -1,0 +1,80 @@
+from musicround import db
+from musicround.models import User
+
+
+def _create_user(app, username, email, password='ErrorPass123!', is_admin=False):
+    with app.app_context():
+        user = User(username=username, email=email, is_admin=is_admin)
+        user.password = password
+        db.session.add(user)
+        db.session.commit()
+
+
+def _login(client, username, password='ErrorPass123!'):
+    return client.post(
+        '/users/login',
+        data={'username': username, 'password': password},
+        follow_redirects=True,
+    )
+
+
+def _register_crashing_route(app):
+    if 'error_security_crash' in app.view_functions:
+        return
+
+    @app.route('/test/error-security-crash', methods=['POST'])
+    def error_security_crash():
+        raise RuntimeError('synthetic boom for error security tests')
+
+
+def test_error_page_hides_debug_payload_for_non_admin_user(app, client):
+    app.config['PROPAGATE_EXCEPTIONS'] = False
+    _register_crashing_route(app)
+    _create_user(app, 'error_non_admin', 'error_non_admin@example.com')
+    _login(client, 'error_non_admin')
+
+    response = client.post(
+        '/test/error-security-crash',
+        data={
+            'password': 'plain-password-value',
+            'remember_token': 'plain-token-value',
+            'comment': 'visible-form-comment',
+        },
+    )
+
+    body = response.get_data(as_text=True)
+    assert response.status_code == 500
+    assert 'synthetic boom for error security tests' not in body
+    assert 'RuntimeError' not in body
+    assert 'Traceback' not in body
+    assert 'request_form' not in body
+    assert 'plain-password-value' not in body
+    assert 'plain-token-value' not in body
+    assert 'visible-form-comment' not in body
+
+
+def test_error_page_redacts_sensitive_form_fields_for_admins(app, client):
+    app.config['PROPAGATE_EXCEPTIONS'] = False
+    _register_crashing_route(app)
+    _create_user(app, 'error_admin', 'error_admin@example.com', is_admin=True)
+    _login(client, 'error_admin')
+
+    response = client.post(
+        '/test/error-security-crash',
+        data={
+            'password': 'plain-password-value',
+            'api_token': 'plain-token-value',
+            'client_secret': 'plain-secret-value',
+            'comment': 'visible-form-comment',
+        },
+    )
+
+    body = response.get_data(as_text=True)
+    assert response.status_code == 500
+    assert 'RuntimeError' in body
+    assert 'request_form' in body
+    assert 'visible-form-comment' in body
+    assert 'plain-password-value' not in body
+    assert 'plain-token-value' not in body
+    assert 'plain-secret-value' not in body
+    assert '[redacted]' in body


### PR DESCRIPTION
## Summary
- restrict rich error debug payloads to authenticated admins only
- redact secret-like form fields before they can appear in admin debug output
- keep non-admin 500 pages generic, including the hidden friendly-error payload
- add regression coverage for non-admin leak prevention and admin redaction

Closes #96.

## Validation
- `SECRET_KEY=test-secret-key-for-testing-only AUTOMATION_TOKEN=test-automation-token-for-testing .venv/bin/pytest tests/test_error_security.py tests/test_routes.py::TestErrorHandling -q`
- `.venv/bin/flake8 musicround/ --count --select=E9,F63,F7,F82 --show-source --statistics`
- `SECRET_KEY=test-secret-key-for-testing-only AUTOMATION_TOKEN=test-automation-token-for-testing .venv/bin/pytest tests/ -q` -> 413 passed, 2 skipped
