### PR TITLE
[codex] Fix Spotify import token fallback

### DIFF
--- a/musicround/helpers/import_helper.py
+++ b/musicround/helpers/import_helper.py
@@ -1,24 +1,13 @@
 """
 Unified import helper for importing music content across different services.
 This module provides consistent import functionality for tracks, albums, and playlists
-from various music streaming services like Spoti                try:
-                    imported_songs = ImportHelper.import_spotify_playlist(spotify_client, item_id)
-                    if not imported_songs or imported_songs.get('imported_count', 0) == 0:
-                        current_app.logger.warning(f"Spotify playlist import returned empty result for playlist ID: {item_id}")
-                        return {
-                            'imported_count': 0,
-                            'skipped_count': 0,
-                            'error_count': 1,
-                            'errors': [f"No songs found in Spotify playlist {item_id} or playlist import failed."]
-                        }
-                    return imported_songser.
+from various music streaming services like Spotify and Deezer.
 """
 import json
-import logging
 import secrets
 import string
 import traceback
-from flask import current_app, flash, session
+from flask import current_app
 from flask_login import current_user
 from authlib.integrations.base_client.errors import MissingTokenError # Corrected import path
 from httpx import HTTPStatusError
@@ -44,6 +33,87 @@ def generate_token(length=32):
 
 class ImportHelper:
     """Unified helper for importing music content from different services."""
+
+    @staticmethod
+    def _authenticated_current_user():
+        """Return the active user when a request context has one."""
+        try:
+            if current_user and current_user.is_authenticated:
+                return current_user
+        except RuntimeError:
+            return None
+        return None
+
+    @staticmethod
+    def _token_expiry_timestamp(expiry):
+        """Convert stored Spotify expiry values into Authlib's timestamp format."""
+        if not expiry:
+            return None
+        if isinstance(expiry, datetime):
+            return int(expiry.timestamp())
+        try:
+            return int(datetime.fromisoformat(str(expiry)).timestamp())
+        except (TypeError, ValueError):
+            current_app.logger.warning("Could not parse Spotify token expiry value.")
+            return None
+
+    @staticmethod
+    def _coerce_spotify_auth_token(token):
+        """Normalize explicit Spotify tokens into an Authlib token dict."""
+        if not token:
+            return None
+        if isinstance(token, dict):
+            normalized = dict(token)
+            if normalized.get('access_token'):
+                normalized.setdefault('token_type', 'Bearer')
+                return normalized
+            return None
+        return {
+            'access_token': token,
+            'token_type': 'Bearer',
+        }
+
+    @staticmethod
+    def _resolve_spotify_auth_token(token=None):
+        """Resolve Spotify auth via explicit token, manual session, user token, or system fallback."""
+        explicit_token = ImportHelper._coerce_spotify_auth_token(token)
+        if explicit_token:
+            return explicit_token
+
+        from musicround.helpers.spotify_helper import get_spotify_token
+
+        access_token, token_source = get_spotify_token()
+        if not access_token:
+            return None
+
+        auth_token = {
+            'access_token': access_token,
+            'token_type': 'Bearer',
+        }
+        user = ImportHelper._authenticated_current_user()
+        if token_source == 'user' and user:
+            auth_token['refresh_token'] = user.spotify_refresh_token
+            auth_token['expires_at'] = ImportHelper._token_expiry_timestamp(user.spotify_token_expiry)
+        return auth_token
+
+    @staticmethod
+    def _save_refreshed_spotify_token(sp, token_to_use, context):
+        """Persist refreshed user tokens without treating manual/system fallback tokens as user tokens."""
+        if not sp.token or not token_to_use:
+            return token_to_use
+        if sp.token.get('access_token') == token_to_use.get('access_token'):
+            return token_to_use
+
+        user = ImportHelper._authenticated_current_user()
+        if not user or not token_to_use.get('refresh_token'):
+            return sp.token
+
+        current_app.logger.info("Spotify token refreshed during %s for user %s.", context, user.id)
+        if update_oauth_tokens(user, sp.token, 'spotify'):
+            current_app.logger.info("Refreshed Spotify token saved for user %s during %s.", user.id, context)
+        else:
+            current_app.logger.error("Failed to save refreshed Spotify token for user %s during %s.", user.id, context)
+        return sp.token
 
     @staticmethod
     def _create_song_from_spotify(track_info):
@@ -82,31 +152,10 @@ class ImportHelper:
             current_app.logger.warning(f"Cannot fetch audio features: Spotify track ID missing for song {song_obj.title if song_obj else 'Unknown'}.")
             return
 
-        if not token and (not current_user or not current_user.is_authenticated or not current_user.spotify_token):
-            current_app.logger.error(f"Cannot fetch audio features for {spotify_track_id}: User not authenticated or no Spotify token, and no explicit token passed.")
-            return
-        
-        # Construct token if not passed explicitly but current_user is available
-        # This provides a fallback if the calling context didn't pass it but expects this method to handle it.
-        # However, for consistency, it's better if the caller (import_spotify_track) always passes it.
-        token_to_use = token
+        token_to_use = ImportHelper._resolve_spotify_auth_token(token)
         if not token_to_use:
-            expires_at_timestamp = None
-            if current_user.spotify_token_expiry:
-                if isinstance(current_user.spotify_token_expiry, datetime):
-                    expires_at_timestamp = int(current_user.spotify_token_expiry.timestamp())
-                else:
-                    try:
-                        expires_at_timestamp = int(datetime.fromisoformat(str(current_user.spotify_token_expiry)).timestamp())
-                    except ValueError:
-                        pass # Logged by caller
-            token_to_use = {
-                'access_token': current_user.spotify_token,
-                'refresh_token': current_user.spotify_refresh_token,
-                'token_type': 'Bearer',
-                'expires_at': expires_at_timestamp
-            }
-            current_app.logger.info(f"Constructed token within _fetch_audio_features_for_song for {spotify_track_id}")
+            current_app.logger.error(f"Cannot fetch audio features for {spotify_track_id}: no Spotify token available.")
+            return
 
         original_access_token = token_to_use.get('access_token') if token_to_use else None
 
@@ -117,12 +166,11 @@ class ImportHelper:
             features = audio_features_resp.json()
 
             if sp.token and original_access_token and sp.token.get('access_token') != original_access_token:
-                current_app.logger.info(f"Spotify token refreshed during _fetch_audio_features for {spotify_track_id}, user {current_user.id}.")
-                if update_oauth_tokens(current_user, sp.token, 'spotify'):
-                    # token_to_use = sp.token # Update local token if it were to be used again in this function
-                    current_app.logger.info(f"Refreshed Spotify token saved (audio features) for user {current_user.id}.")
-                else:
-                    current_app.logger.error(f"Failed to save refreshed Spotify token (audio features) for user {current_user.id}.")
+                ImportHelper._save_refreshed_spotify_token(
+                    sp,
+                    token_to_use,
+                    f"audio feature fetch for {spotify_track_id}",
+                )
 
             if features:
                 song_obj.danceability = features.get('danceability')
@@ -198,7 +246,7 @@ class ImportHelper:
                 current_app.logger.info(f"Added tag '{tag.name}' to song '{song.title}'")
 
     @staticmethod
-    def import_item(service_name, item_type, item_id, oauth_spotify=None): # Added oauth_spotify parameter
+    def import_item(service_name, item_type, item_id, oauth_spotify=None, spotify_token=None): # Added oauth_spotify parameter
         """
         Generic import function to import items from various services.
         
@@ -207,6 +255,7 @@ class ImportHelper:
             item_type (str): The type of item to import (e.g., 'track', 'album', 'playlist').
             item_id (str): The ID of the item to import.
             oauth_spotify: Optional Authlib Spotify client instance.
+            spotify_token: Optional already-resolved Spotify access token or Authlib token dict.
             
         Returns:
             dict: A dictionary containing import statistics (imported_count, skipped_count, error_count, errors).
@@ -224,11 +273,20 @@ class ImportHelper:
                     'error_count': 1,
                     'errors': ["Spotify client not configured or passed correctly."]
                 }
+            auth_token = ImportHelper._resolve_spotify_auth_token(spotify_token)
+            if not auth_token:
+                current_app.logger.error("No usable Spotify token available for import.")
+                return {
+                    'imported_count': 0,
+                    'skipped_count': 0,
+                    'error_count': 1,
+                    'errors': ["No usable Spotify token available."]
+                }
             if item_type.lower() == 'track':
-                return ImportHelper.import_spotify_track(spotify_client, item_id)
+                return ImportHelper.import_spotify_track(spotify_client, item_id, token=auth_token)
             elif item_type.lower() == 'album':
                 try:
-                    imported_songs = ImportHelper.import_spotify_album(spotify_client, item_id)
+                    imported_songs = ImportHelper.import_spotify_album(spotify_client, item_id, token=auth_token)
                     if not imported_songs or len(imported_songs) == 0:
                         current_app.logger.warning(f"Spotify album import returned empty result for album ID: {item_id}")
                         return {
@@ -249,7 +307,7 @@ class ImportHelper:
                     }
             elif item_type.lower() == 'playlist':
                 try:
-                    imported_songs = ImportHelper.import_spotify_playlist(spotify_client, item_id)
+                    imported_songs = ImportHelper.import_spotify_playlist(spotify_client, item_id, token=auth_token)
                     if not imported_songs or imported_songs.get('imported_count', 0) == 0:
                         current_app.logger.warning(f"Spotify playlist import returned empty result for playlist ID: {item_id}")
                         return {
@@ -381,7 +439,7 @@ class ImportHelper:
             }
 
     @staticmethod
-    def import_spotify_track(sp, track_id, commit=True):
+    def import_spotify_track(sp, track_id, commit=True, token=None):
         """Import a single track from Spotify"""
         result = {
             'imported_count': 0,
@@ -390,31 +448,15 @@ class ImportHelper:
             'errors': []
         }
 
-        if not current_user or not current_user.is_authenticated or not current_user.spotify_token:
-            current_app.logger.error(f"Import Spotify track: User not authenticated or no Spotify token for track {track_id}.")
-            result['errors'].append("User not authenticated or no Spotify token.")
+        authlib_token_for_request = ImportHelper._resolve_spotify_auth_token(token)
+        if not authlib_token_for_request:
+            current_app.logger.error(f"Import Spotify track: no Spotify token for track {track_id}.")
+            result['errors'].append("No usable Spotify token available.")
             result['error_count'] += 1
             return result
-
-        expires_at_timestamp = None
-        if current_user.spotify_token_expiry:
-            if isinstance(current_user.spotify_token_expiry, datetime):
-                expires_at_timestamp = int(current_user.spotify_token_expiry.timestamp())
-            else:
-                try:
-                    expires_at_timestamp = int(datetime.fromisoformat(str(current_user.spotify_token_expiry)).timestamp())
-                except ValueError:
-                    current_app.logger.warning(f"Could not parse spotify_token_expiry for user {current_user.id} in import_spotify_track.")
-        
-        authlib_token_for_request = {
-            'access_token': current_user.spotify_token,
-            'refresh_token': current_user.spotify_refresh_token,
-            'token_type': 'Bearer',
-            'expires_at': expires_at_timestamp
-        }
         
         try:
-            current_app.logger.info(f"Attempting to import Spotify track ID: {track_id} for user {current_user.id}")
+            current_app.logger.info(f"Attempting to import Spotify track ID: {track_id}")
             existing_song = Song.query.filter_by(spotify_id=track_id).first()
             if existing_song:
                 current_app.logger.info(f'Spotify track ID {track_id} already exists as song: {existing_song.title} by {existing_song.artist}')
@@ -425,13 +467,11 @@ class ImportHelper:
             resp.raise_for_status()
             track_info = resp.json()
 
-            if sp.token and sp.token.get('access_token') != authlib_token_for_request.get('access_token'):
-                current_app.logger.info(f"Spotify token refreshed during import_spotify_track (track ID: {track_id}) for user {current_user.id}.")
-                if update_oauth_tokens(current_user, sp.token, 'spotify'):
-                    authlib_token_for_request = sp.token # Update local token for any further use in this scope
-                    current_app.logger.info(f"Refreshed Spotify token saved for user {current_user.id} after track import.")
-                else:
-                    current_app.logger.error(f"Failed to save refreshed Spotify token for user {current_user.id} after track import.")
+            authlib_token_for_request = ImportHelper._save_refreshed_spotify_token(
+                sp,
+                authlib_token_for_request,
+                f"track import {track_id}",
+            )
 
             if not track_info:
                 result['errors'].append(f"Track with ID {track_id} not found on Spotify or empty response.")
@@ -525,13 +565,11 @@ class ImportHelper:
                             album_details = album_details_resp.json()
 
                             # Check for token refresh again after this call
-                            if sp.token and sp.token.get('access_token') != authlib_token_for_request.get('access_token'):
-                                current_app.logger.info(f"Spotify token refreshed during album genre fetch for track {track_id}, user {current_user.id}.")
-                                if update_oauth_tokens(current_user, sp.token, 'spotify'):
-                                    authlib_token_for_request = sp.token 
-                                    current_app.logger.info(f"Refreshed Spotify token saved (album genre fetch) for user {current_user.id}.")
-                                else:
-                                    current_app.logger.error(f"Failed to save refreshed Spotify token (album genre fetch) for user {current_user.id}.")
+                            authlib_token_for_request = ImportHelper._save_refreshed_spotify_token(
+                                sp,
+                                authlib_token_for_request,
+                                f"album genre fetch for {track_id}",
+                            )
 
                             if album_details.get('genres'):
                                 current_app.logger.info(f"Found genres from album {album_id_for_genre} for track {track_id}: {album_details['genres']}")
@@ -595,7 +633,7 @@ class ImportHelper:
             return result
 
     @staticmethod
-    def import_spotify_album(sp, album_id):
+    def import_spotify_album(sp, album_id, token=None):
         """Import all tracks from a Spotify album"""
         result = {
             'imported_count': 0,
@@ -604,44 +642,26 @@ class ImportHelper:
             'errors': []
         }
 
-        if not current_user or not current_user.is_authenticated or not current_user.spotify_token:
-            current_app.logger.error(f"Import Spotify album: User not authenticated or no Spotify token for album {album_id}.")
-            result['errors'].append("User not authenticated or no Spotify token.")
+        authlib_token_for_request = ImportHelper._resolve_spotify_auth_token(token)
+        if not authlib_token_for_request:
+            current_app.logger.error(f"Import Spotify album: no Spotify token for album {album_id}.")
+            result['errors'].append("No usable Spotify token available.")
             result['error_count'] += 1
             return result
-
-        expires_at_timestamp = None
-        if current_user.spotify_token_expiry:
-            if isinstance(current_user.spotify_token_expiry, datetime):
-                expires_at_timestamp = int(current_user.spotify_token_expiry.timestamp())
-            else:
-                try:
-                    expires_at_timestamp = int(datetime.fromisoformat(str(current_user.spotify_token_expiry)).timestamp())
-                except ValueError:
-                    current_app.logger.warning(f"Could not parse spotify_token_expiry for user {current_user.id} in import_spotify_album.")
-
-        authlib_token_for_request = {
-            'access_token': current_user.spotify_token,
-            'refresh_token': current_user.spotify_refresh_token,
-            'token_type': 'Bearer',
-            'expires_at': expires_at_timestamp
-        }
         
         try:
-            current_app.logger.info(f"Starting import for Spotify album ID: {album_id} for user {current_user.id}")
+            current_app.logger.info(f"Starting import for Spotify album ID: {album_id}")
             album_resp = sp.get(f'albums/{album_id}', token=authlib_token_for_request) 
             album_resp.raise_for_status()
             album_data = album_resp.json()
             album_name = album_data.get('name', 'Unknown Album')
             current_app.logger.info(f"Importing tracks from album: '{album_name}' (ID: {album_id})")
 
-            if sp.token and sp.token.get('access_token') != authlib_token_for_request.get('access_token'):
-                current_app.logger.info(f"Spotify token refreshed during album metadata fetch (album ID: {album_id}) for user {current_user.id}.")
-                if update_oauth_tokens(current_user, sp.token, 'spotify'):
-                    authlib_token_for_request = sp.token # Update local token
-                    current_app.logger.info(f"Refreshed Spotify token saved for user {current_user.id} after album metadata.")
-                else:
-                    current_app.logger.error(f"Failed to save refreshed Spotify token for user {current_user.id} after album metadata.")
+            authlib_token_for_request = ImportHelper._save_refreshed_spotify_token(
+                sp,
+                authlib_token_for_request,
+                f"album metadata fetch {album_id}",
+            )
 
             tracks_url = f'albums/{album_id}/tracks' # Initial URL
             # Spotify API for album tracks might be relative, ensure sp.get handles it or construct full URL if needed.
@@ -657,13 +677,11 @@ class ImportHelper:
                 tracks_resp.raise_for_status()
                 tracks_data = tracks_resp.json()
 
-                if sp.token and sp.token.get('access_token') != authlib_token_for_request.get('access_token'):
-                    current_app.logger.info(f"Spotify token refreshed during album tracks fetch (album ID: {album_id}, page: {page_count}) for user {current_user.id}.")
-                    if update_oauth_tokens(current_user, sp.token, 'spotify'):
-                        authlib_token_for_request = sp.token # Update local token for next iteration / track import
-                        current_app.logger.info(f"Refreshed Spotify token saved for user {current_user.id} (album tracks page {page_count}).")
-                    else:
-                        current_app.logger.error(f"Failed to save refreshed Spotify token for user {current_user.id} (album tracks page {page_count}).")
+                authlib_token_for_request = ImportHelper._save_refreshed_spotify_token(
+                    sp,
+                    authlib_token_for_request,
+                    f"album tracks fetch {album_id} page {page_count}",
+                )
                 
                 track_items = tracks_data.get('items', [])
                 if not track_items and page_count == 1:
@@ -677,8 +695,12 @@ class ImportHelper:
                         result['error_count'] +=1
                         continue
                     
-                    # Call import_spotify_track. It will handle its own token now.
-                    track_import_result = ImportHelper.import_spotify_track(sp, track_id, commit=False)
+                    track_import_result = ImportHelper.import_spotify_track(
+                        sp,
+                        track_id,
+                        commit=False,
+                        token=authlib_token_for_request,
+                    )
                     
                     result['imported_count'] += track_import_result.get('imported_count', 0)
                     result['skipped_count'] += track_import_result.get('skipped_count', 0)
@@ -718,7 +740,7 @@ class ImportHelper:
         return result
 
     @staticmethod
-    def import_spotify_playlist(sp, playlist_id):
+    def import_spotify_playlist(sp, playlist_id, token=None):
         """Import all tracks from a Spotify playlist"""
         result = {
             'imported_count': 0,
@@ -728,31 +750,15 @@ class ImportHelper:
             'imported_song_ids': []  # Track IDs of successfully imported songs
         }
 
-        if not current_user or not current_user.is_authenticated or not current_user.spotify_token:
-            current_app.logger.error(f"Import Spotify playlist: User not authenticated or no Spotify token for playlist {playlist_id}.")
-            result['errors'].append("User not authenticated or no Spotify token.")
+        authlib_token_for_request = ImportHelper._resolve_spotify_auth_token(token)
+        if not authlib_token_for_request:
+            current_app.logger.error(f"Import Spotify playlist: no Spotify token for playlist {playlist_id}.")
+            result['errors'].append("No usable Spotify token available.")
             result['error_count'] += 1
             return result
 
-        expires_at_timestamp = None
-        if current_user.spotify_token_expiry:
-            if isinstance(current_user.spotify_token_expiry, datetime):
-                expires_at_timestamp = int(current_user.spotify_token_expiry.timestamp())
-            else:
-                try:
-                    expires_at_timestamp = int(datetime.fromisoformat(str(current_user.spotify_token_expiry)).timestamp())
-                except ValueError:
-                    current_app.logger.warning(f"Could not parse spotify_token_expiry for user {current_user.id} in import_spotify_playlist.")
-        
-        authlib_token_for_request = {
-            'access_token': current_user.spotify_token,
-            'refresh_token': current_user.spotify_refresh_token,
-            'token_type': 'Bearer',
-            'expires_at': expires_at_timestamp
-        }
-
         try:
-            current_app.logger.info(f"Starting import for Spotify playlist ID: {playlist_id} for user {current_user.id}")
+            current_app.logger.info(f"Starting import for Spotify playlist ID: {playlist_id}")
             # First, get playlist details to get the name (optional, but good for logging)
             playlist_details_resp = sp.get(f'playlists/{playlist_id}?fields=name,tracks.next', token=authlib_token_for_request)
             playlist_details_resp.raise_for_status()
@@ -760,13 +766,11 @@ class ImportHelper:
             playlist_name = playlist_data.get('name', 'Unknown Playlist')
             current_app.logger.info(f"Importing tracks from playlist: '{playlist_name}' (ID: {playlist_id})")
 
-            if sp.token and sp.token.get('access_token') != authlib_token_for_request.get('access_token'):
-                current_app.logger.info(f"Spotify token refreshed during playlist metadata fetch (playlist ID: {playlist_id}) for user {current_user.id}.")
-                if update_oauth_tokens(current_user, sp.token, 'spotify'):
-                    authlib_token_for_request = sp.token # Update local token
-                    current_app.logger.info(f"Refreshed Spotify token saved for user {current_user.id} after playlist metadata.")
-                else:
-                    current_app.logger.error(f"Failed to save refreshed Spotify token for user {current_user.id} after playlist metadata.")
+            authlib_token_for_request = ImportHelper._save_refreshed_spotify_token(
+                sp,
+                authlib_token_for_request,
+                f"playlist metadata fetch {playlist_id}",
+            )
             
             tracks_url = f'playlists/{playlist_id}/tracks' # Initial URL
             page_count = 0
@@ -779,13 +783,11 @@ class ImportHelper:
                 tracks_resp.raise_for_status()
                 tracks_data = tracks_resp.json()
 
-                if sp.token and sp.token.get('access_token') != authlib_token_for_request.get('access_token'):
-                    current_app.logger.info(f"Spotify token refreshed during playlist tracks fetch (playlist ID: {playlist_id}, page: {page_count}) for user {current_user.id}.")
-                    if update_oauth_tokens(current_user, sp.token, 'spotify'):
-                        authlib_token_for_request = sp.token # Update local token
-                        current_app.logger.info(f"Refreshed Spotify token saved for user {current_user.id} (playlist tracks page {page_count}).")
-                    else:
-                        current_app.logger.error(f"Failed to save refreshed Spotify token for user {current_user.id} (playlist tracks page {page_count}).")
+                authlib_token_for_request = ImportHelper._save_refreshed_spotify_token(
+                    sp,
+                    authlib_token_for_request,
+                    f"playlist tracks fetch {playlist_id} page {page_count}",
+                )
 
                 track_items = tracks_data.get('items', [])
                 if not track_items and page_count == 1 and not tracks_data.get('next'): # Check if playlist is actually empty
@@ -805,8 +807,12 @@ class ImportHelper:
                         result['errors'].append(f"Found a track with no ID in playlist {playlist_id}.")
                         result['error_count'] +=1
                         continue
-                      # Call import_spotify_track. It will handle its own token.
-                    track_import_result = ImportHelper.import_spotify_track(sp, track_id, commit=False)
+                    track_import_result = ImportHelper.import_spotify_track(
+                        sp,
+                        track_id,
+                        commit=False,
+                        token=authlib_token_for_request,
+                    )
                     
                     result['imported_count'] += track_import_result.get('imported_count', 0)
                     result['skipped_count'] += track_import_result.get('skipped_count', 0)

--- a/musicround/helpers/import_queue.py
+++ b/musicround/helpers/import_queue.py
@@ -14,6 +14,7 @@ from sqlalchemy.exc import SQLAlchemyError
 
 from musicround.models import ImportJobRecord, User, db
 from musicround.helpers.import_helper import ImportHelper
+from musicround.helpers.spotify_helper import get_spotify_token
 
 
 @dataclass(order=True)
@@ -236,7 +237,17 @@ class ImportWorker(threading.Thread):
                     job.user_id,
                     job.priority,
                 )
-                result = ImportHelper.import_item(job.service_name, job.item_type, job.item_id)
+                import_kwargs = {}
+                if job.service_name.lower() == 'spotify':
+                    access_token, _token_source = get_spotify_token()
+                    import_kwargs['spotify_token'] = access_token
+
+                result = ImportHelper.import_item(
+                    job.service_name,
+                    job.item_type,
+                    job.item_id,
+                    **import_kwargs,
+                )
                 imported_count, skipped_count, error_message = self._summarize_result(result)
                 self._mark_completed(record, imported_count, skipped_count, error_message)
                 db.session.commit()

--- a/musicround/routes/generate.py
+++ b/musicround/routes/generate.py
@@ -5,6 +5,7 @@ from flask_login import current_user, login_required
 from musicround.models import Song, Round, Tag, db
 from musicround.helpers.auth_helpers import oauth
 from musicround.helpers.import_helper import ImportHelper
+from musicround.helpers.spotify_helper import get_spotify_token
 
 generate_bp = Blueprint('generate', __name__)
 
@@ -363,7 +364,8 @@ def get_songs_from_spotify_playlist(playlist_id):
             item_id=playlist_id,
             item_type='playlist',
             service_name='spotify',
-            oauth_spotify=oauth.spotify
+            oauth_spotify=oauth.spotify,
+            spotify_token=get_spotify_token()[0],
         )
 
         from musicround.models import Song
@@ -380,12 +382,20 @@ def get_songs_from_spotify_playlist(playlist_id):
         # Get playlist tracks (paginated)
         all_spotify_ids = []
         next_url = f'playlists/{playlist_id}/tracks'
+        access_token, token_source = get_spotify_token()
+        if not access_token:
+            current_app.logger.warning(f"No Spotify token available to inspect playlist {playlist_id}")
+            return []
         authlib_token = {
-            'access_token': current_user.spotify_token,
-            'refresh_token': current_user.spotify_refresh_token,
+            'access_token': access_token,
             'token_type': 'Bearer',
-            'expires_at': int(current_user.spotify_token_expiry.timestamp()) if current_user.spotify_token_expiry else None
         }
+        if token_source == 'user':
+            authlib_token['refresh_token'] = current_user.spotify_refresh_token
+            authlib_token['expires_at'] = (
+                int(current_user.spotify_token_expiry.timestamp())
+                if current_user.spotify_token_expiry else None
+            )
         while next_url:
             resp = sp.get(next_url, token=authlib_token)
             resp.raise_for_status()

--- a/musicround/routes/import_songs.py
+++ b/musicround/routes/import_songs.py
@@ -17,26 +17,47 @@ def _require_spotify_token(item_type):
     """Redirect users without any usable Spotify token before import."""
     access_token, _token_source = get_spotify_token()
     if access_token:
-        return None
+        return None, access_token
 
     flash(f"Please connect your Spotify account to import {item_type}.", "warning")
-    return redirect(url_for('users.spotify_link'))
+    return redirect(url_for('users.spotify_link')), None
 
 # Legacy function retained for backward compatibility
 def import_track(track_id):
     """Legacy helper function that now uses the new ImportHelper"""
-    result = ImportHelper.import_item(service_name='spotify', item_type='track', item_id=track_id, oauth_spotify=oauth.spotify)
+    access_token, _token_source = get_spotify_token()
+    result = ImportHelper.import_item(
+        service_name='spotify',
+        item_type='track',
+        item_id=track_id,
+        oauth_spotify=oauth.spotify,
+        spotify_token=access_token,
+    )
     return result.get('imported_count', 0) > 0
 
 # Legacy function retained for backward compatibility
 def import_pl(playlist_id):
     """Legacy helper function that now uses the new ImportHelper"""
-    ImportHelper.import_item(service_name='spotify', item_type='playlist', item_id=playlist_id, oauth_spotify=oauth.spotify)
+    access_token, _token_source = get_spotify_token()
+    ImportHelper.import_item(
+        service_name='spotify',
+        item_type='playlist',
+        item_id=playlist_id,
+        oauth_spotify=oauth.spotify,
+        spotify_token=access_token,
+    )
 
 # Legacy function retained for backward compatibility
 def import_al(album_id):
     """Legacy helper function that now uses the new ImportHelper"""
-    ImportHelper.import_item(service_name='spotify', item_type='album', item_id=album_id, oauth_spotify=oauth.spotify)
+    access_token, _token_source = get_spotify_token()
+    ImportHelper.import_item(
+        service_name='spotify',
+        item_type='album',
+        item_id=album_id,
+        oauth_spotify=oauth.spotify,
+        spotify_token=access_token,
+    )
 
 @import_songs_bp.route('/song', methods=['GET', 'POST'])
 @login_required
@@ -45,7 +66,7 @@ def import_song():
         flash("Please log in to import songs.", "warning")
         return redirect(url_for('users.login'))
 
-    token_redirect = _require_spotify_token("songs")
+    token_redirect, spotify_token = _require_spotify_token("songs")
     if token_redirect:
         return token_redirect
 
@@ -55,7 +76,13 @@ def import_song():
             flash("No song ID provided for import.", "danger")
             return redirect(request.referrer or url_for('core.search'))
             
-        result = ImportHelper.import_item(service_name='spotify', item_type='track', item_id=track_id, oauth_spotify=oauth.spotify)
+        result = ImportHelper.import_item(
+            service_name='spotify',
+            item_type='track',
+            item_id=track_id,
+            oauth_spotify=oauth.spotify,
+            spotify_token=spotify_token,
+        )
         
         imported_count = result.get('imported_count', 0)
         skipped_count = result.get('skipped_count', 0)
@@ -86,7 +113,7 @@ def import_playlist():
         flash("Please log in to import playlists.", "warning")
         return redirect(url_for('users.login'))
 
-    token_redirect = _require_spotify_token("playlists")
+    token_redirect, _spotify_token = _require_spotify_token("playlists")
     if token_redirect:
         return token_redirect
     
@@ -129,7 +156,7 @@ def import_album():
         flash("Please log in to import albums.", "warning")
         return redirect(url_for('users.login'))
 
-    token_redirect = _require_spotify_token("albums")
+    token_redirect, spotify_token = _require_spotify_token("albums")
     if token_redirect:
         return token_redirect
     
@@ -139,7 +166,13 @@ def import_album():
             flash("No album ID provided for import.", "danger")
             return redirect(request.referrer or url_for('core.search'))
             
-        result = ImportHelper.import_item(service_name='spotify', item_type='album', item_id=album_id, oauth_spotify=oauth.spotify)
+        result = ImportHelper.import_item(
+            service_name='spotify',
+            item_type='album',
+            item_id=album_id,
+            oauth_spotify=oauth.spotify,
+            spotify_token=spotify_token,
+        )
         
         imported_count = result.get('imported_count', 0)
         skipped_count = result.get('skipped_count', 0)

--- a/tests/test_import_helper.py
+++ b/tests/test_import_helper.py
@@ -1,5 +1,8 @@
 """Tests for unified import helper behavior."""
+from datetime import datetime, timedelta
+
 from musicround.helpers.import_helper import ImportHelper
+from musicround.models import Song, SystemSetting, db
 
 
 class DeezerPlaylistStub:
@@ -12,6 +15,52 @@ class DeezerPlaylistStub:
     def import_playlist(self, playlist_id, lastfm_api_key=None):
         self.calls.append((playlist_id, lastfm_api_key))
         return self.result
+
+
+class FakeSpotifyResponse:
+    """Minimal response object for Authlib-style Spotify client calls."""
+
+    def __init__(self, payload):
+        self.payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self.payload
+
+
+class FakeSpotifyClient:
+    """Spotify client stub that records the token used for each call."""
+
+    token = None
+
+    def __init__(self):
+        self.calls = []
+
+    def get(self, path, token=None):
+        self.calls.append((path, token))
+        if path == 'tracks/spotify-track-1':
+            return FakeSpotifyResponse({
+                'id': 'spotify-track-1',
+                'name': 'Fallback Track',
+                'artists': [{'name': 'Reliable Artist'}],
+                'album': {
+                    'name': 'Reliable Album',
+                    'release_date': '1999-01-01',
+                    'images': [{'url': 'https://example.com/cover.jpg'}],
+                },
+                'external_ids': {},
+                'preview_url': 'https://example.com/preview.mp3',
+                'popularity': 80,
+            })
+        if path == 'audio-features/spotify-track-1':
+            return FakeSpotifyResponse({
+                'danceability': 0.5,
+                'energy': 0.7,
+                'duration_ms': 240000,
+            })
+        raise AssertionError(f'Unexpected Spotify path: {path}')
 
 
 class TestImportHelperDeezer:
@@ -61,3 +110,55 @@ class TestImportHelperDeezer:
         assert response['skipped_count'] == 0
         assert response['error_count'] == 1
         assert 'No songs found in Deezer playlist playlist-empty' in response['errors'][0]
+
+
+class TestImportHelperSpotifyTokens:
+    """Regression tests for the Spotify token resolution cascade."""
+
+    def test_spotify_track_import_uses_manual_session_token(self, app):
+        """Manual bearer tokens must reach the actual Spotify import call."""
+        spotify = FakeSpotifyClient()
+
+        with app.test_request_context():
+            from flask import session
+
+            session['access_token'] = 'manual-token'
+            session['bearer_token_added'] = datetime.now().timestamp()
+
+            response = ImportHelper.import_item(
+                'spotify',
+                'track',
+                'spotify-track-1',
+                oauth_spotify=spotify,
+            )
+
+        assert response['imported_count'] == 1
+        assert spotify.calls[0][1]['access_token'] == 'manual-token'
+
+        with app.app_context():
+            song = Song.query.filter_by(spotify_id='spotify-track-1').one_or_none()
+            assert song is not None
+            assert song.title == 'Fallback Track'
+
+    def test_spotify_track_import_uses_system_fallback_token(self, app):
+        """System fallback tokens must work when no user token exists."""
+        spotify = FakeSpotifyClient()
+
+        with app.test_request_context():
+            SystemSetting.set('fallback_spotify_refresh_token', 'system-refresh-token')
+            SystemSetting.set('system_spotify_token', 'system-token')
+            SystemSetting.set(
+                'system_spotify_token_expiry',
+                (datetime.now() + timedelta(hours=1)).isoformat(),
+            )
+            db.session.commit()
+
+            response = ImportHelper.import_item(
+                'spotify',
+                'track',
+                'spotify-track-1',
+                oauth_spotify=spotify,
+            )
+
+        assert response['imported_count'] == 1
+        assert spotify.calls[0][1]['access_token'] == 'system-token'

--- a/tests/test_import_queue.py
+++ b/tests/test_import_queue.py
@@ -266,6 +266,36 @@ class TestImportWorker:
 
             mock_import.assert_called_once_with('deezer', 'track', '123')
 
+    def test_process_job_passes_resolved_spotify_token(self, app):
+        """Spotify jobs must pass the worker-resolved fallback token into ImportHelper."""
+        with app.app_context():
+            user = User(username='spotifyworker', email='spotifyworker@example.com')
+            user.password = 'WorkerPass123!'
+            db.session.add(user)
+            db.session.commit()
+
+            worker = ImportWorker(app, ImportQueue())
+            job = ImportJob(
+                priority=1,
+                service_name='spotify',
+                item_type='playlist',
+                item_id='playlist-123',
+                user_id=user.id,
+            )
+
+            with (
+                patch('musicround.helpers.import_queue.get_spotify_token', return_value=('system-token', 'system')),
+                patch('musicround.helpers.import_queue.ImportHelper.import_item') as mock_import,
+            ):
+                worker._process_job(job)
+
+            mock_import.assert_called_once_with(
+                'spotify',
+                'playlist',
+                'playlist-123',
+                spotify_token='system-token',
+            )
+
     def test_process_job_updates_record_status(self, app):
         """Test that worker writes processing and completed state to ImportJobRecord."""
         with app.app_context():

--- a/tests/test_import_songs_routes.py
+++ b/tests/test_import_songs_routes.py
@@ -54,6 +54,18 @@ def _login_spotify_user(client):
     })
 
 
+def _login_user_without_spotify_token(client):
+    user = User(username='manualimporter', email='manualimporter@example.com')
+    user.password = 'ImportPass123!'
+    db.session.add(user)
+    db.session.commit()
+
+    client.post('/users/login', data={
+        'username': 'manualimporter',
+        'password': 'ImportPass123!',
+    })
+
+
 class TestSpotifySongImportRoute:
     """Regression tests for the single-track Spotify import flow."""
 
@@ -83,3 +95,28 @@ class TestSpotifySongImportRoute:
         assert song is not None
         assert song.title == 'Committed Track'
         assert song.artist == 'Reliable Artist'
+
+    def test_spotify_track_import_passes_resolved_manual_token(self, app, client, monkeypatch):
+        """The route must pass the token accepted by its Spotify token gate into ImportHelper."""
+        from musicround.routes import import_songs
+
+        captured = {}
+
+        def fake_import_item(**kwargs):
+            captured.update(kwargs)
+            return {'imported_count': 1, 'skipped_count': 0, 'error_count': 0, 'errors': []}
+
+        with app.app_context():
+            _login_user_without_spotify_token(client)
+
+        monkeypatch.setattr(import_songs, 'get_spotify_token', lambda: ('manual-token', 'manual'))
+        monkeypatch.setattr(import_songs.oauth, 'spotify', object(), raising=False)
+        monkeypatch.setattr(import_songs.ImportHelper, 'import_item', fake_import_item)
+
+        response = client.post('/import/song', data={'song_id': 'spotify-track-1'})
+
+        assert response.status_code == 302
+        assert captured['service_name'] == 'spotify'
+        assert captured['item_type'] == 'track'
+        assert captured['item_id'] == 'spotify-track-1'
+        assert captured['spotify_token'] == 'manual-token'


### PR DESCRIPTION
## Summary
- Route resolved Spotify tokens through the import helpers instead of requiring `current_user.spotify_token` inside the helper layer.
- Allow manual bearer tokens and system fallback tokens to import Spotify tracks, albums, and playlists.
- Pass worker-resolved Spotify tokens into queued imports and cover the route, helper, and worker paths with regression tests.

## Root Cause
The UI-side token gate already accepted manual/session and system fallback tokens, but `ImportHelper` rebuilt its Authlib token from `current_user.spotify_token`. Users without a stored Spotify user token could pass the route check and still fail at the actual import.

## Validation
- `SECRET_KEY=test-secret AUTOMATION_TOKEN=test-token .venv/bin/python -m pytest tests/test_import_helper.py tests/test_import_songs_routes.py tests/test_import_queue.py tests/test_spotify_helper.py -q`
- `SECRET_KEY=test-secret AUTOMATION_TOKEN=test-token .venv/bin/python -m pytest -q`
- `SECRET_KEY=test-secret AUTOMATION_TOKEN=test-token .venv/bin/python -m flake8 musicround/ --count --select=E9,F63,F7,F82 --show-source --statistics`

Closes #99