### PR TITLE
Handle legacy Spotify refresh route

### DIFF
--- a/musicround/routes/users.py
+++ b/musicround/routes/users.py
@@ -983,8 +983,16 @@ def update_bearer_token():
 @users_bp.route('/use-refresh-token', methods=['POST'])
 @login_required
 def use_refresh_token():
-    # This will be reviewed and updated for authlib
-    pass
+    """Legacy refresh-token endpoint kept safe for old forms/bookmarks."""
+    current_app.logger.info(
+        "User %s called legacy Spotify refresh-token endpoint; refresh is automatic",
+        current_user.id,
+    )
+    flash(
+        'Spotify tokens are refreshed automatically when needed. Please reconnect Spotify if it is expired.',
+        'info',
+    )
+    return redirect(url_for('users.profile'))
 
 @users_bp.route('/setup')
 @login_required

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -232,6 +232,13 @@ class TestAuthenticatedRoutes:
         response = client.get('/users/profile')
         assert response.status_code == 200
 
+    def test_legacy_use_refresh_token_redirects_when_logged_in(self, app, client):
+        """Legacy refresh-token endpoint must not return None/500."""
+        self._login(app, client)
+        response = client.post('/users/use-refresh-token')
+        assert response.status_code == 302
+        assert response.headers['Location'].endswith('/users/profile')
+
     def test_api_tags_accessible_when_logged_in(self, app, client):
         """Test that API tags endpoint is accessible when logged in."""
         self._login(app, client)


### PR DESCRIPTION
## Summary
- make the legacy `/users/use-refresh-token` POST route return a safe redirect instead of `None`
- explain to the user that Spotify token refresh is automatic and reconnect is needed when expired
- add an authenticated route regression test so the endpoint cannot return a 500 again

## Root cause
The route was still registered after the Authlib/token-management migration, but the view body only contained `pass`. Flask treats a view returning `None` as a runtime error.

## Validation
- SECRET_KEY=test-secret-key-for-testing-only AUTOMATION_TOKEN=test-automation-token-for-testing .venv/bin/pytest tests/test_routes.py -q
- .venv/bin/flake8 musicround/routes/users.py tests/test_routes.py --count --select=E9,F63,F7,F82 --show-source --statistics
- git diff --check
- SECRET_KEY=test-secret-key-for-testing-only AUTOMATION_TOKEN=test-automation-token-for-testing .venv/bin/pytest tests/ -q

Closes #88.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The legacy refresh-token page now redirects users back to their profile instead of failing silently.
  - Users see a clear message explaining that Spotify tokens refresh automatically, and are prompted to reconnect if needed.
  - Added coverage to confirm the signed-in refresh-token route returns the expected redirect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->