### PR TITLE
Harden security defaults and automation auth

### DIFF
--- a/.env.demo
+++ b/.env.demo
@@ -2,8 +2,10 @@
 # Copy this file to .env and replace with your actual values
 
 # Debug settings
-DEBUG=True
+DEBUG=False
+DEBUG2=False
 SECRET_KEY=your-secret-key-here-make-it-long-and-random
+AUTOMATION_TOKEN=your-automation-token-here-make-it-long-and-random
 
 # API Keys
 OPENAI_API_KEY=your-openai-api-key

--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,10 @@ AUTOMATION_TOKEN=
 # ============================================================================
 # WARNING: Set DEBUG=False in production environments!
 DEBUG=False
+DEBUG2=False
+
+# Session lifetime in hours; keep short for shared admin/operator machines.
+PERMANENT_SESSION_LIFETIME_HOURS=12
 
 # ============================================================================
 # DATABASE CONFIGURATION

--- a/musicround/config.py
+++ b/musicround/config.py
@@ -15,7 +15,8 @@ basedir = os.path.abspath(os.path.dirname(__file__))
 
 class Config:
     # Debug settings
-    DEBUG = os.getenv("DEBUG", "True") == "True"
+    DEBUG = os.getenv("DEBUG", "False") == "True"
+    DEBUG2 = os.getenv("DEBUG2", "False") == "True"
     SECRET_KEY = os.getenv('SECRET_KEY')
     if not SECRET_KEY:
         raise ValueError("SECRET_KEY environment variable must be set. Generate a secure key with: python -c 'import secrets; print(secrets.token_hex(32))'")
@@ -80,6 +81,27 @@ class Config:
     # Reverse proxy settings
     USE_HTTPS = os.getenv("USE_HTTPS", "False") == "True"  # Force HTTPS URL generation
     PREFERRED_URL_SCHEME = os.getenv("PREFERRED_URL_SCHEME", 'https' if USE_HTTPS else 'http')
+
+    # Session and remember-cookie security defaults
+    SESSION_COOKIE_SECURE = USE_HTTPS
+    SESSION_COOKIE_HTTPONLY = True
+    SESSION_COOKIE_SAMESITE = os.getenv("SESSION_COOKIE_SAMESITE", "Lax")
+    REMEMBER_COOKIE_SECURE = USE_HTTPS
+    REMEMBER_COOKIE_HTTPONLY = True
+    REMEMBER_COOKIE_SAMESITE = os.getenv("REMEMBER_COOKIE_SAMESITE", "Lax")
+    try:
+        PERMANENT_SESSION_LIFETIME = timedelta(
+            hours=int(os.getenv("PERMANENT_SESSION_LIFETIME_HOURS", "12"))
+        )
+    except (TypeError, ValueError):
+        PERMANENT_SESSION_LIFETIME = timedelta(hours=12)
+
+    # Minimal in-app authentication throttles. These are per-process safety nets,
+    # not a replacement for edge/WAF rate limiting.
+    LOGIN_RATE_LIMIT_ATTEMPTS = int(os.getenv("LOGIN_RATE_LIMIT_ATTEMPTS", "5"))
+    LOGIN_RATE_LIMIT_WINDOW_SECONDS = int(os.getenv("LOGIN_RATE_LIMIT_WINDOW_SECONDS", "900"))
+    AUTOMATION_RATE_LIMIT_ATTEMPTS = int(os.getenv("AUTOMATION_RATE_LIMIT_ATTEMPTS", "10"))
+    AUTOMATION_RATE_LIMIT_WINDOW_SECONDS = int(os.getenv("AUTOMATION_RATE_LIMIT_WINDOW_SECONDS", "300"))
     
     # Static OAuth URL configuration (for production environments)
     STATIC_OAUTH_URLS = os.getenv("STATIC_OAUTH_URLS", "False") == "True"
@@ -88,5 +110,4 @@ class Config:
     OAUTH_GOOGLE_URL = os.getenv("OAUTH_GOOGLE_URL")
     OAUTH_AUTHENTIK_URL = os.getenv("OAUTH_AUTHENTIK_URL")
     OAUTH_DROPBOX_URL = os.getenv("OAUTH_DROPBOX_URL")
-
 

--- a/musicround/mcp_http.py
+++ b/musicround/mcp_http.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import time
 from secrets import compare_digest
 
 from starlette.responses import JSONResponse
@@ -13,6 +14,46 @@ from musicround.mcp_server import mcp
 
 _BASE_ALLOWED_HOSTS = tuple(mcp.settings.transport_security.allowed_hosts)
 _BASE_ALLOWED_ORIGINS = tuple(mcp.settings.transport_security.allowed_origins)
+_AUTH_FAILURES: dict[str, list[float]] = {}
+
+
+def _prune_attempts(now: float, window_seconds: int) -> None:
+    for key, attempts in list(_AUTH_FAILURES.items()):
+        recent_attempts = [
+            timestamp for timestamp in attempts if now - timestamp < window_seconds
+        ]
+        if recent_attempts:
+            _AUTH_FAILURES[key] = recent_attempts
+        else:
+            _AUTH_FAILURES.pop(key, None)
+
+
+def _rate_limited(key: str, max_attempts: int, window_seconds: int) -> bool:
+    if max_attempts <= 0:
+        return False
+    now = time.time()
+    _prune_attempts(now, window_seconds)
+    return len(_AUTH_FAILURES.get(key, [])) >= max_attempts
+
+
+def _record_auth_failure(key: str, window_seconds: int) -> None:
+    now = time.time()
+    _prune_attempts(now, window_seconds)
+    _AUTH_FAILURES.setdefault(key, []).append(now)
+
+
+def _clear_auth_failures(key: str) -> None:
+    _AUTH_FAILURES.pop(key, None)
+
+
+def _client_rate_limit_id(scope: Scope, headers: dict[bytes, bytes]) -> str:
+    forwarded_for = headers.get(b"x-forwarded-for", b"").decode("latin1")
+    if forwarded_for:
+        return forwarded_for.split(",")[0].strip()
+    client = scope.get("client")
+    if client:
+        return str(client[0])
+    return "unknown"
 
 
 class BearerAuthMiddleware:
@@ -39,9 +80,30 @@ class BearerAuthMiddleware:
             return
 
         headers = dict(scope.get("headers", []))
+        rate_limit_key = _client_rate_limit_id(scope, headers)
+        max_attempts = int(
+            os.getenv(
+                "MCP_AUTH_RATE_LIMIT_ATTEMPTS",
+                os.getenv("AUTOMATION_RATE_LIMIT_ATTEMPTS", "10"),
+            )
+        )
+        window_seconds = int(
+            os.getenv(
+                "MCP_AUTH_RATE_LIMIT_WINDOW_SECONDS",
+                os.getenv("AUTOMATION_RATE_LIMIT_WINDOW_SECONDS", "300"),
+            )
+        )
+        if _rate_limited(rate_limit_key, max_attempts, window_seconds):
+            await JSONResponse(
+                {"error": "Too many authentication attempts."},
+                status_code=429,
+            )(scope, receive, send)
+            return
+
         authorization = headers.get(b"authorization", b"").decode("latin1")
         scheme, _, token = authorization.partition(" ")
         if scheme.lower() != "bearer" or not compare_digest(token.strip(), expected):
+            _record_auth_failure(rate_limit_key, window_seconds)
             await JSONResponse(
                 {"error": "Unauthorized."},
                 headers={"WWW-Authenticate": "Bearer"},
@@ -49,6 +111,7 @@ class BearerAuthMiddleware:
             )(scope, receive, send)
             return
 
+        _clear_auth_failures(rate_limit_key)
         await self.app(scope, receive, send)
 
 

--- a/musicround/routes/users.py
+++ b/musicround/routes/users.py
@@ -3,8 +3,10 @@ User authentication and profile management routes
 """
 import uuid  # Add missing import
 import time  # Add missing import
+from functools import wraps
+from secrets import compare_digest
 from datetime import datetime, timedelta
-from flask import Blueprint, render_template, redirect, url_for, flash, request, current_app, session, jsonify
+from flask import Blueprint, render_template, redirect, url_for, flash, request, current_app, session, jsonify, g
 from flask_login import login_user, current_user, logout_user, login_required  # Ensure flask_login is imported
 from werkzeug.security import generate_password_hash, check_password_hash
 from sqlalchemy.exc import IntegrityError
@@ -15,6 +17,95 @@ from musicround.helpers.auth_helpers import oauth, find_or_create_user, update_o
 from musicround.helpers.spotify_helper import get_spotify_token, get_current_user_spotify_token, get_spotify_user_info as spotify_helper_get_user_info
 
 users_bp = Blueprint('users', __name__, url_prefix='/users')
+_LOGIN_FAILURES = {}
+_AUTOMATION_FAILURES = {}
+
+
+def _client_rate_limit_id():
+    forwarded_for = request.headers.get('X-Forwarded-For', '')
+    if forwarded_for:
+        return forwarded_for.split(',')[0].strip()
+    return request.remote_addr or 'unknown'
+
+
+def _prune_attempts(store, now, window_seconds):
+    for key, attempts in list(store.items()):
+        recent_attempts = [timestamp for timestamp in attempts if now - timestamp < window_seconds]
+        if recent_attempts:
+            store[key] = recent_attempts
+        else:
+            store.pop(key, None)
+
+
+def _rate_limited(store, key, max_attempts, window_seconds):
+    if max_attempts <= 0:
+        return False
+    now = time.time()
+    _prune_attempts(store, now, window_seconds)
+    return len(store.get(key, [])) >= max_attempts
+
+
+def _record_rate_limit_failure(store, key, window_seconds):
+    now = time.time()
+    _prune_attempts(store, now, window_seconds)
+    store.setdefault(key, []).append(now)
+
+
+def _clear_rate_limit_failures(store, key):
+    store.pop(key, None)
+
+
+def _login_rate_limit_key(username_or_email):
+    normalized_username = (username_or_email or '').strip().lower()
+    return f"{_client_rate_limit_id()}:{normalized_username}"
+
+
+def _automation_rate_limit_key():
+    return f"automation:{_client_rate_limit_id()}"
+
+
+def _automation_token_from_header():
+    return request.headers.get('X-Automation-Token', '').strip()
+
+
+def _valid_automation_token():
+    provided_token = _automation_token_from_header()
+    expected_token = current_app.config.get('AUTOMATION_TOKEN') or ''
+    return bool(provided_token and expected_token and compare_digest(provided_token, expected_token))
+
+
+def automation_or_admin_required(f):
+    @wraps(f)
+    def decorated_function(*args, **kwargs):
+        automation_key = _automation_rate_limit_key()
+        max_attempts = current_app.config.get('AUTOMATION_RATE_LIMIT_ATTEMPTS', 10)
+        window_seconds = current_app.config.get('AUTOMATION_RATE_LIMIT_WINDOW_SECONDS', 300)
+
+        provided_token = _automation_token_from_header()
+        if provided_token:
+            if _rate_limited(_AUTOMATION_FAILURES, automation_key, max_attempts, window_seconds):
+                return jsonify({"status": "error", "message": "Too many automation attempts"}), 429
+            if _valid_automation_token():
+                _clear_rate_limit_failures(_AUTOMATION_FAILURES, automation_key)
+                g.automation_request = True
+                return f(*args, **kwargs)
+            _record_rate_limit_failure(_AUTOMATION_FAILURES, automation_key, window_seconds)
+            return jsonify({"status": "error", "message": "Unauthorized"}), 401
+
+        if not current_user.is_authenticated:
+            if request.headers.get('Accept') == 'application/json':
+                return jsonify({"status": "error", "message": "Unauthorized"}), 401
+            return redirect(url_for('users.login'))
+
+        if not current_user.is_admin:
+            if request.headers.get('Accept') == 'application/json':
+                return jsonify({"status": "error", "message": "Admin access required"}), 403
+            flash('Admin access required.', 'danger')
+            return redirect(url_for('users.profile'))
+
+        g.automation_request = False
+        return f(*args, **kwargs)
+    return decorated_function
 
 # Helper function for processing Spotify account linking
 def _process_spotify_link(user, token_payload, spotify_user_data):
@@ -58,7 +149,6 @@ def _process_spotify_disconnect(user):
     current_app.logger.info(f"User {user.id} successfully disconnected their Spotify account.")
 
 def admin_required(f):
-    from functools import wraps
     @wraps(f)
     def decorated_function(*args, **kwargs):
         if not current_user.is_authenticated or not current_user.is_admin:
@@ -379,6 +469,16 @@ def login():
         username_or_email = request.form.get('username')
         password = request.form.get('password')
         remember = True if request.form.get('remember') else False
+        rate_limit_key = _login_rate_limit_key(username_or_email)
+        max_attempts = current_app.config.get('LOGIN_RATE_LIMIT_ATTEMPTS', 5)
+        window_seconds = current_app.config.get('LOGIN_RATE_LIMIT_WINDOW_SECONDS', 900)
+
+        if _rate_limited(_LOGIN_FAILURES, rate_limit_key, max_attempts, window_seconds):
+            flash('Too many failed login attempts. Please try again later.', 'danger')
+            return render_template(
+                'users/login.html',
+                oauth_providers=oauth_providers
+            ), 429
         
         # Find user by username or email
         user = User.query.filter_by(username=username_or_email).first()
@@ -387,10 +487,12 @@ def login():
         
         # Check if user exists and password is correct
         if not user or not check_password_hash(user.password_hash, password):
+            _record_rate_limit_failure(_LOGIN_FAILURES, rate_limit_key, window_seconds)
             flash('Invalid username/email or password', 'danger')
             return render_template('users/login.html', oauth_providers=oauth_providers)
         
         # Log in the user
+        _clear_rate_limit_failures(_LOGIN_FAILURES, rate_limit_key)
         login_user(user, remember=remember)
         user.last_login = datetime.now()
         db.session.commit()
@@ -1256,19 +1358,11 @@ def backup_manager():
     )
 
 @users_bp.route('/create-backup', methods=['POST'])
-@login_required
-@admin_required
+@automation_or_admin_required
 def create_backup():
     """Create a new backup"""
     from musicround.helpers.backup_helper import create_backup as create_backup_helper
-    
-    # Check for automation token for scheduled backups
-    automation_token = request.headers.get('X-Automation-Token') or request.args.get('token')
-    if automation_token == current_app.config.get('AUTOMATION_TOKEN'):
-        # Allow the request without authentication for automation
-        pass
-    elif not current_user.is_authenticated or not current_user.is_admin:
-        return jsonify({"status": "error", "message": "Unauthorized"}), 401
+    automation_request = bool(getattr(g, 'automation_request', False))
     
     # Get custom backup name if provided
     backup_name = request.form.get('backup_name', '').strip()
@@ -1285,7 +1379,7 @@ def create_backup():
     )
     
     # If this is an API request, return JSON
-    if request.headers.get('Accept') == 'application/json' or automation_token:
+    if request.headers.get('Accept') == 'application/json' or automation_request:
         return jsonify(result)
     
     # Otherwise, store the result for display in the UI and redirect

--- a/tests/test_mcp_http.py
+++ b/tests/test_mcp_http.py
@@ -8,7 +8,12 @@ from starlette.testclient import TestClient
 os.environ.setdefault("SECRET_KEY", "test-secret-key-for-testing-only")
 os.environ.setdefault("AUTOMATION_TOKEN", "test-automation-token-for-testing")
 
-from musicround.mcp_http import BearerAuthMiddleware, build_app, mcp  # noqa: E402
+from musicround.mcp_http import (  # noqa: E402
+    _AUTH_FAILURES,
+    BearerAuthMiddleware,
+    build_app,
+    mcp,
+)
 
 
 async def _dummy_app(scope, receive, send):
@@ -27,6 +32,8 @@ def test_healthz_does_not_require_auth(monkeypatch):
 
 def test_mcp_requires_bearer_token(monkeypatch):
     monkeypatch.setenv("MCP_BEARER_TOKEN", "test-mcp-token")
+    monkeypatch.delenv("MCP_AUTH_RATE_LIMIT_ATTEMPTS", raising=False)
+    _AUTH_FAILURES.clear()
     client = TestClient(BearerAuthMiddleware(_dummy_app))
 
     missing = client.get("/mcp")
@@ -39,9 +46,28 @@ def test_mcp_requires_bearer_token(monkeypatch):
     assert accepted.status_code != 401
 
 
+def test_mcp_rate_limits_failed_bearer_attempts(monkeypatch):
+    monkeypatch.setenv("MCP_BEARER_TOKEN", "test-mcp-token")
+    monkeypatch.setenv("MCP_AUTH_RATE_LIMIT_ATTEMPTS", "1")
+    monkeypatch.setenv("MCP_AUTH_RATE_LIMIT_WINDOW_SECONDS", "300")
+    _AUTH_FAILURES.clear()
+    client = TestClient(BearerAuthMiddleware(_dummy_app))
+
+    first = client.get("/mcp", headers={"Authorization": "Bearer wrong"})
+    blocked = client.get("/mcp", headers={"Authorization": "Bearer test-mcp-token"})
+
+    _AUTH_FAILURES.clear()
+    accepted = client.get("/mcp", headers={"Authorization": "Bearer test-mcp-token"})
+
+    assert first.status_code == 401
+    assert blocked.status_code == 429
+    assert accepted.status_code == 204
+
+
 def test_mcp_falls_back_to_automation_token(monkeypatch):
     monkeypatch.delenv("MCP_BEARER_TOKEN", raising=False)
     monkeypatch.setenv("AUTOMATION_TOKEN", "automation-token")
+    _AUTH_FAILURES.clear()
     client = TestClient(BearerAuthMiddleware(_dummy_app))
 
     accepted = client.get("/mcp", headers={"Authorization": "Bearer automation-token"})

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -3,6 +3,7 @@ import pytest
 import os
 import re
 import importlib
+from unittest.mock import patch
 import musicround.config
 
 
@@ -208,6 +209,38 @@ class TestSecureDefaults:
         
         # Should have DEBUG=False
         assert 'DEBUG=False' in content, ".env.example should have DEBUG=False"
+        assert 'DEBUG2=False' in content, ".env.example should have DEBUG2=False"
+
+    def test_config_debug_defaults_false(self, monkeypatch):
+        """Test that debug config defaults are disabled without env overrides."""
+        monkeypatch.setenv('SECRET_KEY', 'test-secret-key-for-security-test')
+        monkeypatch.setenv('AUTOMATION_TOKEN', 'test-automation-token-for-security-test')
+        monkeypatch.delenv('DEBUG', raising=False)
+        monkeypatch.delenv('DEBUG2', raising=False)
+
+        config_module = importlib.reload(musicround.config)
+
+        assert config_module.Config.DEBUG is False
+        assert config_module.Config.DEBUG2 is False
+
+    def test_cookie_security_defaults(self, monkeypatch):
+        """Test secure session and remember-cookie defaults."""
+        monkeypatch.setenv('SECRET_KEY', 'test-secret-key-for-security-test')
+        monkeypatch.setenv('AUTOMATION_TOKEN', 'test-automation-token-for-security-test')
+        monkeypatch.setenv('USE_HTTPS', 'True')
+
+        config_module = importlib.reload(musicround.config)
+
+        assert config_module.Config.SESSION_COOKIE_SECURE is True
+        assert config_module.Config.SESSION_COOKIE_HTTPONLY is True
+        assert config_module.Config.SESSION_COOKIE_SAMESITE == 'Lax'
+        assert config_module.Config.REMEMBER_COOKIE_SECURE is True
+        assert config_module.Config.REMEMBER_COOKIE_HTTPONLY is True
+        assert config_module.Config.REMEMBER_COOKIE_SAMESITE == 'Lax'
+        assert config_module.Config.PERMANENT_SESSION_LIFETIME.total_seconds() == 12 * 3600
+
+        monkeypatch.setenv('USE_HTTPS', 'False')
+        importlib.reload(musicround.config)
     
     def test_https_recommended(self):
         """Test that HTTPS is documented as recommended."""
@@ -219,6 +252,76 @@ class TestSecureDefaults:
             "SECURITY.md should mention HTTPS"
         assert 'USE_HTTPS' in content, \
             "SECURITY.md should document USE_HTTPS setting"
+
+
+class TestAuthRateLimiting:
+    """Test authentication throttling."""
+
+    def test_login_rate_limit_blocks_repeated_failures(self, app, client):
+        """Test repeated bad logins are throttled."""
+        from musicround.routes import users as users_routes
+
+        users_routes._LOGIN_FAILURES.clear()
+        app.config['LOGIN_RATE_LIMIT_ATTEMPTS'] = 2
+        app.config['LOGIN_RATE_LIMIT_WINDOW_SECONDS'] = 900
+
+        payload = {'username': 'rate-limit-user', 'password': 'wrong-password'}
+        first = client.post('/users/login', data=payload)
+        second = client.post('/users/login', data=payload)
+        third = client.post('/users/login', data=payload)
+
+        assert first.status_code == 200
+        assert second.status_code == 200
+        assert third.status_code == 429
+
+    def test_create_backup_accepts_header_automation_token(self, app, client):
+        """Test backup automation uses header-only token auth without login."""
+        app.config['AUTOMATION_TOKEN'] = 'automation-secret'
+
+        with patch('musicround.helpers.backup_helper.create_backup') as mock_create:
+            mock_create.return_value = {'status': 'success', 'message': 'created'}
+            response = client.post(
+                '/users/create-backup',
+                headers={'X-Automation-Token': 'automation-secret'},
+            )
+
+        assert response.status_code == 200
+        assert response.get_json()['status'] == 'success'
+        mock_create.assert_called_once()
+
+    def test_create_backup_rejects_query_string_token(self, app, client):
+        """Test automation tokens are not accepted in URLs."""
+        app.config['AUTOMATION_TOKEN'] = 'automation-secret'
+
+        with patch('musicround.helpers.backup_helper.create_backup') as mock_create:
+            response = client.post(
+                '/users/create-backup?token=automation-secret',
+                headers={'Accept': 'application/json'},
+            )
+
+        assert response.status_code == 401
+        mock_create.assert_not_called()
+
+    def test_create_backup_rate_limits_bad_automation_tokens(self, app, client):
+        """Test repeated invalid automation headers are throttled."""
+        from musicround.routes import users as users_routes
+
+        users_routes._AUTOMATION_FAILURES.clear()
+        app.config['AUTOMATION_TOKEN'] = 'automation-secret'
+        app.config['AUTOMATION_RATE_LIMIT_ATTEMPTS'] = 1
+        app.config['AUTOMATION_RATE_LIMIT_WINDOW_SECONDS'] = 300
+
+        first = client.post(
+            '/users/create-backup',
+            headers={'X-Automation-Token': 'wrong-token'},
+        )
+        second = client.post(
+            '/users/create-backup',
+            headers={'X-Automation-Token': 'wrong-token'},
+        )
+
+        assert first.status_code == 401
+        assert second.status_code == 429
 
 
 class TestSecretManagement:


### PR DESCRIPTION
## Summary
- closes #63
- default DEBUG/DEBUG2 to disabled and document the defaults
- add secure session/remember-cookie defaults and a bounded permanent session lifetime
- add per-process throttling for login, backup automation token auth, and MCP bearer auth
- make backup automation header-only and use constant-time token comparison

## Local validation
- `SECRET_KEY=test-secret-key-for-testing-only AUTOMATION_TOKEN=test-automation-token-for-testing .venv/bin/pytest tests/test_security.py tests/test_mcp_http.py -q` -> 25 passed
- `.venv/bin/flake8 musicround/ --count --select=E9,F63,F7,F82 --show-source --statistics` -> 0
- `SECRET_KEY=test-secret-key-for-testing-only AUTOMATION_TOKEN=test-automation-token-for-testing .venv/bin/pytest tests/ -q` -> 425 passed, 2 skipped
- `git diff --check` -> clean
