### PR TITLE
Make app factory tests self-contained

### DIFF
--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -1,5 +1,11 @@
 """Tests for Flask app factory configuration helpers."""
+import os
+
 from flask import Flask
+
+os.environ.setdefault('SECRET_KEY', 'test-secret-key-for-testing-only')
+os.environ.setdefault('AUTOMATION_TOKEN', 'test-automation-token-for-testing')
+os.environ.setdefault('SQLALCHEMY_DATABASE_URI', 'sqlite:///:memory:')
 
 from musicround import _configure_database_uri
 
@@ -45,10 +51,12 @@ def test_configure_database_uri_uses_sqlite_fallback(monkeypatch):
 
 def test_create_app_honors_env_database_uri(monkeypatch):
     """Test create_app keeps SQLALCHEMY_DATABASE_URI from the environment."""
-    from musicround import create_app, db
-
+    monkeypatch.setenv('SECRET_KEY', 'test-secret-key-for-testing-only')
+    monkeypatch.setenv('AUTOMATION_TOKEN', 'test-automation-token-for-testing')
     monkeypatch.setenv('SQLALCHEMY_DATABASE_URI', 'sqlite:///:memory:')
     monkeypatch.setenv('IMPORT_WORKERS_ENABLED', 'false')
+
+    from musicround import create_app, db
 
     app = create_app()
 


### PR DESCRIPTION
## Summary
- Set required app environment defaults before importing musicround in app factory tests
- Move create_app/db import after the test-specific environment setup

## Verification
- git diff --check
- python3 -m py_compile tests/test_app_factory.py
- /tmp/qb-pr125-venv/bin/python -m pytest tests/test_app_factory.py -q (blocked locally on Python 3.14 because pydub expects audioop/pyaudioop; 3 focused tests passed before that app import path)