### PR TITLE
[codex] Preserve Spotify tokens for queued imports

### DIFF
--- a/musicround/helpers/import_helper.py
+++ b/musicround/helpers/import_helper.py
@@ -74,11 +74,25 @@ class ImportHelper:
         }
 
     @staticmethod
+    def _enrich_user_spotify_token(auth_token):
+        """Add refresh metadata when an explicit token is the logged-in user's token."""
+        user = ImportHelper._authenticated_current_user()
+        if not user or auth_token.get('access_token') != user.spotify_token:
+            return auth_token
+        enriched_token = dict(auth_token)
+        if user.spotify_refresh_token:
+            enriched_token.setdefault('refresh_token', user.spotify_refresh_token)
+        expires_at = ImportHelper._token_expiry_timestamp(user.spotify_token_expiry)
+        if expires_at:
+            enriched_token.setdefault('expires_at', expires_at)
+        return enriched_token
+
+    @staticmethod
     def _resolve_spotify_auth_token(token=None):
         """Resolve Spotify auth via explicit token, manual session, user token, or system fallback."""
         explicit_token = ImportHelper._coerce_spotify_auth_token(token)
         if explicit_token:
-            return explicit_token
+            return ImportHelper._enrich_user_spotify_token(explicit_token)
 
         from musicround.helpers.spotify_helper import get_spotify_token
 

--- a/musicround/helpers/import_queue.py
+++ b/musicround/helpers/import_queue.py
@@ -26,6 +26,7 @@ class ImportJob:
     item_type: str = field(compare=False)
     item_id: str = field(compare=False)
     user_id: int = field(compare=False)
+    spotify_token: Optional[str] = field(default=None, compare=False)
     record_id: Optional[int] = field(default=None, compare=False)
 
 
@@ -60,6 +61,7 @@ class ImportQueue:
         item_id: str,
         user_id: int,
         priority: Any = 10,
+        spotify_token: Optional[str] = None,
     ) -> ImportJobRecord:
         """Create a persistent job record and enqueue it for local workers."""
         normalized_priority = self.normalize_priority(priority)
@@ -73,10 +75,10 @@ class ImportQueue:
         )
         db.session.add(record)
         db.session.commit()
-        self.enqueue_record(record)
+        self.enqueue_record(record, spotify_token=spotify_token)
         return record
 
-    def enqueue_record(self, record: ImportJobRecord) -> None:
+    def enqueue_record(self, record: ImportJobRecord, spotify_token: Optional[str] = None) -> None:
         """Enqueue an existing pending job record."""
         self.add_job(
             ImportJob(
@@ -85,6 +87,7 @@ class ImportQueue:
                 item_type=record.item_type,
                 item_id=record.item_id,
                 user_id=record.user_id,
+                spotify_token=spotify_token,
                 record_id=record.id,
             )
         )
@@ -239,7 +242,9 @@ class ImportWorker(threading.Thread):
                 )
                 import_kwargs = {}
                 if job.service_name.lower() == 'spotify':
-                    access_token, _token_source = get_spotify_token()
+                    access_token = job.spotify_token
+                    if not access_token:
+                        access_token, _token_source = get_spotify_token()
                     import_kwargs['spotify_token'] = access_token
 
                 result = ImportHelper.import_item(
@@ -349,6 +354,7 @@ def enqueue_import_job(
     item_id: str,
     user_id: int,
     priority: Any = 10,
+    spotify_token: Optional[str] = None,
 ) -> ImportJobRecord:
     """Create and enqueue an import job using the app-wide queue."""
-    return queue.enqueue(service_name, item_type, item_id, user_id, priority)
+    return queue.enqueue(service_name, item_type, item_id, user_id, priority, spotify_token=spotify_token)

--- a/musicround/helpers/import_queue.py
+++ b/musicround/helpers/import_queue.py
@@ -357,4 +357,11 @@ def enqueue_import_job(
     spotify_token: Optional[str] = None,
 ) -> ImportJobRecord:
     """Create and enqueue an import job using the app-wide queue."""
-    return queue.enqueue(service_name, item_type, item_id, user_id, priority, spotify_token=spotify_token)
+    return queue.enqueue(
+        service_name,
+        item_type,
+        item_id,
+        user_id,
+        priority,
+        spotify_token=spotify_token,
+    )

--- a/musicround/routes/import_routes.py
+++ b/musicround/routes/import_routes.py
@@ -171,6 +171,7 @@ def import_official_playlists():
             item_type='playlist',
             item_id=playlist_id,
             user_id=current_user.id,
+            spotify_token=access_token,
         )
         flash(f'Official Spotify playlist import queued as job #{job_record.id}.', 'info')
             
@@ -322,6 +323,7 @@ def direct_official_playlists():
             item_type='playlist',
             item_id=playlist_id,
             user_id=current_user.id,
+            spotify_token=bearer_token,
         )
         flash(f'Direct Spotify playlist import queued as job #{job_record.id}.', 'info')
         

--- a/musicround/routes/import_songs.py
+++ b/musicround/routes/import_songs.py
@@ -113,7 +113,7 @@ def import_playlist():
         flash("Please log in to import playlists.", "warning")
         return redirect(url_for('users.login'))
 
-    token_redirect, _spotify_token = _require_spotify_token("playlists")
+    token_redirect, spotify_token = _require_spotify_token("playlists")
     if token_redirect:
         return token_redirect
     
@@ -136,6 +136,7 @@ def import_playlist():
             item_type='playlist',
             item_id=playlist_id,
             user_id=current_user.id,
+            spotify_token=spotify_token,
         )
         flash(f'Playlist import queued as job #{job_record.id}.', 'info')
         return redirect(url_for('core.view_songs'))

--- a/tests/test_final_coverage.py
+++ b/tests/test_final_coverage.py
@@ -154,6 +154,68 @@ class TestImportRoutesAccess:
         # Without Spotify token, it may redirect elsewhere; still a valid response
         assert response.status_code in (200, 302)
 
+    def test_official_playlist_queue_passes_resolved_token(self, app, client, monkeypatch):
+        """Official playlist imports should retain the token accepted by the route."""
+        from musicround.routes import import_routes
+
+        captured = {}
+
+        class FakeJob:
+            id = 99
+
+        def fake_enqueue_import_job(**kwargs):
+            captured.update(kwargs)
+            return FakeJob()
+
+        _login(app, client)
+        monkeypatch.setattr(import_routes, 'get_spotify_token', lambda: ('manual-token', 'manual'))
+        monkeypatch.setitem(app.config, 'import_queue', object())
+        monkeypatch.setattr(
+            'musicround.helpers.import_queue.enqueue_import_job',
+            fake_enqueue_import_job,
+        )
+
+        response = client.post('/import/official-playlists', data={'playlist_id': 'playlist-123'})
+
+        assert response.status_code == 302
+        assert captured['service_name'] == 'spotify'
+        assert captured['item_type'] == 'playlist'
+        assert captured['item_id'] == 'playlist-123'
+        assert captured['spotify_token'] == 'manual-token'
+
+    def test_direct_official_playlist_queue_passes_direct_token(self, app, client, monkeypatch):
+        """Direct official playlist imports should carry the direct bearer token into the queue."""
+        captured = {}
+
+        class FakeJob:
+            id = 100
+
+        def fake_enqueue_import_job(**kwargs):
+            captured.update(kwargs)
+            return FakeJob()
+
+        _login(app, client)
+        with client.session_transaction() as sess:
+            sess['direct_bearer_token'] = 'direct-token'
+
+        monkeypatch.setitem(app.config, 'import_queue', object())
+        monkeypatch.setattr(
+            'musicround.helpers.spotify_direct.SpotifyDirectClient',
+            lambda bearer_token: object(),
+        )
+        monkeypatch.setattr(
+            'musicround.helpers.import_queue.enqueue_import_job',
+            fake_enqueue_import_job,
+        )
+
+        response = client.post('/import/direct-official-playlists', data={'playlist_id': 'playlist-456'})
+
+        assert response.status_code == 302
+        assert captured['service_name'] == 'spotify'
+        assert captured['item_type'] == 'playlist'
+        assert captured['item_id'] == 'playlist-456'
+        assert captured['spotify_token'] == 'direct-token'
+
     def test_queue_status_requires_login(self, client):
         """Test that queue status requires authentication."""
         response = client.get('/import/queue-status')

--- a/tests/test_import_helper.py
+++ b/tests/test_import_helper.py
@@ -1,8 +1,10 @@
 """Tests for unified import helper behavior."""
 from datetime import datetime, timedelta
 
+from flask_login import login_user
+
 from musicround.helpers.import_helper import ImportHelper
-from musicround.models import Song, SystemSetting, db
+from musicround.models import Song, SystemSetting, User, db
 
 
 class DeezerPlaylistStub:
@@ -162,3 +164,23 @@ class TestImportHelperSpotifyTokens:
 
         assert response['imported_count'] == 1
         assert spotify.calls[0][1]['access_token'] == 'system-token'
+
+    def test_explicit_user_spotify_token_keeps_refresh_metadata(self, app):
+        """Explicit user tokens must still allow Authlib refresh persistence."""
+        expiry = datetime.now() + timedelta(hours=1)
+
+        with app.test_request_context():
+            user = User(username='refreshuser', email='refresh@example.com')
+            user.password = 'ImportPass123!'
+            user.spotify_token = 'user-access-token'
+            user.spotify_refresh_token = 'user-refresh-token'
+            user.spotify_token_expiry = expiry
+            db.session.add(user)
+            db.session.commit()
+            login_user(user)
+
+            token = ImportHelper._resolve_spotify_auth_token('user-access-token')
+
+        assert token['access_token'] == 'user-access-token'
+        assert token['refresh_token'] == 'user-refresh-token'
+        assert token['expires_at'] == int(expiry.timestamp())

--- a/tests/test_import_queue.py
+++ b/tests/test_import_queue.py
@@ -192,6 +192,29 @@ class TestImportQueue:
             assert snapshot[0]['record_id'] == record.id
             assert snapshot[0]['item_id'] == 'playlist123'
 
+    def test_enqueue_can_attach_ephemeral_spotify_token(self, app):
+        """Manual Spotify tokens should be carried in memory without persisting them."""
+        with app.app_context():
+            user = User(username='manualqueue', email='manualqueue@example.com')
+            user.password = 'QueuePass123!'
+            db.session.add(user)
+            db.session.commit()
+
+            queue = ImportQueue()
+            record = enqueue_import_job(
+                queue=queue,
+                service_name='spotify',
+                item_type='playlist',
+                item_id='playlist123',
+                user_id=user.id,
+                priority='4',
+                spotify_token='manual-token',
+            )
+
+            assert not hasattr(record, 'spotify_token')
+            job = queue.get_job(timeout=0.1)
+            assert job.spotify_token == 'manual-token'
+
     def test_enqueue_pending_records_loads_database_jobs(self, app):
         """Test startup can reload pending jobs from the database."""
         with app.app_context():
@@ -294,6 +317,37 @@ class TestImportWorker:
                 'playlist',
                 'playlist-123',
                 spotify_token='system-token',
+            )
+
+    def test_process_job_prefers_ephemeral_spotify_token(self, app):
+        """Worker jobs should use the token captured when the playlist was queued."""
+        with app.app_context():
+            user = User(username='manualworker', email='manualworker@example.com')
+            user.password = 'WorkerPass123!'
+            db.session.add(user)
+            db.session.commit()
+
+            worker = ImportWorker(app, ImportQueue())
+            job = ImportJob(
+                priority=1,
+                service_name='spotify',
+                item_type='playlist',
+                item_id='playlist-123',
+                user_id=user.id,
+                spotify_token='manual-token',
+            )
+
+            with (
+                patch('musicround.helpers.import_queue.get_spotify_token', return_value=('fallback-token', 'system')),
+                patch('musicround.helpers.import_queue.ImportHelper.import_item') as mock_import,
+            ):
+                worker._process_job(job)
+
+            mock_import.assert_called_once_with(
+                'spotify',
+                'playlist',
+                'playlist-123',
+                spotify_token='manual-token',
             )
 
     def test_process_job_updates_record_status(self, app):

--- a/tests/test_import_songs_routes.py
+++ b/tests/test_import_songs_routes.py
@@ -120,3 +120,34 @@ class TestSpotifySongImportRoute:
         assert captured['item_type'] == 'track'
         assert captured['item_id'] == 'spotify-track-1'
         assert captured['spotify_token'] == 'manual-token'
+
+    def test_spotify_playlist_queue_passes_resolved_manual_token(self, app, client, monkeypatch):
+        """Queued playlist imports must retain the manual token accepted by the route gate."""
+        from musicround.routes import import_songs
+
+        captured = {}
+
+        class FakeJob:
+            id = 42
+
+        def fake_enqueue_import_job(**kwargs):
+            captured.update(kwargs)
+            return FakeJob()
+
+        with app.app_context():
+            _login_user_without_spotify_token(client)
+
+        monkeypatch.setattr(import_songs, 'get_spotify_token', lambda: ('manual-token', 'manual'))
+        monkeypatch.setitem(app.config, 'import_queue', object())
+        monkeypatch.setattr(
+            'musicround.helpers.import_queue.enqueue_import_job',
+            fake_enqueue_import_job,
+        )
+
+        response = client.post('/import/playlist', data={'playlist_id': 'playlist-123'})
+
+        assert response.status_code == 302
+        assert captured['service_name'] == 'spotify'
+        assert captured['item_type'] == 'playlist'
+        assert captured['item_id'] == 'playlist-123'
+        assert captured['spotify_token'] == 'manual-token'


### PR DESCRIPTION
## Summary
- carry the Spotify token accepted by the playlist import route into the in-memory queue job
- avoid persisting manual bearer tokens in ImportJobRecord storage
- enrich explicit user access tokens with refresh metadata so long imports can still refresh and persist user tokens
- add focused regression coverage for route, queue, worker, and token enrichment paths

Follow-up to #137, addressing the Copilot review concern about queued playlist imports losing manual session tokens and explicit user tokens losing refresh metadata.

## Validation
- python3 -m py_compile musicround/helpers/import_helper.py musicround/helpers/import_queue.py musicround/routes/import_songs.py tests/test_import_helper.py tests/test_import_queue.py tests/test_import_songs_routes.py
- git diff --check

## Note
- Focused pytest could not complete in this local checkout because collection hung before running tests, even with PYTEST_DISABLE_PLUGIN_AUTOLOAD=1.