### PR TITLE
Avoid app factory DB env leakage

### DIFF
--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -5,7 +5,6 @@ from flask import Flask
 
 os.environ.setdefault('SECRET_KEY', 'test-secret-key-for-testing-only')
 os.environ.setdefault('AUTOMATION_TOKEN', 'test-automation-token-for-testing')
-os.environ.setdefault('SQLALCHEMY_DATABASE_URI', 'sqlite:///:memory:')
 
 from musicround import _configure_database_uri
 


### PR DESCRIPTION
## Summary
- remove the module-level SQLALCHEMY_DATABASE_URI default from the app factory tests
- keep only the required app import env defaults at module import time

## Verification
- git diff --check
- python3 -m py_compile tests/test_app_factory.py
- /tmp/qb-pr125-venv/bin/python -m pytest tests/test_app_factory.py -q (blocked locally on Python 3.14 because pydub expects audioop/pyaudioop; 3 focused tests passed before that app import path)