### PR TITLE
Reject symlink entries in backup restores

### DIFF
--- a/musicround/helpers/backup_helper.py
+++ b/musicround/helpers/backup_helper.py
@@ -6,6 +6,7 @@ import shutil
 import json
 import logging
 import sqlite3
+import stat
 import zipfile
 from datetime import datetime
 import tempfile
@@ -27,6 +28,10 @@ def _find_database_member(file_list):
 def _unsafe_zip_member_name(zip_info, target_dir):
     member_name = zip_info.filename.replace('\\', '/')
     if member_name.startswith('/') or member_name.startswith('../'):
+        return zip_info.filename
+
+    file_mode = zip_info.external_attr >> 16
+    if stat.S_ISLNK(file_mode):
         return zip_info.filename
 
     target_root = os.path.abspath(target_dir)

--- a/tests/test_backup_helper.py
+++ b/tests/test_backup_helper.py
@@ -3,6 +3,7 @@ import pytest
 import json
 import os
 import sqlite3
+import stat
 import zipfile
 import tempfile
 from unittest.mock import patch, MagicMock
@@ -26,6 +27,15 @@ def _read_sqlite_marker(path):
         return conn.execute('SELECT value FROM smoke').fetchone()[0]
     finally:
         conn.close()
+
+
+def _exists_including_zip(zip_path):
+    original_exists = os.path.exists
+
+    def exists(path):
+        return path == str(zip_path) or original_exists(path)
+
+    return exists
 
 
 class TestListBackups:
@@ -206,7 +216,7 @@ class TestVerifyBackup:
         with zipfile.ZipFile(str(zip_path), 'w') as zf:
             zf.writestr('backup_metadata.json', json.dumps({'version': '1.0'}))
 
-        with patch('os.path.exists', side_effect=lambda p: p == str(zip_path) or os.path.exists(p)), \
+        with patch('os.path.exists', side_effect=_exists_including_zip(zip_path)), \
              patch('os.path.join', return_value=str(zip_path)):
             result = verify_backup('no_db.zip')
         assert result['is_valid'] is False
@@ -223,7 +233,7 @@ class TestVerifyBackup:
             zf.writestr('backup_metadata.json', json.dumps(metadata))
             zf.write(db_path, 'song_data.db')
 
-        with patch('os.path.exists', side_effect=lambda p: p == str(zip_path) or os.path.exists(p)), \
+        with patch('os.path.exists', side_effect=_exists_including_zip(zip_path)), \
              patch('os.path.join', return_value=str(zip_path)):
             result = verify_backup('valid.zip')
         assert result['is_valid'] is True
@@ -239,7 +249,7 @@ class TestVerifyBackup:
         with zipfile.ZipFile(str(zip_path), 'w') as zf:
             zf.write(db_path, 'database.db')
 
-        with patch('os.path.exists', side_effect=lambda p: p == str(zip_path) or os.path.exists(p)), \
+        with patch('os.path.exists', side_effect=_exists_including_zip(zip_path)), \
              patch('os.path.join', return_value=str(zip_path)):
             result = verify_backup('legacy_valid.zip')
         assert result['is_valid'] is True
@@ -348,6 +358,40 @@ class TestRestoreBackup:
         assert 'unsafe path' in result['message'].lower()
         assert _read_sqlite_marker(live_db) == 'live'
         assert not outside_target.exists()
+
+    def test_restore_backup_rejects_zip_symlink_member(self, app, tmp_path):
+        """Test restore_backup rejects symlink members before extraction."""
+        from musicround.helpers.backup_helper import restore_backup
+
+        backup_dir = tmp_path / 'backups'
+        backup_dir.mkdir()
+        live_db = tmp_path / 'live.db'
+        backup_db = tmp_path / 'song_data.db'
+        _write_sqlite_db(live_db, marker='live')
+        _write_sqlite_db(backup_db, marker='restored')
+
+        symlink_info = zipfile.ZipInfo('safe-link')
+        symlink_info.external_attr = (stat.S_IFLNK | 0o777) << 16
+
+        zip_path = backup_dir / 'symlink.zip'
+        with zipfile.ZipFile(str(zip_path), 'w') as zf:
+            zf.write(backup_db, 'song_data.db')
+            zf.writestr(symlink_info, '../outside')
+
+        orig_join = os.path.join
+
+        def mock_join(*args):
+            if args == ('/data', 'backups'):
+                return str(backup_dir)
+            return orig_join(*args)
+
+        app.config['SQLALCHEMY_DATABASE_URI'] = f'sqlite:///{live_db}'
+        with patch('os.path.join', side_effect=mock_join):
+            result = restore_backup('symlink.zip')
+
+        assert result['status'] == 'error'
+        assert 'unsafe path' in result['message'].lower()
+        assert _read_sqlite_marker(live_db) == 'live'
 
 
 class TestScheduleBackup:


### PR DESCRIPTION
## Summary
- reject ZIP symlink members before backup restore extraction
- add a restore regression for symlink archive entries
- make verify_backup path-exists mocks delegate to the original os.path.exists

## Validation
- SECRET_KEY=test AUTOMATION_TOKEN=test python3 -m py_compile musicround/helpers/backup_helper.py tests/test_backup_helper.py
- SECRET_KEY=test AUTOMATION_TOKEN=test .venv/bin/pytest tests/test_backup_helper.py::TestRestoreBackup::test_restore_backup_rejects_zip_symlink_member tests/test_backup_helper.py::TestVerifyBackup::test_verify_backup_accepts_database_db_filename -q (blocked locally on Python 3.14 because pydub expects audioop/pyaudioop)

Follow-up for Copilot review comments on #120.