### PR TITLE
Harden backup restore validation

### DIFF
--- a/musicround/helpers/backup_helper.py
+++ b/musicround/helpers/backup_helper.py
@@ -14,6 +14,53 @@ from flask import current_app
 # Set up logging
 logger = logging.getLogger(__name__)
 
+BACKUP_DATABASE_FILENAMES = ('song_data.db', 'database.db')
+
+
+def _find_database_member(file_list):
+    for filename in BACKUP_DATABASE_FILENAMES:
+        if filename in file_list:
+            return filename
+    return None
+
+
+def _unsafe_zip_member_name(zip_info, target_dir):
+    member_name = zip_info.filename.replace('\\', '/')
+    if member_name.startswith('/') or member_name.startswith('../'):
+        return zip_info.filename
+
+    target_root = os.path.abspath(target_dir)
+    destination = os.path.abspath(os.path.join(target_dir, member_name))
+    if os.path.commonpath([target_root, destination]) != target_root:
+        return zip_info.filename
+
+    return None
+
+
+def _validate_zip_members(zipf, target_dir):
+    for zip_info in zipf.infolist():
+        unsafe_name = _unsafe_zip_member_name(zip_info, target_dir)
+        if unsafe_name:
+            return unsafe_name
+    return None
+
+
+def _validate_sqlite_database(db_path):
+    try:
+        connection = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        try:
+            result = connection.execute("PRAGMA integrity_check").fetchone()
+        finally:
+            connection.close()
+    except sqlite3.Error as exc:
+        return False, str(exc)
+
+    if not result or result[0] != "ok":
+        return False, result[0] if result else "No integrity result returned"
+
+    return True, None
+
+
 def create_backup(backup_name=None, include_mp3s=True, include_config=True):
     """
     Create a full system backup including database, MP3s, and configuration.
@@ -263,6 +310,13 @@ def restore_backup(backup_filename):
         with tempfile.TemporaryDirectory() as temp_dir:
             # Extract the backup ZIP
             with zipfile.ZipFile(backup_path, 'r') as zipf:
+                unsafe_member = _validate_zip_members(zipf, temp_dir)
+                if unsafe_member:
+                    logger.error(f"Unsafe path found in backup archive: {unsafe_member}")
+                    return {
+                        "status": "error",
+                        "message": f"Backup archive contains unsafe path: {unsafe_member}"
+                    }
                 zipf.extractall(temp_dir)
             
             # Get backup metadata
@@ -277,10 +331,19 @@ def restore_backup(backup_filename):
                 }
             
             # Restore database
-            db_backup_path = os.path.join(temp_dir, 'song_data.db')
+            db_member_name = _find_database_member(os.listdir(temp_dir))
+            db_backup_path = os.path.join(temp_dir, db_member_name) if db_member_name else None
             db_path = current_app.config['SQLALCHEMY_DATABASE_URI'].replace('sqlite:///', '')
             
-            if os.path.exists(db_backup_path):
+            if db_backup_path and os.path.exists(db_backup_path):
+                is_valid_db, validation_error = _validate_sqlite_database(db_backup_path)
+                if not is_valid_db:
+                    logger.error(f"Database file in backup failed validation: {validation_error}")
+                    return {
+                        "status": "error",
+                        "message": "Database file in backup failed validation"
+                    }
+
                 # Create a backup of the current database before overwriting
                 timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
                 db_current_backup = f"{db_path}.{timestamp}.bak"
@@ -418,7 +481,7 @@ def verify_backup(backup_filename):
                 }
             
             # Check for essential files
-            if 'song_data.db' not in zipf.namelist():
+            if not _find_database_member(zipf.namelist()):
                 return {
                     "status": "error",
                     "message": "Backup file does not contain a database",
@@ -765,7 +828,7 @@ def upload_backup(file):
         with zipfile.ZipFile(save_path, 'r') as zip_ref:
             file_list = zip_ref.namelist()
             # Check for essential files in the backup
-            if 'database.db' not in file_list and 'song_data.db' not in file_list:
+            if not _find_database_member(file_list):
                 # Clean up invalid backup
                 if os.path.exists(save_path):
                     os.remove(save_path)

--- a/tests/test_backup_helper.py
+++ b/tests/test_backup_helper.py
@@ -2,10 +2,30 @@
 import pytest
 import json
 import os
+import sqlite3
 import zipfile
 import tempfile
 from unittest.mock import patch, MagicMock
 from musicround.models import SystemSetting
+
+
+def _write_sqlite_db(path, marker='backup'):
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute('CREATE TABLE IF NOT EXISTS smoke (value TEXT)')
+        conn.execute('DELETE FROM smoke')
+        conn.execute('INSERT INTO smoke (value) VALUES (?)', (marker,))
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _read_sqlite_marker(path):
+    conn = sqlite3.connect(path)
+    try:
+        return conn.execute('SELECT value FROM smoke').fetchone()[0]
+    finally:
+        conn.close()
 
 
 class TestListBackups:
@@ -196,16 +216,138 @@ class TestVerifyBackup:
         from musicround.helpers.backup_helper import verify_backup
 
         metadata = {'version': '1.0.0', 'timestamp': '2024-01-01T12:00:00'}
+        db_path = tmp_path / 'song_data.db'
+        _write_sqlite_db(db_path)
         zip_path = tmp_path / 'valid.zip'
         with zipfile.ZipFile(str(zip_path), 'w') as zf:
             zf.writestr('backup_metadata.json', json.dumps(metadata))
-            zf.writestr('song_data.db', b'sqlite3 content')
+            zf.write(db_path, 'song_data.db')
 
         with patch('os.path.exists', side_effect=lambda p: p == str(zip_path) or os.path.exists(p)), \
              patch('os.path.join', return_value=str(zip_path)):
             result = verify_backup('valid.zip')
         assert result['is_valid'] is True
         assert result['status'] == 'success'
+
+    def test_verify_backup_accepts_database_db_filename(self, app, tmp_path):
+        """Test verify_backup accepts legacy database.db archives."""
+        from musicround.helpers.backup_helper import verify_backup
+
+        db_path = tmp_path / 'database.db'
+        _write_sqlite_db(db_path)
+        zip_path = tmp_path / 'legacy_valid.zip'
+        with zipfile.ZipFile(str(zip_path), 'w') as zf:
+            zf.write(db_path, 'database.db')
+
+        with patch('os.path.exists', side_effect=lambda p: p == str(zip_path) or os.path.exists(p)), \
+             patch('os.path.join', return_value=str(zip_path)):
+            result = verify_backup('legacy_valid.zip')
+        assert result['is_valid'] is True
+        assert result['status'] == 'success'
+
+
+class TestRestoreBackup:
+    """Tests for restore_backup function."""
+
+    def test_restore_backup_accepts_database_db_filename(self, app, tmp_path):
+        """Test restore_backup restores a backup whose DB member is database.db."""
+        from musicround.helpers.backup_helper import restore_backup
+
+        backup_dir = tmp_path / 'backups'
+        backup_dir.mkdir()
+        live_db = tmp_path / 'live.db'
+        backup_db = tmp_path / 'database.db'
+        _write_sqlite_db(live_db, marker='live')
+        _write_sqlite_db(backup_db, marker='restored')
+
+        zip_path = backup_dir / 'legacy.zip'
+        with zipfile.ZipFile(str(zip_path), 'w') as zf:
+            zf.write(backup_db, 'database.db')
+            zf.writestr('backup_metadata.json', json.dumps({
+                'includes_mp3s': False,
+                'includes_config': False,
+            }))
+
+        orig_join = os.path.join
+
+        def mock_join(*args):
+            if args == ('/data', 'backups'):
+                return str(backup_dir)
+            return orig_join(*args)
+
+        app.config['SQLALCHEMY_DATABASE_URI'] = f'sqlite:///{live_db}'
+        with patch('os.path.join', side_effect=mock_join):
+            result = restore_backup('legacy.zip')
+
+        assert result['status'] == 'success'
+        assert _read_sqlite_marker(live_db) == 'restored'
+        assert list(tmp_path.glob('live.db.*.bak'))
+
+    def test_restore_backup_rejects_corrupted_database_before_overwrite(self, app, tmp_path):
+        """Test corrupted database archives do not overwrite the live DB."""
+        from musicround.helpers.backup_helper import restore_backup
+
+        backup_dir = tmp_path / 'backups'
+        backup_dir.mkdir()
+        live_db = tmp_path / 'live.db'
+        _write_sqlite_db(live_db, marker='live')
+
+        zip_path = backup_dir / 'bad-db.zip'
+        with zipfile.ZipFile(str(zip_path), 'w') as zf:
+            zf.writestr('song_data.db', b'not a sqlite database')
+            zf.writestr('backup_metadata.json', json.dumps({
+                'includes_mp3s': False,
+                'includes_config': False,
+            }))
+
+        orig_join = os.path.join
+
+        def mock_join(*args):
+            if args == ('/data', 'backups'):
+                return str(backup_dir)
+            return orig_join(*args)
+
+        app.config['SQLALCHEMY_DATABASE_URI'] = f'sqlite:///{live_db}'
+        with patch('os.path.join', side_effect=mock_join):
+            result = restore_backup('bad-db.zip')
+
+        assert result['status'] == 'error'
+        assert 'validation' in result['message'].lower()
+        assert _read_sqlite_marker(live_db) == 'live'
+        assert not list(tmp_path.glob('live.db.*.bak'))
+
+    def test_restore_backup_rejects_zip_slip_member(self, app, tmp_path):
+        """Test restore_backup rejects archive members outside the extraction dir."""
+        from musicround.helpers.backup_helper import restore_backup
+
+        backup_dir = tmp_path / 'backups'
+        backup_dir.mkdir()
+        live_db = tmp_path / 'live.db'
+        backup_db = tmp_path / 'song_data.db'
+        outside_target = tmp_path / 'escape.txt'
+        _write_sqlite_db(live_db, marker='live')
+        _write_sqlite_db(backup_db, marker='restored')
+
+        zip_path = backup_dir / 'zip-slip.zip'
+        with zipfile.ZipFile(str(zip_path), 'w') as zf:
+            zf.write(backup_db, 'song_data.db')
+            zf.writestr('../escape.txt', 'should not be extracted')
+
+        orig_join = os.path.join
+
+        def mock_join(*args):
+            if args == ('/data', 'backups'):
+                return str(backup_dir)
+            return orig_join(*args)
+
+        app.config['SQLALCHEMY_DATABASE_URI'] = f'sqlite:///{live_db}'
+        with patch('os.path.join', side_effect=mock_join):
+            result = restore_backup('zip-slip.zip')
+
+        assert result['status'] == 'error'
+        assert 'unsafe path' in result['message'].lower()
+        assert _read_sqlite_marker(live_db) == 'live'
+        assert not outside_target.exists()
 
 
 class TestScheduleBackup:


### PR DESCRIPTION
## Summary
- make backup upload, verify, and restore agree on `song_data.db` and legacy `database.db`
- reject unsafe ZIP member paths before restore extraction
- validate the extracted SQLite database with `PRAGMA integrity_check` before overwriting the live DB
- add restore regression coverage for legacy DB filename, corrupted DB rejection, and zip-slip rejection

Closes #101.

## Validation
- `SECRET_KEY=test-secret-key-for-testing-only AUTOMATION_TOKEN=test-automation-token-for-testing .venv/bin/pytest tests/test_backup_helper.py -q` -> 22 passed
- `.venv/bin/flake8 musicround/ --count --select=E9,F63,F7,F82 --show-source --statistics`
- `SECRET_KEY=test-secret-key-for-testing-only AUTOMATION_TOKEN=test-automation-token-for-testing .venv/bin/pytest tests/ -q` -> 417 passed, 2 skipped
