### PR TITLE
[codex] Fix Spotify track import commit

### DIFF
--- a/musicround/helpers/import_helper.py
+++ b/musicround/helpers/import_helper.py
@@ -381,7 +381,7 @@ class ImportHelper:
             }
 
     @staticmethod
-    def import_spotify_track(sp, track_id):
+    def import_spotify_track(sp, track_id, commit=True):
         """Import a single track from Spotify"""
         result = {
             'imported_count': 0,
@@ -555,7 +555,8 @@ class ImportHelper:
                 # Fetch audio features
                 ImportHelper._fetch_audio_features_for_song(sp, song, track_id, token=authlib_token_for_request) # Pass token
                 
-                # Final commit                db.session.commit()
+                if commit:
+                    db.session.commit()
                 result['imported_count'] += 1
                 result['song_id'] = song.id  # Add the song ID to the result
                 current_app.logger.info(f"Successfully imported Spotify track {track_id} as '{song.title}' with ID {song.id}")
@@ -677,7 +678,7 @@ class ImportHelper:
                         continue
                     
                     # Call import_spotify_track. It will handle its own token now.
-                    track_import_result = ImportHelper.import_spotify_track(sp, track_id)
+                    track_import_result = ImportHelper.import_spotify_track(sp, track_id, commit=False)
                     
                     result['imported_count'] += track_import_result.get('imported_count', 0)
                     result['skipped_count'] += track_import_result.get('skipped_count', 0)
@@ -805,7 +806,7 @@ class ImportHelper:
                         result['error_count'] +=1
                         continue
                       # Call import_spotify_track. It will handle its own token.
-                    track_import_result = ImportHelper.import_spotify_track(sp, track_id)
+                    track_import_result = ImportHelper.import_spotify_track(sp, track_id, commit=False)
                     
                     result['imported_count'] += track_import_result.get('imported_count', 0)
                     result['skipped_count'] += track_import_result.get('skipped_count', 0)

--- a/tests/test_import_songs_routes.py
+++ b/tests/test_import_songs_routes.py
@@ -1,0 +1,85 @@
+"""Tests for manual song import routes."""
+from datetime import datetime, timedelta
+
+from musicround.models import Song, User, db
+
+
+class FakeSpotifyResponse:
+    """Minimal response object for Authlib-style Spotify client calls."""
+
+    def __init__(self, payload):
+        self.payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self.payload
+
+
+class FakeSpotifyClient:
+    """Spotify client stub that returns one importable track."""
+
+    token = None
+
+    def get(self, path, token=None):
+        assert path == 'tracks/spotify-track-1'
+        return FakeSpotifyResponse({
+            'id': 'spotify-track-1',
+            'name': 'Committed Track',
+            'artists': [{'name': 'Reliable Artist'}],
+            'album': {
+                'name': 'Reliable Album',
+                'release_date': '1999-01-01',
+                'images': [{'url': 'https://example.com/cover.jpg'}],
+            },
+            'external_ids': {},
+            'preview_url': 'https://example.com/preview.mp3',
+            'popularity': 80,
+        })
+
+
+def _login_spotify_user(client):
+    user = User(username='spotifyimporter', email='spotifyimporter@example.com')
+    user.password = 'ImportPass123!'
+    user.spotify_token = 'spotify-access-token'
+    user.spotify_refresh_token = 'spotify-refresh-token'
+    user.spotify_token_expiry = datetime.now() + timedelta(hours=1)
+    db.session.add(user)
+    db.session.commit()
+
+    client.post('/users/login', data={
+        'username': 'spotifyimporter',
+        'password': 'ImportPass123!',
+    })
+
+
+class TestSpotifySongImportRoute:
+    """Regression tests for the single-track Spotify import flow."""
+
+    def test_spotify_track_import_commits_created_song(self, app, client, monkeypatch):
+        """A successful single-track import must survive request session cleanup."""
+        from musicround.routes import import_songs
+
+        with app.app_context():
+            _login_spotify_user(client)
+
+        monkeypatch.setattr(import_songs, 'get_spotify_token', lambda: ('spotify-access-token', 'user'))
+        monkeypatch.setattr(import_songs.oauth, 'spotify', FakeSpotifyClient(), raising=False)
+        monkeypatch.setattr(
+            'musicround.helpers.import_helper.ImportHelper._fetch_audio_features_for_song',
+            lambda *args, **kwargs: None,
+        )
+
+        response = client.post('/import/song', data={'song_id': 'spotify-track-1'})
+
+        assert response.status_code == 302
+        assert response.headers['Location'].endswith('/view-songs')
+
+        with app.app_context():
+            db.session.remove()
+            song = Song.query.filter_by(spotify_id='spotify-track-1').one_or_none()
+
+        assert song is not None
+        assert song.title == 'Committed Track'
+        assert song.artist == 'Reliable Artist'


### PR DESCRIPTION
## Summary
- make standalone Spotify track imports commit the newly created song
- keep album and playlist imports on their existing batch-commit behavior
- add a route-level regression test proving `/import/song` persists after request session cleanup

## Root Cause
The single-track Spotify importer had `db.session.commit()` accidentally embedded inside a comment, so the route could report success after a flush while the request cleanup rolled the new song back.

## Validation
- `SECRET_KEY=test-secret-key-for-testing-only AUTOMATION_TOKEN=test-automation-token-for-testing .venv/bin/python -m pytest tests/test_import_songs_routes.py tests/test_import_queue.py -q`
- `SECRET_KEY=test-secret-key-for-testing-only AUTOMATION_TOKEN=test-automation-token-for-testing .venv/bin/python -m pytest -q`

Closes #92