### PR TITLE
Respect configured database URI

### DIFF
--- a/musicround/__init__.py
+++ b/musicround/__init__.py
@@ -23,6 +23,26 @@ csrf = CSRFProtect()
 # Set up logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
+DEFAULT_DATABASE_DIR = '/data'
+DEFAULT_DATABASE_PATH = os.path.join(DEFAULT_DATABASE_DIR, 'song_data.db')
+
+
+def _configure_database_uri(app):
+    """Use an explicit database URI when configured, otherwise fall back to SQLite."""
+    configured_uri = os.environ.get('SQLALCHEMY_DATABASE_URI') or app.config.get(
+        'SQLALCHEMY_DATABASE_URI'
+    )
+    if configured_uri:
+        app.config['SQLALCHEMY_DATABASE_URI'] = configured_uri
+        return
+
+    if not os.path.exists(DEFAULT_DATABASE_DIR):
+        os.makedirs(DEFAULT_DATABASE_DIR, exist_ok=True)
+    app.config['SQLALCHEMY_DATABASE_URI'] = f'sqlite:///{DEFAULT_DATABASE_PATH}'
+    app.logger.warning(
+        "SQLALCHEMY_DATABASE_URI is not configured; using local SQLite fallback at %s",
+        DEFAULT_DATABASE_PATH,
+    )
 
 def run_migrations():
     """
@@ -114,13 +134,6 @@ def create_app(config=None):
             environ['HTTP_X_FORWARDED_PROTO'] = 'https'
             return self.app(environ, start_response)
     
-    # Create data directory if it doesn't exist
-    data_dir = '/data'
-    if not os.path.exists(data_dir):
-        os.makedirs(data_dir, exist_ok=True)
-      # Set the database file path in the data directory
-    db_path = os.path.join(data_dir, 'song_data.db')
-
     # Configure the app
     app.config.from_object(Config)
     
@@ -131,8 +144,7 @@ def create_app(config=None):
         app.wsgi_app = ForceHTTPSMiddleware(app.wsgi_app)
         app.logger.info("Applying ForceHTTPSMiddleware - all URLs will use HTTPS scheme regardless of headers")
     
-    # Explicitly set the database URI to ensure correct path
-    app.config['SQLALCHEMY_DATABASE_URI'] = f'sqlite:///{db_path}'
+    _configure_database_uri(app)
     
     # Initialize extensions with app
     db.init_app(app)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,20 +3,19 @@ import os
 import sys
 import tempfile
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 # Add project root to path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 
-def _make_app():
+def _make_app(database_uri, monkeypatch):
     """
     Create a Flask application instance suitable for testing.
 
-    The standard create_app() tries to access /data which may not be writable
-    in CI environments.  We redirect that path to a temporary directory during
-    app creation and then reconfigure SQLAlchemy to use an in-memory database
-    for the actual test session.
+    The standard create_app() falls back to /data when no database URI is
+    configured. Tests should use an explicit temporary database so that app
+    startup never touches production-like paths or developer environment DBs.
     """
     # Set required environment variables before importing the app so that config
     # defaults are populated correctly.  Use setdefault so that values provided
@@ -24,46 +23,25 @@ def _make_app():
     os.environ.setdefault('SECRET_KEY', 'test-secret-key-for-testing-only')
     os.environ.setdefault('AUTOMATION_TOKEN', 'test-automation-token-for-testing')
 
+    monkeypatch.setenv('SQLALCHEMY_DATABASE_URI', database_uri)
+
     from musicround import create_app, db
 
-    tmpdir = tempfile.mkdtemp()
-
-    _orig_join = os.path.join
-    _orig_exists = os.path.exists
-    _orig_makedirs = os.makedirs
-
-    def _join(*args):
-        result = _orig_join(*args)
-        if result == '/data/song_data.db':
-            return os.path.join(tmpdir, 'test.db')
-        return result
-
-    def _exists(path):
-        if path == '/data':
-            return True
-        return _orig_exists(path)
-
-    def _makedirs(path, **kwargs):
-        if path == '/data':
-            return
-        return _orig_makedirs(path, **kwargs)
-
-    with patch('os.path.join', side_effect=_join), \
-         patch('os.path.exists', side_effect=_exists), \
-         patch('os.makedirs', side_effect=_makedirs):
-        app = create_app()
+    app = create_app()
 
     return app, db
 
 
 @pytest.fixture
-def app():
+def app(monkeypatch):
     """Create a test Flask application instance."""
-    app, db = _make_app()
+    tmpdir = tempfile.mkdtemp()
+    database_uri = f"sqlite:///{os.path.join(tmpdir, 'test.db')}"
+    app, db = _make_app(database_uri, monkeypatch)
 
     test_config = {
         'TESTING': True,
-        'SQLALCHEMY_DATABASE_URI': 'sqlite:///:memory:',
+        'SQLALCHEMY_DATABASE_URI': database_uri,
         'SQLALCHEMY_TRACK_MODIFICATIONS': False,
         'SECRET_KEY': 'test-secret-key-for-testing-only',
         'AUTOMATION_TOKEN': 'test-automation-token-for-testing',

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -1,0 +1,58 @@
+"""Tests for Flask app factory configuration helpers."""
+from flask import Flask
+
+from musicround import _configure_database_uri
+
+
+def test_configure_database_uri_preserves_explicit_env_uri(monkeypatch):
+    """Test explicit SQLALCHEMY_DATABASE_URI is not overwritten."""
+    monkeypatch.setenv('SQLALCHEMY_DATABASE_URI', 'sqlite:///:memory:')
+    app = Flask(__name__)
+
+    _configure_database_uri(app)
+
+    assert app.config['SQLALCHEMY_DATABASE_URI'] == 'sqlite:///:memory:'
+
+
+def test_configure_database_uri_preserves_explicit_config_uri(monkeypatch):
+    """Test explicit app config URI is not overwritten."""
+    monkeypatch.delenv('SQLALCHEMY_DATABASE_URI', raising=False)
+    app = Flask(__name__)
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'postgresql://db.example/qb'
+
+    _configure_database_uri(app)
+
+    assert app.config['SQLALCHEMY_DATABASE_URI'] == 'postgresql://db.example/qb'
+
+
+def test_configure_database_uri_uses_sqlite_fallback(monkeypatch):
+    """Test fallback SQLite path is only used when no URI is configured."""
+    monkeypatch.delenv('SQLALCHEMY_DATABASE_URI', raising=False)
+    created_paths = []
+    app = Flask(__name__)
+
+    monkeypatch.setattr('musicround.os.path.exists', lambda path: False)
+    monkeypatch.setattr(
+        'musicround.os.makedirs',
+        lambda path, exist_ok=False: created_paths.append((path, exist_ok)),
+    )
+
+    _configure_database_uri(app)
+
+    assert app.config['SQLALCHEMY_DATABASE_URI'] == 'sqlite:////data/song_data.db'
+    assert created_paths == [('/data', True)]
+
+
+def test_create_app_honors_env_database_uri(monkeypatch):
+    """Test create_app keeps SQLALCHEMY_DATABASE_URI from the environment."""
+    from musicround import create_app, db
+
+    monkeypatch.setenv('SQLALCHEMY_DATABASE_URI', 'sqlite:///:memory:')
+    monkeypatch.setenv('IMPORT_WORKERS_ENABLED', 'false')
+
+    app = create_app()
+
+    assert app.config['SQLALCHEMY_DATABASE_URI'] == 'sqlite:///:memory:'
+    with app.app_context():
+        db.session.remove()
+        db.drop_all()


### PR DESCRIPTION
## Summary
- preserve an explicitly configured SQLALCHEMY_DATABASE_URI instead of overwriting it during app startup
- keep the /data SQLite fallback only for unconfigured local starts, with a warning log
- make tests use an explicit temporary database URI and cover env/config/fallback behavior

## Root cause
create_app loaded Config and then unconditionally replaced SQLALCHEMY_DATABASE_URI with sqlite:////data/song_data.db, so production or externally managed database settings were ignored.

## Validation
- SECRET_KEY=test-secret-key-for-testing-only AUTOMATION_TOKEN=test-automation-token-for-testing .venv/bin/pytest tests/test_app_factory.py tests/test_security.py -q
- .venv/bin/flake8 musicround/ tests/conftest.py tests/test_app_factory.py --count --select=E9,F63,F7,F82 --show-source --statistics
- git diff --check
- SECRET_KEY=test-secret-key-for-testing-only AUTOMATION_TOKEN=test-automation-token-for-testing .venv/bin/pytest tests/ -q

Closes #94.
Closes #86.