### PR TITLE
[codex] Fix Deezer playlist generate import

### DIFF
--- a/musicround/deezer_client.py
+++ b/musicround/deezer_client.py
@@ -315,12 +315,14 @@ class DeezerClient:
         tracks = self.get_playlist_tracks(playlist_id)
         imported_songs = []
         skipped_songs = []
+        playlist_songs = []
         
         for track in tracks:
             track_id = track.get('id')
             if track_id:
                 song, was_new = self.import_track(track_id, lastfm_api_key)
                 if song:
+                    playlist_songs.append(song)
                     if was_new:
                         imported_songs.append(song)
                     else:
@@ -330,6 +332,8 @@ class DeezerClient:
                 time.sleep(0.2)
         
         return {
+            'songs': playlist_songs,
+            'song_ids': [song.id for song in playlist_songs if getattr(song, 'id', None) is not None],
             'imported_songs': imported_songs,
             'skipped_songs': skipped_songs,
             'imported_count': len(imported_songs),

--- a/musicround/helpers/import_helper.py
+++ b/musicround/helpers/import_helper.py
@@ -333,6 +333,11 @@ class ImportHelper:
                     result = deezer_client.import_playlist(item_id, lastfm_api_key=lastfm_api_key)
                     imported_count = result.get('imported_count', 0)
                     skipped_count = result.get('skipped_count', 0)
+                    song_ids = result.get('song_ids') or [
+                        song.id
+                        for song in result.get('songs', [])
+                        if getattr(song, 'id', None) is not None
+                    ]
 
                     if imported_count == 0 and skipped_count == 0:
                         current_app.logger.warning(f"Deezer playlist import returned empty result for playlist ID: {item_id}")
@@ -346,7 +351,8 @@ class ImportHelper:
                         'imported_count': imported_count,
                         'skipped_count': skipped_count,
                         'error_count': 0,
-                        'errors': []
+                        'errors': [],
+                        'song_ids': song_ids,
                     }
                 except Exception as e:
                     current_app.logger.error(f"Exception occurred while importing Deezer playlist {item_id}: {str(e)}")

--- a/musicround/routes/generate.py
+++ b/musicround/routes/generate.py
@@ -329,21 +329,57 @@ def get_songs_from_deezer_playlist(playlist_id):
     Fetch songs from a Deezer playlist, properly import them with metadata, and return them
     """
     try:
-        deezer_client = current_app.config['deezer']
-        songs_per_round = current_app.config.get('SONGS_PER_ROUND', 10)
-        
-        imported_songs = ImportHelper.import_item(
-            item_id=playlist_id,
-            item_type='playlist',
-            source='deezer',
-            deezer_client=deezer_client
-        )
-
-        if not imported_songs:
-            current_app.logger.warning(f"No songs returned from ImportHelper.import_item for Deezer playlist {playlist_id}")
+        if not current_app.config.get('deezer'):
+            current_app.logger.error("Deezer client not configured for playlist import.")
             return []
 
-        return imported_songs[:songs_per_round]
+        songs_per_round = current_app.config.get('SONGS_PER_ROUND', 10)
+
+        import_result = ImportHelper.import_item(
+            service_name='deezer',
+            item_type='playlist',
+            item_id=playlist_id,
+        )
+
+        if (
+            not import_result
+            or (
+                import_result.get('error_count', 0) > 0
+                and import_result.get('imported_count', 0) == 0
+                and import_result.get('skipped_count', 0) == 0
+            )
+        ):
+            current_app.logger.warning(f"No songs imported from Deezer playlist {playlist_id}: {import_result}")
+            return []
+
+        song_ids = []
+        seen_song_ids = set()
+        for song_id in import_result.get('song_ids', []):
+            if song_id is None:
+                continue
+            try:
+                song_id = int(song_id)
+            except (TypeError, ValueError):
+                continue
+            if song_id in seen_song_ids:
+                continue
+            song_ids.append(song_id)
+            seen_song_ids.add(song_id)
+
+        if not song_ids:
+            current_app.logger.warning(f"No song IDs returned after importing Deezer playlist {playlist_id}")
+            return []
+
+        songs_by_id = {
+            song.id: song
+            for song in Song.query.filter(Song.id.in_(song_ids)).all()
+        }
+        ordered_songs = [songs_by_id[song_id] for song_id in song_ids if song_id in songs_by_id]
+        if not ordered_songs:
+            current_app.logger.warning(f"No imported songs resolved for Deezer playlist {playlist_id}")
+            return []
+
+        return ordered_songs[:songs_per_round]
     except Exception as e:
         current_app.logger.error(f"Error fetching or importing Deezer playlist {playlist_id}: {e}")
         import traceback

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -332,3 +332,51 @@ class TestBuildMusicRoundRoute:
         _login(app, client)
         response = client.get('/build-music-round')
         assert response.status_code == 200
+
+    def test_import_deezer_playlist_returns_imported_songs(self, app, client, monkeypatch):
+        """Test Deezer playlist imports from the Generate page return songs for review."""
+        with app.app_context():
+            app.config['deezer'] = object()
+            app.config['SONGS_PER_ROUND'] = 2
+            second_song = Song(title='Second In Database', artist='Artist B', deezer_id=501, source='deezer')
+            first_song = Song(title='First In Playlist', artist='Artist A', deezer_id=502, source='deezer')
+            missing_from_playlist = Song(title='Not In Playlist', artist='Artist C', deezer_id=503, source='deezer')
+            db.session.add_all([second_song, first_song, missing_from_playlist])
+            db.session.commit()
+            first_song_id = first_song.id
+            second_song_id = second_song.id
+
+        import_calls = []
+
+        def fake_import_item(**kwargs):
+            import_calls.append(kwargs)
+            return {
+                'imported_count': 1,
+                'skipped_count': 1,
+                'error_count': 0,
+                'errors': [],
+                'song_ids': [first_song_id, second_song_id, 999999],
+            }
+
+        monkeypatch.setattr('musicround.routes.generate.ImportHelper.import_item', fake_import_item)
+        _login(app, client)
+
+        response = client.post(
+            '/import-playlist',
+            data={
+                'platform': 'deezer',
+                'playlist_url': 'https://www.deezer.com/playlist/playlist123?utm=test',
+                'round_name': 'Deezer Regression',
+            },
+        )
+
+        body = response.get_data(as_text=True)
+        assert response.status_code == 200
+        assert import_calls == [{
+            'service_name': 'deezer',
+            'item_type': 'playlist',
+            'item_id': 'playlist123',
+        }]
+        assert body.index('First In Playlist') < body.index('Second In Database')
+        assert 'Not In Playlist' not in body
+        assert 'Deezer Playlist: playlist123' in body

--- a/tests/test_import_helper.py
+++ b/tests/test_import_helper.py
@@ -24,6 +24,7 @@ class TestImportHelperDeezer:
             'skipped_songs': ['duplicate-a'],
             'imported_count': 2,
             'skipped_count': 1,
+            'song_ids': [10, 11, 12],
         }
         deezer = DeezerPlaylistStub(result)
 
@@ -38,6 +39,7 @@ class TestImportHelperDeezer:
             'skipped_count': 1,
             'error_count': 0,
             'errors': [],
+            'song_ids': [10, 11, 12],
         }
         assert deezer.calls == [('playlist-123', 'lastfm-test-key')]
 


### PR DESCRIPTION
## Summary
- fix the Generate page Deezer playlist import to call `ImportHelper.import_item` with the current contract
- rebuild the round candidate songs from Deezer playlist track IDs in playlist order after import
- add a regression test for the real `/import-playlist` Deezer POST flow

## Root Cause
The Generate page still used the old Deezer import helper signature (`source`, `deezer_client`) and then treated import statistics as song objects. That made valid Deezer playlist imports fall through as empty rounds.

## Validation
- `SECRET_KEY=test-secret-key-for-testing-only AUTOMATION_TOKEN=test-automation-token-for-testing .venv/bin/python -m pytest tests/test_generate.py -q`
- `SECRET_KEY=test-secret-key-for-testing-only AUTOMATION_TOKEN=test-automation-token-for-testing .venv/bin/python -m pytest -q`

Closes #83
Closes #93

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Playlist imports now preserve the original Deezer track order in the results.
  * Only valid playlist tracks are included, with clearer handling when tracks can’t be matched.
  * Import results now respect the configured maximum number of songs per round.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->