### PR TITLE
Harden round song integrity

### DIFF
--- a/musicround/models.py
+++ b/musicround/models.py
@@ -269,12 +269,34 @@ class Round(db.Model):
         )
 
     @property
+    def song_id_list(self):
+        """
+        Returns the round's stored song IDs in their saved order.
+        """
+        song_ids = []
+        for token in (self.songs or '').split(','):
+            token = token.strip()
+            if not token:
+                continue
+            try:
+                song_ids.append(int(token))
+            except ValueError:
+                continue
+        return song_ids
+
+    @property
     def song_list(self):
         """
         Returns a list of Song objects associated with this round
         """
-        song_ids = self.songs.split(',')
-        return Song.query.filter(Song.id.in_(song_ids)).all()
+        song_ids = self.song_id_list
+        if not song_ids:
+            return []
+        songs_by_id = {
+            song.id: song
+            for song in Song.query.filter(Song.id.in_(song_ids)).all()
+        }
+        return [songs_by_id[song_id] for song_id in song_ids if song_id in songs_by_id]
         
     def reset_generated_status(self):
         """

--- a/musicround/routes/generate.py
+++ b/musicround/routes/generate.py
@@ -533,13 +533,29 @@ def save_round():
     tag = request.form.get('tag')
     
     # get list of song IDs from form
-    song_ids = request.form.getlist('song_id')
+    raw_song_ids = [song_id.strip() for song_id in request.form.getlist('song_id') if song_id.strip()]
+    if not raw_song_ids:
+        flash('Please select at least one song before saving a round.', 'error')
+        return redirect(url_for('generate.build_music_round'))
 
-    # get list of song objects from database
-    songs = Song.query.filter(Song.id.in_(song_ids)).all()
+    try:
+        song_ids = [int(song_id) for song_id in raw_song_ids]
+    except ValueError:
+        flash('Invalid song selection. Please build the round again.', 'error')
+        return redirect(url_for('generate.build_music_round'))
+
+    # get list of song objects from database while preserving the submitted order
+    songs_by_id = {
+        song.id: song
+        for song in Song.query.filter(Song.id.in_(song_ids)).all()
+    }
+    songs = [songs_by_id[song_id] for song_id in song_ids if song_id in songs_by_id]
+    if len(songs) != len(song_ids):
+        flash('One or more selected songs could not be found. Please build the round again.', 'error')
+        return redirect(url_for('generate.build_music_round'))
 
     # create string representation of song IDs
-    song_ids_str = ','.join(song_id for song_id in song_ids)
+    song_ids_str = ','.join(str(song_id) for song_id in song_ids)
 
     # determine round type
     if genre:

--- a/musicround/routes/rounds.py
+++ b/musicround/routes/rounds.py
@@ -40,12 +40,7 @@ def round_detail(round_id):
     rnd = Round.query.get(round_id)
     
     if rnd:
-        song_ids = rnd.songs.split(',')
-        songs = Song.query.filter(Song.id.in_(song_ids)).all()
-        
-        # Ensure songs are in the same order as in the round's song list
-        song_id_to_obj = {str(song.id): song for song in songs}
-        ordered_songs = [song_id_to_obj.get(song_id) for song_id in song_ids if song_id in song_id_to_obj]
+        ordered_songs = rnd.song_list
         
         email_error = session.pop('email_error', None)  # Retrieve and remove the error message from the session
         
@@ -113,7 +108,14 @@ def round_mp3(round_id):
             return jsonify({'success': False, 'error': 'Authentication required'}), 401
 
     round = Round.query.get_or_404(round_id)
-    song_ids = [int(song_id) for song_id in round.songs.split(',')]
+    song_ids = round.song_id_list
+    if not song_ids:
+        error_msg = 'Round contains no songs. Please add songs before generating an MP3.'
+        current_app.logger.warning(error_msg)
+        if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
+            return jsonify({'success': False, 'error': error_msg}), 400
+        flash(error_msg, 'error')
+        return redirect(url_for('rounds.round_detail', round_id=round_id))
     
     # Create a dict mapping song_id to Song object for all songs in the round
     songs_dict = {song.id: song for song in Song.query.filter(Song.id.in_(song_ids)).all()}
@@ -328,7 +330,9 @@ def generate_pdf(round_id):
             return file.read()
 
     # Get songs data in the correct order
-    song_ids = [int(sid) for sid in rnd.songs.split(',')]
+    song_ids = rnd.song_id_list
+    if not song_ids:
+        return 'Round contains no songs'
     
     # Create a dict mapping song_id to Song object for all songs in the round
     songs_dict = {song.id: song for song in Song.query.filter(Song.id.in_(song_ids)).all()}
@@ -498,6 +502,11 @@ def round_pdf(round_id):
     rnd = db.session.get(Round, round_id)
     if not rnd:
         return jsonify({'success': False, 'error': 'Round not found'})
+    if not rnd.song_id_list:
+        return jsonify({
+            'success': False,
+            'error': 'Round contains no songs',
+        }), 400
     
     # Define path for the PDF file
     pdfs_dir = '/data/pdfs'
@@ -524,8 +533,8 @@ def round_pdf(round_id):
     
     try:
         pdf_data = generate_pdf(round_id)
-        if isinstance(pdf_data, str) and pdf_data.startswith('Round not found'):
-            return jsonify({'success': False, 'error': pdf_data})
+        if isinstance(pdf_data, str):
+            return jsonify({'success': False, 'error': pdf_data}), 400
 
         with open(pdf_file_path, 'wb') as f:
             f.write(pdf_data)
@@ -820,9 +829,20 @@ def export_to_dropbox(round_id):
         except Exception as song_err:
             current_app.logger.error(f"Error getting song list: {str(song_err)}")
             # Fallback method to get songs
-            song_ids = [int(sid) for sid in round_obj.songs.split(',')]
-            songs = Song.query.filter(Song.id.in_(song_ids)).all()
+            song_ids = round_obj.song_id_list
+            songs_by_id = {
+                song.id: song
+                for song in Song.query.filter(Song.id.in_(song_ids)).all()
+            }
+            songs = [
+                songs_by_id[song_id]
+                for song_id in song_ids
+                if song_id in songs_by_id
+            ]
             current_app.logger.debug(f"Fallback method retrieved {len(songs)} songs")
+
+        if not songs:
+            raise Exception('Round contains no songs')
         
         # 1. Export song metadata as JSON
         song_data = []
@@ -888,7 +908,7 @@ def export_to_dropbox(round_id):
             if not round_obj.pdf_generated:
                 current_app.logger.debug("PDF not generated yet, generating now")
                 pdf_data = generate_pdf(round_id)
-                if isinstance(pdf_data, str) and pdf_data.startswith('Round not found'):
+                if isinstance(pdf_data, str):
                     current_app.logger.error(f"Error generating PDF: {pdf_data}")
                     raise Exception(f"Error generating PDF: {pdf_data}")
             else:

--- a/tests/test_extra_coverage.py
+++ b/tests/test_extra_coverage.py
@@ -202,6 +202,20 @@ class TestSaveRoundRoute:
             round_ = Round.query.filter_by(name='Saved Round').first()
             assert round_ is not None
 
+    def test_save_round_rejects_empty_song_selection(self, app, client):
+        """Test that save_round does not persist empty rounds."""
+        _login(app, client)
+
+        response = client.post('/save_round', data={
+            'round_criteria': 'Empty criteria',
+            'round_name': 'Empty Round',
+        }, follow_redirects=True)
+
+        assert response.status_code == 200
+        assert b'at least one song' in response.data
+        with app.app_context():
+            assert Round.query.filter_by(name='Empty Round').first() is None
+
     def test_save_round_increments_used_count(self, app, client):
         """Test that save_round increments used_count for songs."""
         _login(app, client)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -425,6 +425,33 @@ class TestRoundModel:
         result_ids = {s.id for s in result}
         assert result_ids == {s.id for s in songs}
 
+    def test_round_song_list_preserves_saved_order(self, app):
+        """Test Round.song_list returns songs in the saved round order."""
+        songs = self._make_songs(3)
+        ordered_ids = [songs[2].id, songs[0].id, songs[1].id]
+        round_ = Round(
+            round_type='genre',
+            round_criteria_used='Pop',
+            songs=','.join(str(song_id) for song_id in ordered_ids),
+        )
+        db.session.add(round_)
+        db.session.commit()
+
+        assert [song.id for song in round_.song_list] == ordered_ids
+
+    def test_round_song_list_handles_empty_legacy_value(self, app):
+        """Test Round.song_list does not crash for legacy empty rounds."""
+        round_ = Round(
+            round_type='genre',
+            round_criteria_used='Pop',
+            songs='',
+        )
+        db.session.add(round_)
+        db.session.commit()
+
+        assert round_.song_id_list == []
+        assert round_.song_list == []
+
     def test_round_defaults(self, app):
         """Test Round model default values."""
         songs = self._make_songs(1)

--- a/tests/test_rounds_routes.py
+++ b/tests/test_rounds_routes.py
@@ -1,6 +1,7 @@
 """Tests for rounds blueprint routes."""
 import pytest
 import json
+from unittest.mock import patch
 from musicround.models import db, User, Song, Round
 
 
@@ -198,3 +199,59 @@ class TestRoundDownloadRoutes:
         _login(app, client)
         response = client.get('/rounds/download/pdf/round_99999')
         assert response.status_code in (302, 404, 500)
+
+
+class TestLegacyEmptyRoundRoutes:
+    """Tests for legacy rounds with empty song lists."""
+
+    def test_empty_round_mp3_returns_clear_error(self, app, client):
+        """Test MP3 generation does not crash for empty legacy rounds."""
+        _login(app, client)
+        round_id = _create_round(app, [])
+
+        response = client.post(
+            f'/rounds/round/{round_id}/mp3',
+            headers={'X-Requested-With': 'XMLHttpRequest'},
+        )
+
+        assert response.status_code == 400
+        assert response.get_json()['success'] is False
+        assert 'no songs' in response.get_json()['error']
+
+    def test_empty_round_pdf_returns_clear_error(self, app, client):
+        """Test PDF generation does not crash for empty legacy rounds."""
+        _login(app, client)
+        round_id = _create_round(app, [])
+
+        response = client.post(
+            f'/rounds/{round_id}/pdf',
+            headers={'X-Requested-With': 'XMLHttpRequest'},
+        )
+
+        assert response.status_code == 400
+        assert response.get_json()['success'] is False
+        assert 'no songs' in response.get_json()['error']
+
+    def test_empty_round_dropbox_export_returns_clear_error(self, app, client):
+        """Test Dropbox export does not crash for empty legacy rounds."""
+        _login(app, client)
+        round_id = _create_round(app, [])
+        with app.app_context():
+            user = User.query.filter_by(username='roundsuser').one()
+            user.dropbox_token = 'dropbox-access-token'
+            user.dropbox_refresh_token = 'dropbox-refresh-token'
+            db.session.commit()
+
+        with patch(
+            'musicround.helpers.dropbox_helper.refresh_dropbox_token_if_needed',
+            return_value={'success': True, 'message': 'ok'},
+        ), patch('musicround.helpers.dropbox_helper.upload_to_dropbox') as mock_upload:
+            response = client.post(
+                f'/rounds/{round_id}/export-to-dropbox',
+                data={'include_mp3s': 'false', 'include_pdf': 'false'},
+            )
+
+        assert response.status_code == 200
+        assert response.get_json()['success'] is False
+        assert 'no songs' in response.get_json()['message']
+        mock_upload.assert_not_called()


### PR DESCRIPTION
## Summary
- closes #95
- closes #85
- reject saving a manual round when no songs were submitted
- add ordered, empty-token-safe round song parsing on the Round model
- reuse the ordered song list in round detail and Dropbox metadata export
- return clear non-500 errors for legacy empty rounds in MP3, PDF, and Dropbox export paths

## Local validation
- `SECRET_KEY=test-secret-key-for-testing-only AUTOMATION_TOKEN=test-automation-token-for-testing .venv/bin/pytest tests/test_models.py tests/test_extra_coverage.py::TestSaveRoundRoute tests/test_rounds_routes.py -q` -> 75 passed
- `.venv/bin/flake8 musicround/ --count --select=E9,F63,F7,F82 --show-source --statistics` -> 0
- `git diff --check` -> clean
- `SECRET_KEY=test-secret-key-for-testing-only AUTOMATION_TOKEN=test-automation-token-for-testing .venv/bin/pytest tests/ -q` -> 437 passed, 2 skipped
