### PR TITLE
[codex] Fix migration drift for song and round columns

### DIFF
--- a/migrations/add_round_generation_status.py
+++ b/migrations/add_round_generation_status.py
@@ -1,0 +1,42 @@
+"""Add generated-asset status fields to Round."""
+
+import logging
+
+from sqlalchemy import inspect, text
+
+
+def run_migration():
+    try:
+        from musicround import db
+
+        inspector = inspect(db.engine)
+        existing_columns = [column["name"] for column in inspector.get_columns("round")]
+        columns = {
+            "mp3_generated": "BOOLEAN DEFAULT 0",
+            "pdf_generated": "BOOLEAN DEFAULT 0",
+            "last_generated_at": "DATETIME",
+        }
+
+        changes_made = False
+        with db.engine.connect() as conn:
+            for column_name, column_type in columns.items():
+                if column_name in existing_columns:
+                    continue
+                conn.execute(text(f"ALTER TABLE round ADD COLUMN {column_name} {column_type}"))
+                changes_made = True
+            if changes_made:
+                conn.commit()
+
+        if changes_made:
+            logging.info("Migration add_round_generation_status completed successfully")
+            return True
+        logging.info("No changes were needed")
+        return None
+    except Exception as exc:
+        logging.error("Migration add_round_generation_status failed: %s", exc)
+        return False
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    run_migration()

--- a/migrations/add_song_fields.py
+++ b/migrations/add_song_fields.py
@@ -16,7 +16,7 @@ depends_on = None
 
 def upgrade():
     # Add new columns to the song table
-    op.add_column('song', sa.Column('isrc', sa.String(50), nullable=True))
+    op.add_column('song', sa.Column('isrc', sa.String(20), nullable=True))
     op.add_column('song', sa.Column('album_name', sa.String(100), nullable=True))
     op.add_column('song', sa.Column('metadata_sources', sa.String(100), nullable=True))
     op.add_column('song', sa.Column('import_date', sa.DateTime, nullable=True))
@@ -92,6 +92,7 @@ def run_migration():
         
         # Define the new columns to add
         new_columns = [
+            ("isrc", "VARCHAR(20)"),
             ("album_name", "VARCHAR(200)"),
             ("metadata_sources", "VARCHAR(500)"),
             ("import_date", "DATETIME"),
@@ -106,6 +107,13 @@ def run_migration():
                 logger.info(f"Added column: {column_name} {column_type}")
             else:
                 logger.info(f"Column already exists: {column_name}")
+
+        indexes = [row[1] for row in cursor.execute("PRAGMA index_list(song)").fetchall()]
+        if "ix_song_isrc" not in indexes:
+            cursor.execute("CREATE INDEX ix_song_isrc ON song (isrc)")
+            logger.info("Added index: ix_song_isrc")
+        else:
+            logger.info("Index already exists: ix_song_isrc")
         
         # Commit changes and close connection
         conn.commit()

--- a/musicround/models.py
+++ b/musicround/models.py
@@ -252,7 +252,7 @@ class Round(db.Model):
     name = db.Column(db.String(200), nullable=True)  # Optional name for the round
     round_type = db.Column(db.String(50), nullable=False)
     round_criteria_used = db.Column(db.String(500), nullable=False)
-    songs = db.Column(db.Text, nullable=False)  # JSON string of song IDs in order
+    songs = db.Column(db.Text, nullable=False)  # Comma-separated song IDs in saved order
     genre = db.Column(db.String(100))
     decade = db.Column(db.String(10))
     tag = db.Column(db.String(50))

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,0 +1,92 @@
+"""Regression tests for hand-written database migrations."""
+
+import sqlite3
+
+from flask import Flask
+
+from musicround import db
+from musicround.models import Round, Song
+
+
+def _legacy_app(database_path):
+    app = Flask(__name__)
+    app.config.update(
+        SQLALCHEMY_DATABASE_URI=f"sqlite:///{database_path}",
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+        SECRET_KEY="test-secret-key-for-testing-only",
+        AUTOMATION_TOKEN="test-automation-token-for-testing",
+    )
+    db.init_app(app)
+    return app
+
+
+def _column_names(database_path, table_name):
+    with sqlite3.connect(database_path) as conn:
+        return [column[1] for column in conn.execute(f"PRAGMA table_info({table_name})")]
+
+
+def test_add_song_fields_adds_model_isrc_to_legacy_song_table(tmp_path):
+    """Legacy databases upgraded by run_migration get Song.isrc."""
+    database_path = tmp_path / "legacy-song.db"
+    with sqlite3.connect(database_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE song (
+                id INTEGER PRIMARY KEY,
+                title VARCHAR(200) NOT NULL,
+                artist VARCHAR(200) NOT NULL
+            )
+            """
+        )
+
+    app = _legacy_app(database_path)
+    with app.app_context():
+        from migrations import add_song_fields
+
+        assert add_song_fields.run_migration() is True
+
+    columns = _column_names(database_path, "song")
+    assert "isrc" in columns
+    assert Song.__table__.columns["isrc"].type.length == 20
+
+    with sqlite3.connect(database_path) as conn:
+        indexes = [row[1] for row in conn.execute("PRAGMA index_list(song)").fetchall()]
+    assert "ix_song_isrc" in indexes
+
+
+def test_add_round_generation_status_adds_model_columns_to_legacy_round_table(tmp_path):
+    """Legacy round tables get generated-asset status columns."""
+    database_path = tmp_path / "legacy-round.db"
+    with sqlite3.connect(database_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE round (
+                id INTEGER PRIMARY KEY,
+                round_type VARCHAR(50) NOT NULL,
+                round_criteria_used VARCHAR(500) NOT NULL,
+                songs TEXT NOT NULL
+            )
+            """
+        )
+
+    app = _legacy_app(database_path)
+    with app.app_context():
+        from migrations import add_round_generation_status
+
+        assert add_round_generation_status.run_migration() is True
+
+    columns = set(_column_names(database_path, "round"))
+    expected_columns = {"mp3_generated", "pdf_generated", "last_generated_at"}
+    assert expected_columns.issubset(columns)
+    assert expected_columns.issubset(Round.__table__.columns.keys())
+
+
+def test_round_songs_comment_matches_storage_behavior():
+    """Round.songs remains documented and parsed as comma-separated IDs."""
+    round_ = Round(
+        round_type="manual",
+        round_criteria_used="test",
+        songs="1, 2,not-an-id,3",
+    )
+
+    assert round_.song_id_list == [1, 2, 3]


### PR DESCRIPTION
## Summary
- add `Song.isrc` to the real `add_song_fields.run_migration()` path and align the dead Alembic column length with the model
- add a dedicated migration for `Round.mp3_generated`, `Round.pdf_generated`, and `Round.last_generated_at`
- correct the `Round.songs` model comment to document the actual comma-separated storage format
- add regression tests that upgrade legacy song and round tables

## Root Cause
The app migration runner only executes each migration script's `run_migration()` function. `Song.isrc` existed only in the unused Alembic-style `upgrade()` path, and the generated-asset Round columns had no migration at all, so older databases could miss columns that current routes and helpers expect.

## Validation
- `SECRET_KEY=test-secret-key-for-testing-only AUTOMATION_TOKEN=test-automation-token-for-testing .venv/bin/python -m pytest tests/test_migrations.py tests/test_models.py -q`
- `SECRET_KEY=test-secret-key-for-testing-only AUTOMATION_TOKEN=test-automation-token-for-testing .venv/bin/python -m pytest -q`
- `.venv/bin/python -m flake8 musicround/ --count --select=E9,F63,F7,F82 --show-source --statistics`

Closes #102