### PR TITLE
Fix Deezer playlist import counts

### DIFF
--- a/musicround/helpers/import_helper.py
+++ b/musicround/helpers/import_helper.py
@@ -330,8 +330,11 @@ class ImportHelper:
                     }
             elif item_type.lower() == 'playlist':
                 try:
-                    imported_songs = deezer_client.import_playlist(item_id, lastfm_api_key=lastfm_api_key)
-                    if not imported_songs or len(imported_songs) == 0:
+                    result = deezer_client.import_playlist(item_id, lastfm_api_key=lastfm_api_key)
+                    imported_count = result.get('imported_count', 0)
+                    skipped_count = result.get('skipped_count', 0)
+
+                    if imported_count == 0 and skipped_count == 0:
                         current_app.logger.warning(f"Deezer playlist import returned empty result for playlist ID: {item_id}")
                         return {
                             'imported_count': 0,
@@ -340,8 +343,8 @@ class ImportHelper:
                             'errors': [f"No songs found in Deezer playlist {item_id} or playlist import failed."]
                         }
                     return {
-                        'imported_count': len(imported_songs),
-                        'skipped_count': 0,
+                        'imported_count': imported_count,
+                        'skipped_count': skipped_count,
                         'error_count': 0,
                         'errors': []
                     }

--- a/tests/test_import_helper.py
+++ b/tests/test_import_helper.py
@@ -1,0 +1,61 @@
+"""Tests for unified import helper behavior."""
+from musicround.helpers.import_helper import ImportHelper
+
+
+class DeezerPlaylistStub:
+    """Minimal Deezer client stub for playlist import result contracts."""
+
+    def __init__(self, result):
+        self.result = result
+        self.calls = []
+
+    def import_playlist(self, playlist_id, lastfm_api_key=None):
+        self.calls.append((playlist_id, lastfm_api_key))
+        return self.result
+
+
+class TestImportHelperDeezer:
+    """Tests for Deezer import result handling."""
+
+    def test_deezer_playlist_uses_reported_import_and_skip_counts(self, app):
+        """Playlist imports must report DeezerClient's actual counters."""
+        result = {
+            'imported_songs': ['song-a', 'song-b'],
+            'skipped_songs': ['duplicate-a'],
+            'imported_count': 2,
+            'skipped_count': 1,
+        }
+        deezer = DeezerPlaylistStub(result)
+
+        with app.app_context():
+            app.config['deezer'] = deezer
+            app.config['LASTFM_API_KEY'] = 'lastfm-test-key'
+
+            response = ImportHelper.import_item('deezer', 'playlist', 'playlist-123')
+
+        assert response == {
+            'imported_count': 2,
+            'skipped_count': 1,
+            'error_count': 0,
+            'errors': [],
+        }
+        assert deezer.calls == [('playlist-123', 'lastfm-test-key')]
+
+    def test_deezer_playlist_empty_counts_return_error(self, app):
+        """An empty Deezer playlist result should be treated as no songs found."""
+        deezer = DeezerPlaylistStub({
+            'imported_songs': [],
+            'skipped_songs': [],
+            'imported_count': 0,
+            'skipped_count': 0,
+        })
+
+        with app.app_context():
+            app.config['deezer'] = deezer
+
+            response = ImportHelper.import_item('deezer', 'playlist', 'playlist-empty')
+
+        assert response['imported_count'] == 0
+        assert response['skipped_count'] == 0
+        assert response['error_count'] == 1
+        assert 'No songs found in Deezer playlist playlist-empty' in response['errors'][0]


### PR DESCRIPTION
## Summary
- make Deezer playlist imports read `imported_count` and `skipped_count` from the DeezerClient result dict
- keep the empty playlist/import failure branch only when both counters are zero
- add regression coverage for imported and skipped playlist counts

## Root cause
The playlist branch treated `deezer_client.import_playlist()` as if it returned a list. It actually returns a dict, so `len(result)` reported the number of dict keys and `skipped_count` was always forced to zero.

## Validation
- SECRET_KEY=test-secret-key-for-testing-only AUTOMATION_TOKEN=test-automation-token-for-testing .venv/bin/pytest tests/test_import_helper.py tests/test_deezer_client.py -q
- .venv/bin/flake8 musicround/helpers/import_helper.py tests/test_import_helper.py --count --select=E9,F63,F7,F82 --show-source --statistics
- git diff --check
- SECRET_KEY=test-secret-key-for-testing-only AUTOMATION_TOKEN=test-automation-token-for-testing .venv/bin/pytest tests/ -q

Closes #98.