### PR TITLE
Simplify error-page login helper

### DIFF
--- a/tests/test_error_security.py
+++ b/tests/test_error_security.py
@@ -10,14 +10,13 @@ def _create_user(app, username, email, password='ErrorPass123!', is_admin=False)
         db.session.commit()
 
 
-def _login(app, client, username, password='ErrorPass123!'):
+def _login(client, username, password='ErrorPass123!'):
     response = client.post(
         '/users/login',
         data={'username': username, 'password': password},
     )
     assert response.status_code == 302
-    with app.app_context():
-        expected_user_id = str(User.query.filter_by(username=username).one().id)
+    expected_user_id = str(User.query.filter_by(username=username).one().id)
     with client.session_transaction() as session:
         assert session['_user_id'] == expected_user_id
     return response
@@ -36,7 +35,7 @@ def test_error_page_hides_debug_payload_for_non_admin_user(app, client):
     app.config['PROPAGATE_EXCEPTIONS'] = False
     _register_crashing_route(app)
     _create_user(app, 'error_non_admin', 'error_non_admin@example.com')
-    _login(app, client, 'error_non_admin')
+    _login(client, 'error_non_admin')
 
     response = client.post(
         '/test/error-security-crash',
@@ -62,7 +61,7 @@ def test_error_page_redacts_sensitive_form_fields_for_admins(app, client):
     app.config['PROPAGATE_EXCEPTIONS'] = False
     _register_crashing_route(app)
     _create_user(app, 'error_admin', 'error_admin@example.com', is_admin=True)
-    _login(app, client, 'error_admin')
+    _login(client, 'error_admin')
 
     response = client.post(
         '/test/error-security-crash',


### PR DESCRIPTION
## Summary
- remove the redundant app parameter from the error-page security login helper
- rely on the existing app fixture context while still asserting the Flask-Login session user id

## Validation
- git diff --check
- .venv/bin/python -m py_compile tests/test_error_security.py
- SECRET_KEY=test AUTOMATION_TOKEN=test .venv/bin/python -m pytest tests/test_error_security.py -q