### PR TITLE
[codex] Fix round email delivery helper

### DIFF
--- a/musicround/helpers/email_helper.py
+++ b/musicround/helpers/email_helper.py
@@ -31,6 +31,8 @@ def send_email(recipient, subject, body_text, attachments=None):
     mail_username = current_app.config.get('MAIL_USERNAME')
     mail_password = current_app.config.get('MAIL_PASSWORD')
     mail_sender = current_app.config.get('MAIL_SENDER')
+    mail_use_tls = current_app.config.get('MAIL_USE_TLS', False)
+    mail_use_ssl = current_app.config.get('MAIL_USE_SSL', False)
     
     # Check if all email configuration parameters are available
     missing_config = []
@@ -82,9 +84,15 @@ def send_email(recipient, subject, body_text, attachments=None):
 
     try:
         current_app.logger.info(f"Attempting to send email to {recipient} via {mail_host}:{mail_port}")
-        with smtplib.SMTP(mail_host, mail_port, timeout=30) as server:
-            server.starttls()
-            current_app.logger.debug("STARTTLS established")
+        smtp_client = smtplib.SMTP_SSL if mail_use_ssl else smtplib.SMTP
+        with smtp_client(mail_host, mail_port, timeout=30) as server:
+            if mail_use_ssl:
+                current_app.logger.debug("Implicit TLS SMTP connection established")
+            elif mail_use_tls:
+                server.starttls()
+                current_app.logger.debug("STARTTLS established")
+            else:
+                current_app.logger.debug("Plain SMTP connection established")
             server.login(mail_username, mail_password)
             current_app.logger.debug(f"Login successful for {mail_username}")
             server.sendmail(mail_sender, recipient, msg.as_string())

--- a/musicround/routes/rounds.py
+++ b/musicround/routes/rounds.py
@@ -1,5 +1,4 @@
 import os
-import smtplib
 import shutil
 import base64
 import tempfile
@@ -7,10 +6,6 @@ import requests
 import logging
 from datetime import datetime
 from io import BytesIO
-from email.mime.multipart import MIMEMultipart
-from email.mime.text import MIMEText
-from email.mime.base import MIMEBase
-from email import encoders
 import re
 import zipfile
 import io
@@ -23,6 +18,7 @@ from pydub import AudioSegment
 from reportlab.lib.pagesizes import A4
 from reportlab.pdfgen import canvas
 from musicround.helpers.auth_helpers import oauth
+from musicround.helpers.email_helper import send_email as send_quiz_email
 
 rounds_bp = Blueprint('rounds', __name__, url_prefix='/rounds')
 
@@ -565,7 +561,7 @@ def round_pdf(round_id):
 @login_required
 def send_email(round_id):
     """
-    Generate PDF + MP3, attach them to an email, and send via Postmark.
+    Generate PDF + MP3, attach them to an email, and send via configured SMTP.
     """
     if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
         # For AJAX requests, keep the response consistent
@@ -593,21 +589,28 @@ def send_email(round_id):
         # Call the round_mp3 function but don't return its result yet
         # This will generate the MP3 file at mp3_file_path
         response = round_mp3(round_id)
-        
-        if isinstance(response, str) and response.startswith('Error'):
-            error_msg = response
+
+        response_obj = response
+        status_code = getattr(response, 'status_code', 200)
+        if isinstance(response, tuple):
+            response_obj = response[0]
+            if len(response) > 1 and isinstance(response[1], int):
+                status_code = response[1]
+            else:
+                status_code = getattr(response_obj, 'status_code', 200)
+        if status_code >= 400 or not os.path.exists(mp3_file_path):
+            error_msg = "MP3 generation failed. Please resolve the round audio issues before sending email."
+            try:
+                response_json = response_obj.get_json(silent=True)
+            except Exception:
+                response_json = None
+            if response_json and response_json.get('error'):
+                error_msg = response_json['error']
             if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
                 return jsonify({'error': error_msg})
             else:
                 flash(error_msg, 'error')
                 return redirect(url_for('rounds.round_detail', round_id=round_id))
-
-    # Get mail configuration from environment variables
-    mail_host = current_app.config.get('MAIL_HOST')
-    mail_port = current_app.config.get('MAIL_PORT')
-    mail_username = current_app.config.get('MAIL_USERNAME')
-    mail_password = current_app.config.get('MAIL_PASSWORD')
-    mail_sender = current_app.config.get('MAIL_SENDER')
     
     # Use the current user's email address as the recipient
     mail_recipient = current_user.email
@@ -622,84 +625,45 @@ def send_email(round_id):
             session['email_error'] = error_msg
             return redirect(url_for('rounds.round_detail', round_id=round_id))
     
-    # Check if all email configuration parameters are available
-    missing_config = []
-    if not mail_host:
-        missing_config.append("MAIL_HOST")
-    if not mail_port:
-        missing_config.append("MAIL_PORT")
-    if not mail_username:
-        missing_config.append("MAIL_USERNAME")
-    if not mail_password:
-        missing_config.append("MAIL_PASSWORD")
-    if not mail_sender:
-        missing_config.append("MAIL_SENDER")
-    
-    if missing_config:
-        missing_params = ", ".join(missing_config)
-        error_msg = f"Email server configuration is incomplete. Missing parameters: {missing_params}. Please check your .env file."
-        current_app.logger.error(f"Email configuration error: {error_msg}")
-        current_app.logger.error(f"Current config values - MAIL_HOST: {'set' if mail_host else 'missing'}, "
-                               f"MAIL_PORT: {'set' if mail_port else 'missing'}, "
-                               f"MAIL_USERNAME: {'set' if mail_username else 'missing'}, "
-                               f"MAIL_PASSWORD: {'set' if mail_password else 'missing'}, "
-                               f"MAIL_SENDER: {'set' if mail_sender else 'missing'}")
-        
-        if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
-            return jsonify({'error': error_msg})
-        else:
-            session['email_error'] = error_msg  # Store the error message in the session
-            return redirect(url_for('rounds.round_detail', round_id=round_id))
-
-    msg = MIMEMultipart()
-    msg['From'] = mail_sender
-    msg['To'] = mail_recipient
-    
     # Get the round name for the subject
     round_title = f'Pub Quiz Round #{round_id}'
     if rnd and rnd.name:
         round_title = rnd.name
-    
-    msg['Subject'] = round_title
-    msg.attach(MIMEText('Attached please find the MP3 and PDF files for the quiz round.', 'plain'))
-
-    # Attach PDF
-    pdf_attachment = MIMEBase('application', 'pdf')
-    pdf_attachment.set_payload(pdf_data)
-    encoders.encode_base64(pdf_attachment)
-    pdf_attachment.add_header('Content-Disposition', f'attachment; filename=round_{round_id}.pdf')
-    msg.attach(pdf_attachment)
-
-    # Attach MP3
-    with open(mp3_file_path, 'rb') as mp3_file:
-        mp3_data = mp3_file.read()
-        mp3_attachment = MIMEBase('audio', 'mpeg')
-        mp3_attachment.set_payload(mp3_data)
-        encoders.encode_base64(mp3_attachment)
-        mp3_attachment.add_header('Content-Disposition', f'attachment; filename=round_{round_id}.mp3')
-        msg.attach(mp3_attachment)
 
     try:
-        current_app.logger.info(f"Attempting to send email to {mail_recipient} via {mail_host}:{mail_port}")
-        with smtplib.SMTP(mail_host, mail_port) as server:
-            server.starttls()
-            current_app.logger.debug("STARTTLS established")
-            server.login(mail_username, mail_password)
-            current_app.logger.debug(f"Login successful for {mail_username}")
-            server.sendmail(mail_sender, mail_recipient, msg.as_string())
-            current_app.logger.info(f"Email sent successfully from {mail_sender} to {mail_recipient}")
-        
-        success_msg = f'Email sent successfully to {mail_recipient}!'
+        with open(mp3_file_path, 'rb') as mp3_file:
+            attachments = [
+                {
+                    'data': pdf_data,
+                    'filename': f'round_{round_id}.pdf',
+                    'mimetype': 'application/pdf',
+                },
+                {
+                    'data': mp3_file.read(),
+                    'filename': f'round_{round_id}.mp3',
+                    'mimetype': 'audio/mpeg',
+                },
+            ]
+
+        success, message = send_quiz_email(
+            mail_recipient,
+            round_title,
+            'Attached please find the MP3 and PDF files for the quiz round.',
+            attachments,
+        )
+        if not success:
+            raise RuntimeError(message)
+
+        success_msg = message
         if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
             return jsonify({'success': True, 'message': success_msg})
         else:
             flash(success_msg, 'success')
             return redirect(url_for('rounds.round_detail', round_id=round_id))
             
-    except smtplib.SMTPException as e:
+    except Exception as e:
         error_msg = str(e)
-        current_app.logger.error(f"SMTP Error: {error_msg}")
-        current_app.logger.error(f"Failed to send email from {mail_sender} to {mail_recipient} via {mail_host}:{mail_port}")
+        current_app.logger.error(f"Email send error: {error_msg}")
         
         if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
             return jsonify({'error': error_msg})

--- a/musicround/routes/rounds.py
+++ b/musicround/routes/rounds.py
@@ -573,21 +573,21 @@ def send_email(round_id):
     
     # Generate PDF
     pdf_data = generate_pdf(round_id)
-    if isinstance(pdf_data, str) and pdf_data.startswith('Round not found'):
-        error_msg = 'Round not found'
+    if isinstance(pdf_data, str):
+        error_msg = pdf_data
         if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
             return jsonify({'error': error_msg})
-        else:
+        if pdf_data.startswith('Round not found'):
             flash(error_msg, 'error')
             return redirect(url_for('rounds.rounds_list'))
+        flash(error_msg, 'error')
+        return redirect(url_for('rounds.round_detail', round_id=round_id))
     
     # Define the path for the MP3 file
     mp3_file_path = os.path.join('/data/rounds', f'round_{round_id}.mp3')
     
-    # Check if MP3 exists, if not generate it
-    if not os.path.exists(mp3_file_path):
-        # Call the round_mp3 function but don't return its result yet
-        # This will generate the MP3 file at mp3_file_path
+    # Regenerate if the database marks the asset stale or the file is missing.
+    if not rnd.mp3_generated or not os.path.exists(mp3_file_path):
         response = round_mp3(round_id)
 
         response_obj = response
@@ -611,6 +611,13 @@ def send_email(round_id):
             else:
                 flash(error_msg, 'error')
                 return redirect(url_for('rounds.round_detail', round_id=round_id))
+        db.session.refresh(rnd)
+        if not rnd.mp3_generated:
+            error_msg = "MP3 generation failed. Please resolve the round audio issues before sending email."
+            if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
+                return jsonify({'error': error_msg})
+            flash(error_msg, 'error')
+            return redirect(url_for('rounds.round_detail', round_id=round_id))
     
     # Use the current user's email address as the recipient
     mail_recipient = current_user.email
@@ -662,8 +669,8 @@ def send_email(round_id):
             return redirect(url_for('rounds.round_detail', round_id=round_id))
             
     except Exception as e:
-        error_msg = str(e)
-        current_app.logger.error(f"Email send error: {error_msg}")
+        current_app.logger.error(f"Email send error: {e}")
+        error_msg = "Unable to send the email. Please try again later or contact an administrator."
         
         if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
             return jsonify({'error': error_msg})

--- a/tests/test_email_helper.py
+++ b/tests/test_email_helper.py
@@ -1,0 +1,94 @@
+"""Tests for email helper SMTP transport behavior."""
+from musicround.helpers.email_helper import send_email
+
+
+class FakeSmtpServer:
+    """Small SMTP test double that records how it was used."""
+
+    instances = []
+
+    def __init__(self, host, port, timeout=None):
+        self.host = host
+        self.port = port
+        self.timeout = timeout
+        self.starttls_called = False
+        self.login_args = None
+        self.sendmail_args = None
+        self.__class__.instances.append(self)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def starttls(self):
+        self.starttls_called = True
+
+    def login(self, username, password):
+        self.login_args = (username, password)
+
+    def sendmail(self, sender, recipient, message):
+        self.sendmail_args = (sender, recipient, message)
+
+
+def _configure_mail(app, use_tls=False, use_ssl=False):
+    app.config.update(
+        MAIL_HOST='smtp.example.test',
+        MAIL_PORT=465 if use_ssl else 587,
+        MAIL_USERNAME='mailer',
+        MAIL_PASSWORD='secret',
+        MAIL_SENDER='sender@example.test',
+        MAIL_USE_TLS=use_tls,
+        MAIL_USE_SSL=use_ssl,
+    )
+
+
+def test_send_email_uses_smtp_ssl_when_configured(app, monkeypatch):
+    """Test implicit TLS uses SMTP_SSL and does not call STARTTLS."""
+    _configure_mail(app, use_tls=False, use_ssl=True)
+    FakeSmtpServer.instances = []
+
+    def unexpected_smtp(*_args, **_kwargs):
+        raise AssertionError("SMTP should not be used when MAIL_USE_SSL is enabled")
+
+    monkeypatch.setattr('musicround.helpers.email_helper.smtplib.SMTP', unexpected_smtp)
+    monkeypatch.setattr('musicround.helpers.email_helper.smtplib.SMTP_SSL', FakeSmtpServer)
+
+    success, message = send_email('to@example.test', 'Subject', 'Body')
+
+    assert success is True
+    assert message == 'Email sent successfully to to@example.test!'
+    server = FakeSmtpServer.instances[0]
+    assert server.host == 'smtp.example.test'
+    assert server.port == 465
+    assert server.timeout == 30
+    assert server.starttls_called is False
+    assert server.login_args == ('mailer', 'secret')
+    assert server.sendmail_args[0:2] == ('sender@example.test', 'to@example.test')
+
+
+def test_send_email_uses_starttls_only_when_configured(app, monkeypatch):
+    """Test STARTTLS is controlled by MAIL_USE_TLS."""
+    _configure_mail(app, use_tls=True, use_ssl=False)
+    FakeSmtpServer.instances = []
+
+    monkeypatch.setattr('musicround.helpers.email_helper.smtplib.SMTP', FakeSmtpServer)
+
+    success, _message = send_email('to@example.test', 'Subject', 'Body')
+
+    assert success is True
+    assert FakeSmtpServer.instances[0].starttls_called is True
+
+
+def test_send_email_plain_smtp_does_not_start_tls_when_disabled(app, monkeypatch):
+    """Test plain SMTP remains possible for local mail relays."""
+    _configure_mail(app, use_tls=False, use_ssl=False)
+    FakeSmtpServer.instances = []
+
+    monkeypatch.setattr('musicround.helpers.email_helper.smtplib.SMTP', FakeSmtpServer)
+
+    success, _message = send_email('to@example.test', 'Subject', 'Body')
+
+    assert success is True
+    assert FakeSmtpServer.instances[0].starttls_called is False

--- a/tests/test_rounds_routes.py
+++ b/tests/test_rounds_routes.py
@@ -1,7 +1,8 @@
 """Tests for rounds blueprint routes."""
 import pytest
 import json
-from unittest.mock import patch
+from unittest.mock import patch, mock_open
+from flask import jsonify
 from musicround.models import db, User, Song, Round
 
 
@@ -255,3 +256,65 @@ class TestLegacyEmptyRoundRoutes:
         assert response.get_json()['success'] is False
         assert 'no songs' in response.get_json()['message']
         mock_upload.assert_not_called()
+
+
+class TestRoundEmailRoute:
+    """Tests for POST /rounds/<id>/mail."""
+
+    def test_mail_route_returns_mp3_error_without_sending(self, app, client):
+        """Test failed MP3 generation blocks email instead of crashing later."""
+        _login(app, client)
+        round_id = _create_round(app, [])
+
+        def failed_mp3(_round_id):
+            return jsonify({'success': False, 'error': 'Audio boom'}), 400
+
+        with patch('musicround.routes.rounds.generate_pdf', return_value=b'%PDF'), \
+                patch('musicround.routes.rounds.round_mp3', side_effect=failed_mp3), \
+                patch('musicround.routes.rounds.send_quiz_email') as mock_send:
+            response = client.post(
+                f'/rounds/{round_id}/mail',
+                headers={'X-Requested-With': 'XMLHttpRequest'},
+            )
+
+        assert response.status_code == 200
+        assert response.get_json()['error'] == 'Audio boom'
+        mock_send.assert_not_called()
+
+    def test_mail_route_uses_shared_email_helper_with_attachments(self, app, client):
+        """Test email delivery is delegated to the shared helper."""
+        _login(app, client)
+        song_id = _create_song(app, title='Mailable Song')
+        round_id = _create_round(app, [song_id], name='Mailable Round')
+
+        with patch('musicround.routes.rounds.generate_pdf', return_value=b'%PDF'), \
+                patch('musicround.routes.rounds.os.path.exists', return_value=True), \
+                patch('builtins.open', mock_open(read_data=b'ID3 test mp3')), \
+                patch(
+                    'musicround.routes.rounds.send_quiz_email',
+                    return_value=(True, 'sent'),
+                ) as mock_send:
+            response = client.post(
+                f'/rounds/{round_id}/mail',
+                headers={'X-Requested-With': 'XMLHttpRequest'},
+            )
+
+        assert response.status_code == 200
+        assert response.get_json() == {'success': True, 'message': 'sent'}
+        mock_send.assert_called_once()
+        recipient, subject, body, attachments = mock_send.call_args.args
+        assert recipient == 'rounds@example.com'
+        assert subject == 'Mailable Round'
+        assert 'Attached please find' in body
+        assert attachments == [
+            {
+                'data': b'%PDF',
+                'filename': f'round_{round_id}.pdf',
+                'mimetype': 'application/pdf',
+            },
+            {
+                'data': b'ID3 test mp3',
+                'filename': f'round_{round_id}.mp3',
+                'mimetype': 'audio/mpeg',
+            },
+        ]

--- a/tests/test_rounds_routes.py
+++ b/tests/test_rounds_routes.py
@@ -286,6 +286,10 @@ class TestRoundEmailRoute:
         _login(app, client)
         song_id = _create_song(app, title='Mailable Song')
         round_id = _create_round(app, [song_id], name='Mailable Round')
+        with app.app_context():
+            round_ = Round.query.get(round_id)
+            round_.mp3_generated = True
+            db.session.commit()
 
         with patch('musicround.routes.rounds.generate_pdf', return_value=b'%PDF'), \
                 patch('musicround.routes.rounds.os.path.exists', return_value=True), \
@@ -318,3 +322,82 @@ class TestRoundEmailRoute:
                 'mimetype': 'audio/mpeg',
             },
         ]
+
+    def test_mail_route_returns_pdf_error_without_sending(self, app, client):
+        """Test PDF generation errors block email before attachment creation."""
+        _login(app, client)
+        song_id = _create_song(app, title='PDF Error Song')
+        round_id = _create_round(app, [song_id], name='PDF Error Round')
+
+        with patch(
+            'musicround.routes.rounds.generate_pdf',
+            return_value='Round contains no songs',
+        ), patch('musicround.routes.rounds.send_quiz_email') as mock_send:
+            response = client.post(
+                f'/rounds/{round_id}/mail',
+                headers={'X-Requested-With': 'XMLHttpRequest'},
+            )
+
+        assert response.status_code == 200
+        assert response.get_json()['error'] == 'Round contains no songs'
+        mock_send.assert_not_called()
+
+    def test_mail_route_regenerates_stale_mp3_before_sending(self, app, client):
+        """Test stale MP3 database state triggers regeneration before email."""
+        _login(app, client)
+        song_id = _create_song(app, title='Stale MP3 Song')
+        round_id = _create_round(app, [song_id], name='Stale MP3 Round')
+
+        def regenerate_mp3(_round_id):
+            round_ = Round.query.get(round_id)
+            round_.mp3_generated = True
+            db.session.commit()
+            return jsonify({'success': True, 'message': 'MP3 file successfully generated'})
+
+        with patch('musicround.routes.rounds.generate_pdf', return_value=b'%PDF'), \
+                patch('musicround.routes.rounds.os.path.exists', return_value=True), \
+                patch('builtins.open', mock_open(read_data=b'ID3 refreshed mp3')), \
+                patch(
+                    'musicround.routes.rounds.round_mp3',
+                    side_effect=regenerate_mp3,
+                ) as mock_round_mp3, \
+                patch(
+                    'musicround.routes.rounds.send_quiz_email',
+                    return_value=(True, 'sent'),
+                ) as mock_send:
+            response = client.post(
+                f'/rounds/{round_id}/mail',
+                headers={'X-Requested-With': 'XMLHttpRequest'},
+            )
+
+        assert response.status_code == 200
+        assert response.get_json() == {'success': True, 'message': 'sent'}
+        mock_round_mp3.assert_called_once_with(round_id)
+        mock_send.assert_called_once()
+
+    def test_mail_route_hides_email_helper_failure_details(self, app, client):
+        """Test SMTP/config details are logged but not exposed to the user."""
+        _login(app, client)
+        song_id = _create_song(app, title='SMTP Error Song')
+        round_id = _create_round(app, [song_id], name='SMTP Error Round')
+        with app.app_context():
+            round_ = Round.query.get(round_id)
+            round_.mp3_generated = True
+            db.session.commit()
+
+        with patch('musicround.routes.rounds.generate_pdf', return_value=b'%PDF'), \
+                patch('musicround.routes.rounds.os.path.exists', return_value=True), \
+                patch('builtins.open', mock_open(read_data=b'ID3 test mp3')), \
+                patch(
+                    'musicround.routes.rounds.send_quiz_email',
+                    return_value=(False, 'Missing parameters: MAIL_PASSWORD'),
+                ):
+            response = client.post(
+                f'/rounds/{round_id}/mail',
+                headers={'X-Requested-With': 'XMLHttpRequest'},
+            )
+
+        assert response.status_code == 200
+        assert response.get_json()['error'] == (
+            'Unable to send the email. Please try again later or contact an administrator.'
+        )


### PR DESCRIPTION
## Summary
- block round email delivery when MP3 generation returns an error or fails to create the expected MP3 file
- route round email sending through the shared email helper instead of duplicating SMTP/MIME logic in the route
- make the shared email helper respect MAIL_USE_TLS and MAIL_USE_SSL

## Root Cause
The round mail route only checked for a string error from `round_mp3()`, but `round_mp3()` returns Flask responses or response tuples. Failed MP3 generation could therefore continue into attachment handling and fail later with a 500. The route also duplicated SMTP code that always attempted STARTTLS regardless of SSL/TLS configuration.

## Validation
- `SECRET_KEY=test-secret AUTOMATION_TOKEN=test-token .venv/bin/python -m py_compile musicround/helpers/email_helper.py musicround/routes/rounds.py tests/test_rounds_routes.py tests/test_email_helper.py`
- `SECRET_KEY=test-secret AUTOMATION_TOKEN=test-token .venv/bin/python -m pytest tests/test_rounds_routes.py tests/test_email_helper.py -q`
- `SECRET_KEY=test-secret AUTOMATION_TOKEN=test-token .venv/bin/python -m pytest -q`
- `SECRET_KEY=test-secret AUTOMATION_TOKEN=test-token .venv/bin/python -m flake8 musicround/helpers/email_helper.py musicround/routes/rounds.py tests/test_rounds_routes.py tests/test_email_helper.py --select=E9,F63,F7,F82`

Closes #97


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Email delivery now supports both SSL and TLS connection modes for greater compatibility with different mail server setups.
  * Round emails now include attached PDF and MP3 files through a centralized sending flow.

* **Bug Fixes**
  * Improved error handling when MP3 generation fails, including clearer user-facing messages.
  * Email sending failures now return consistent failure responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->