### PR TITLE
fix: harden auth rate-limit identity

### DIFF
--- a/musicround/config.py
+++ b/musicround/config.py
@@ -13,6 +13,14 @@ openai.api_key = os.getenv("OPENAI_API_KEY")
 # Get the base directory of the application
 basedir = os.path.abspath(os.path.dirname(__file__))
 
+
+def _int_from_env(name, default):
+    try:
+        return int(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
 class Config:
     # Debug settings
     DEBUG = os.getenv("DEBUG", "False") == "True"
@@ -98,10 +106,10 @@ class Config:
 
     # Minimal in-app authentication throttles. These are per-process safety nets,
     # not a replacement for edge/WAF rate limiting.
-    LOGIN_RATE_LIMIT_ATTEMPTS = int(os.getenv("LOGIN_RATE_LIMIT_ATTEMPTS", "5"))
-    LOGIN_RATE_LIMIT_WINDOW_SECONDS = int(os.getenv("LOGIN_RATE_LIMIT_WINDOW_SECONDS", "900"))
-    AUTOMATION_RATE_LIMIT_ATTEMPTS = int(os.getenv("AUTOMATION_RATE_LIMIT_ATTEMPTS", "10"))
-    AUTOMATION_RATE_LIMIT_WINDOW_SECONDS = int(os.getenv("AUTOMATION_RATE_LIMIT_WINDOW_SECONDS", "300"))
+    LOGIN_RATE_LIMIT_ATTEMPTS = _int_from_env("LOGIN_RATE_LIMIT_ATTEMPTS", 5)
+    LOGIN_RATE_LIMIT_WINDOW_SECONDS = _int_from_env("LOGIN_RATE_LIMIT_WINDOW_SECONDS", 900)
+    AUTOMATION_RATE_LIMIT_ATTEMPTS = _int_from_env("AUTOMATION_RATE_LIMIT_ATTEMPTS", 10)
+    AUTOMATION_RATE_LIMIT_WINDOW_SECONDS = _int_from_env("AUTOMATION_RATE_LIMIT_WINDOW_SECONDS", 300)
     
     # Static OAuth URL configuration (for production environments)
     STATIC_OAUTH_URLS = os.getenv("STATIC_OAUTH_URLS", "False") == "True"
@@ -110,4 +118,3 @@ class Config:
     OAUTH_GOOGLE_URL = os.getenv("OAUTH_GOOGLE_URL")
     OAUTH_AUTHENTIK_URL = os.getenv("OAUTH_AUTHENTIK_URL")
     OAUTH_DROPBOX_URL = os.getenv("OAUTH_DROPBOX_URL")
-

--- a/musicround/mcp_http.py
+++ b/musicround/mcp_http.py
@@ -46,9 +46,17 @@ def _clear_auth_failures(key: str) -> None:
     _AUTH_FAILURES.pop(key, None)
 
 
+def _int_from_env(name: str, default: int) -> int:
+    try:
+        return int(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
 def _client_rate_limit_id(scope: Scope, headers: dict[bytes, bytes]) -> str:
+    trust_x_forwarded_for = os.getenv("MCP_TRUST_X_FORWARDED_FOR", "False") == "True"
     forwarded_for = headers.get(b"x-forwarded-for", b"").decode("latin1")
-    if forwarded_for:
+    if trust_x_forwarded_for and forwarded_for:
         return forwarded_for.split(",")[0].strip()
     client = scope.get("client")
     if client:
@@ -81,17 +89,13 @@ class BearerAuthMiddleware:
 
         headers = dict(scope.get("headers", []))
         rate_limit_key = _client_rate_limit_id(scope, headers)
-        max_attempts = int(
-            os.getenv(
-                "MCP_AUTH_RATE_LIMIT_ATTEMPTS",
-                os.getenv("AUTOMATION_RATE_LIMIT_ATTEMPTS", "10"),
-            )
+        max_attempts = _int_from_env(
+            "MCP_AUTH_RATE_LIMIT_ATTEMPTS",
+            _int_from_env("AUTOMATION_RATE_LIMIT_ATTEMPTS", 10),
         )
-        window_seconds = int(
-            os.getenv(
-                "MCP_AUTH_RATE_LIMIT_WINDOW_SECONDS",
-                os.getenv("AUTOMATION_RATE_LIMIT_WINDOW_SECONDS", "300"),
-            )
+        window_seconds = _int_from_env(
+            "MCP_AUTH_RATE_LIMIT_WINDOW_SECONDS",
+            _int_from_env("AUTOMATION_RATE_LIMIT_WINDOW_SECONDS", 300),
         )
         if _rate_limited(rate_limit_key, max_attempts, window_seconds):
             await JSONResponse(

--- a/musicround/routes/users.py
+++ b/musicround/routes/users.py
@@ -22,9 +22,8 @@ _AUTOMATION_FAILURES = {}
 
 
 def _client_rate_limit_id():
-    forwarded_for = request.headers.get('X-Forwarded-For', '')
-    if forwarded_for:
-        return forwarded_for.split(',')[0].strip()
+    # create_app installs ProxyFix, so remote_addr is already normalized by the
+    # trusted proxy configuration instead of trusting raw client-supplied XFF.
     return request.remote_addr or 'unknown'
 
 
@@ -77,6 +76,10 @@ def _valid_automation_token():
 def automation_or_admin_required(f):
     @wraps(f)
     def decorated_function(*args, **kwargs):
+        if current_user.is_authenticated and current_user.is_admin:
+            g.automation_request = False
+            return f(*args, **kwargs)
+
         automation_key = _automation_rate_limit_key()
         max_attempts = current_app.config.get('AUTOMATION_RATE_LIMIT_ATTEMPTS', 10)
         window_seconds = current_app.config.get('AUTOMATION_RATE_LIMIT_WINDOW_SECONDS', 300)

--- a/tests/test_mcp_http.py
+++ b/tests/test_mcp_http.py
@@ -10,6 +10,7 @@ os.environ.setdefault("AUTOMATION_TOKEN", "test-automation-token-for-testing")
 
 from musicround.mcp_http import (  # noqa: E402
     _AUTH_FAILURES,
+    _client_rate_limit_id,
     BearerAuthMiddleware,
     build_app,
     mcp,
@@ -62,6 +63,34 @@ def test_mcp_rate_limits_failed_bearer_attempts(monkeypatch):
     assert first.status_code == 401
     assert blocked.status_code == 429
     assert accepted.status_code == 204
+
+
+def test_mcp_rate_limit_id_ignores_x_forwarded_for_by_default(monkeypatch):
+    monkeypatch.delenv("MCP_TRUST_X_FORWARDED_FOR", raising=False)
+    scope = {"type": "http", "client": ("10.0.0.8", 4567)}
+    headers = {b"x-forwarded-for": b"203.0.113.9"}
+
+    assert _client_rate_limit_id(scope, headers) == "10.0.0.8"
+
+
+def test_mcp_rate_limit_id_can_explicitly_trust_x_forwarded_for(monkeypatch):
+    monkeypatch.setenv("MCP_TRUST_X_FORWARDED_FOR", "True")
+    scope = {"type": "http", "client": ("10.0.0.8", 4567)}
+    headers = {b"x-forwarded-for": b"203.0.113.9, 198.51.100.1"}
+
+    assert _client_rate_limit_id(scope, headers) == "203.0.113.9"
+
+
+def test_mcp_rate_limit_env_falls_back_when_invalid(monkeypatch):
+    monkeypatch.setenv("MCP_BEARER_TOKEN", "test-mcp-token")
+    monkeypatch.setenv("MCP_AUTH_RATE_LIMIT_ATTEMPTS", "bad")
+    monkeypatch.setenv("MCP_AUTH_RATE_LIMIT_WINDOW_SECONDS", "bad")
+    _AUTH_FAILURES.clear()
+    client = TestClient(BearerAuthMiddleware(_dummy_app))
+
+    response = client.get("/mcp", headers={"Authorization": "Bearer test-mcp-token"})
+
+    assert response.status_code == 204
 
 
 def test_mcp_falls_back_to_automation_token(monkeypatch):

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -341,7 +341,10 @@ class TestAuthRateLimiting:
             mock_create.return_value = {'status': 'success', 'message': 'created'}
             response = client.post(
                 '/users/create-backup',
-                headers={'X-Automation-Token': 'stale-token'},
+                headers={
+                    'Accept': 'application/json',
+                    'X-Automation-Token': 'stale-token',
+                },
             )
 
         assert response.status_code == 200

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -241,7 +241,23 @@ class TestSecureDefaults:
 
         monkeypatch.setenv('USE_HTTPS', 'False')
         importlib.reload(musicround.config)
-    
+
+    def test_rate_limit_settings_fall_back_when_env_is_invalid(self, monkeypatch):
+        """Test invalid numeric rate-limit settings do not break config import."""
+        monkeypatch.setenv('SECRET_KEY', 'test-secret-key-for-security-test')
+        monkeypatch.setenv('AUTOMATION_TOKEN', 'test-automation-token-for-security-test')
+        monkeypatch.setenv('LOGIN_RATE_LIMIT_ATTEMPTS', 'not-a-number')
+        monkeypatch.setenv('LOGIN_RATE_LIMIT_WINDOW_SECONDS', 'bad-window')
+        monkeypatch.setenv('AUTOMATION_RATE_LIMIT_ATTEMPTS', 'bad-attempts')
+        monkeypatch.setenv('AUTOMATION_RATE_LIMIT_WINDOW_SECONDS', 'bad-window')
+
+        config_module = importlib.reload(musicround.config)
+
+        assert config_module.Config.LOGIN_RATE_LIMIT_ATTEMPTS == 5
+        assert config_module.Config.LOGIN_RATE_LIMIT_WINDOW_SECONDS == 900
+        assert config_module.Config.AUTOMATION_RATE_LIMIT_ATTEMPTS == 10
+        assert config_module.Config.AUTOMATION_RATE_LIMIT_WINDOW_SECONDS == 300
+
     def test_https_recommended(self):
         """Test that HTTPS is documented as recommended."""
         security_md_path = os.path.join(os.path.dirname(__file__), '..', 'SECURITY.md')
@@ -256,6 +272,17 @@ class TestSecureDefaults:
 
 class TestAuthRateLimiting:
     """Test authentication throttling."""
+
+    def test_rate_limit_id_uses_proxy_normalized_remote_addr(self, app):
+        """Test raw X-Forwarded-For does not directly control Flask rate limits."""
+        from musicround.routes import users as users_routes
+
+        with app.test_request_context(
+            '/users/login',
+            headers={'X-Forwarded-For': '203.0.113.20'},
+            environ_base={'REMOTE_ADDR': '10.0.0.5'},
+        ):
+            assert users_routes._client_rate_limit_id() == '10.0.0.5'
 
     def test_login_rate_limit_blocks_repeated_failures(self, app, client):
         """Test repeated bad logins are throttled."""
@@ -283,6 +310,38 @@ class TestAuthRateLimiting:
             response = client.post(
                 '/users/create-backup',
                 headers={'X-Automation-Token': 'automation-secret'},
+            )
+
+        assert response.status_code == 200
+        assert response.get_json()['status'] == 'success'
+        mock_create.assert_called_once()
+
+    def test_admin_backup_ignores_stale_automation_header(self, app, client):
+        """Test admin sessions are not blocked by stale automation headers."""
+        from musicround.models import db, User
+        from musicround.routes import users as users_routes
+
+        users_routes._AUTOMATION_FAILURES.clear()
+        app.config['AUTOMATION_TOKEN'] = 'automation-secret'
+        with app.app_context():
+            user = User(
+                username='automation-admin',
+                email='automation-admin@example.com',
+                is_admin=True,
+            )
+            user.password = 'AdminPass123!'
+            db.session.add(user)
+            db.session.commit()
+        client.post(
+            '/users/login',
+            data={'username': 'automation-admin', 'password': 'AdminPass123!'},
+        )
+
+        with patch('musicround.helpers.backup_helper.create_backup') as mock_create:
+            mock_create.return_value = {'status': 'success', 'message': 'created'}
+            response = client.post(
+                '/users/create-backup',
+                headers={'X-Automation-Token': 'stale-token'},
             )
 
         assert response.status_code == 200


### PR DESCRIPTION
Follow-up for Copilot review comments on #122 after it merged.\n\nChanges:\n- Stop trusting raw X-Forwarded-For for Flask auth rate-limit keys; use ProxyFix-normalized remote_addr.\n- Let authenticated admins short-circuit before stale automation-token headers are evaluated.\n- Add safe numeric env parsing for auth throttle settings.\n- Default MCP bearer-auth throttling to scope client identity and only trust X-Forwarded-For behind an explicit MCP_TRUST_X_FORWARDED_FOR opt-in.\n\nValidation:\n- git diff --check\n- py_compile for touched modules/tests\n- flake8 --select=E9,F63,F7,F82 on touched files\n\nNote: local pytest on this Mac is blocked by Python 3.13/3.14 removing audioop while pydub expects audioop/pyaudioop; GitHub CI uses Python 3.11 and should exercise the full suite.