### PR TITLE
Wrap Spotify refresh flash message

### DIFF
--- a/musicround/routes/users.py
+++ b/musicround/routes/users.py
@@ -989,7 +989,8 @@ def use_refresh_token():
         current_user.id,
     )
     flash(
-        'Spotify tokens are refreshed automatically when needed. Please reconnect Spotify if it is expired.',
+        'Spotify tokens are refreshed automatically when needed. '
+        'Please reconnect Spotify if it is expired.',
         'info',
     )
     return redirect(url_for('users.profile'))


### PR DESCRIPTION
## Summary
- wrap the legacy Spotify refresh flash message to keep the line under the Python style limit
- no behavior change

## Verification
- git diff --check
- python3 -m py_compile musicround/routes/users.py