### PR TITLE
Assert error-page security login succeeds

### DIFF
--- a/tests/test_error_security.py
+++ b/tests/test_error_security.py
@@ -11,11 +11,14 @@ def _create_user(app, username, email, password='ErrorPass123!', is_admin=False)
 
 
 def _login(client, username, password='ErrorPass123!'):
-    return client.post(
+    response = client.post(
         '/users/login',
         data={'username': username, 'password': password},
         follow_redirects=True,
     )
+    assert response.status_code == 200
+    assert 'You have been logged in!' in response.get_data(as_text=True)
+    return response
 
 
 def _register_crashing_route(app):


### PR DESCRIPTION
## Summary
- assert the error-page security test login helper reaches a successful login
- keep the non-admin/admin debug payload regression tests from passing against an anonymous session

## Validation
- git diff --check
- .venv/bin/python -m py_compile musicround/errors.py tests/test_error_security.py
- SECRET_KEY=test AUTOMATION_TOKEN=test .venv/bin/python -m pytest tests/test_error_security.py -q