### PR TITLE
[codex] Add round ops review workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added a browser round-ops workflow with round calendar, catalog/fatigue analytics, quizmaster planning briefs, round review/approval state, package quality inspection, actionable replacement suggestions, and browser review of announcement and per-track hint script drafts.
 - Added a public-safe `/healthz` endpoint and reusable service-health payloads for database, artifact storage, Spotify, Dropbox, and email checks.
 - Added import queue and worker health to service-health payloads, including pending/dead-letter job warnings.
 - Added readiness and scheduled-delivery badges to the rounds list.

--- a/migrations/add_round_review_workflow.py
+++ b/migrations/add_round_review_workflow.py
@@ -1,0 +1,70 @@
+"""Add review and approval state to quiz rounds."""
+
+import logging
+
+from sqlalchemy import inspect, text
+
+logger = logging.getLogger(__name__)
+
+
+def _columns(inspector, table_name):
+    return {column["name"] for column in inspector.get_columns(table_name)}
+
+
+def _index_exists(inspector, table_name, index_name):
+    return any(index.get("name") == index_name for index in inspector.get_indexes(table_name))
+
+
+def run_migration():
+    """Backfill lightweight round-review workflow columns."""
+    try:
+        from musicround import db
+
+        inspector = inspect(db.engine)
+        if "round" not in set(inspector.get_table_names()):
+            logger.info("Skipping round review migration because round table is missing")
+            return None
+
+        changes_made = False
+        with db.engine.connect() as conn:
+            preparer = conn.dialect.identifier_preparer
+            round_table = preparer.quote("round")
+            columns = _columns(inspector, "round")
+            column_defs = {
+                "review_status": "VARCHAR(20) DEFAULT 'draft' NOT NULL",
+                "review_notes": "TEXT",
+                "approved_at": "DATETIME",
+                "approved_by_id": "INTEGER",
+            }
+            for column_name, column_type in column_defs.items():
+                if column_name not in columns:
+                    conn.execute(text(f"ALTER TABLE {round_table} ADD COLUMN {column_name} {column_type}"))
+                    changes_made = True
+
+            inspector = inspect(db.engine)
+            columns = _columns(inspector, "round")
+            if (
+                {"review_status", "approved_at"}.issubset(columns)
+                and not _index_exists(inspector, "round", "idx_round_review_status")
+            ):
+                quoted_index = preparer.quote("idx_round_review_status")
+                conn.execute(
+                    text(
+                        f"CREATE INDEX {quoted_index} ON {round_table} "
+                        "(review_status, approved_at)"
+                    )
+                )
+                changes_made = True
+
+            if changes_made:
+                conn.commit()
+
+        return True if changes_made else None
+    except Exception as exc:
+        logger.error("Migration add_round_review_workflow failed: %s", exc)
+        return False
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    run_migration()

--- a/migrations/add_round_review_workflow.py
+++ b/migrations/add_round_review_workflow.py
@@ -67,4 +67,8 @@ def run_migration():
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
-    run_migration()
+    from musicround import create_app
+
+    app = create_app()
+    with app.app_context():
+        run_migration()

--- a/musicround/models.py
+++ b/musicround/models.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from musicround import db
 from flask_login import UserMixin
+from sqlalchemy.orm import validates
 from werkzeug.security import generate_password_hash, check_password_hash
 import uuid
 
@@ -289,6 +290,13 @@ class Round(db.Model):
             f"Round('{self.name or self.id}', '{self.round_type}', '{self.round_criteria_used}', "
             f"'{self.songs}', '{self.created_at}')"
         )
+
+    @validates('review_status')
+    def _validate_review_status(self, key, value):
+        allowed_statuses = {'draft', 'reviewed', 'approved', 'rejected'}
+        if value not in allowed_statuses:
+            raise ValueError(f"Invalid review_status: {value!r}")
+        return value
 
     @property
     def song_id_list(self):

--- a/musicround/models.py
+++ b/musicround/models.py
@@ -269,14 +269,20 @@ class Round(db.Model):
     mp3_generated = db.Column(db.Boolean, default=False)  # Track if MP3 has been generated
     pdf_generated = db.Column(db.Boolean, default=False)  # Track if PDF has been generated
     last_generated_at = db.Column(db.DateTime, nullable=True)  # When files were last generated
+    review_status = db.Column(db.String(20), default='draft', nullable=False)
+    review_notes = db.Column(db.Text, nullable=True)
+    approved_at = db.Column(db.DateTime, nullable=True)
+    approved_by_id = db.Column(db.Integer, db.ForeignKey('user.id', ondelete='SET NULL'), nullable=True)
 
     __table_args__ = (
         db.Index('idx_round_created_at', 'created_at'),
         db.Index('idx_round_generation_status', 'mp3_generated', 'pdf_generated'),
         db.Index('idx_round_owner_created', 'user_id', 'created_at'),
+        db.Index('idx_round_review_status', 'review_status', 'approved_at'),
     )
 
     owner = db.relationship('User', backref=db.backref('rounds', lazy='dynamic'), foreign_keys=[user_id])
+    approved_by = db.relationship('User', foreign_keys=[approved_by_id])
 
     def __repr__(self):
         return (

--- a/musicround/routes/rounds.py
+++ b/musicround/routes/rounds.py
@@ -25,6 +25,8 @@ from musicround.helpers.storage_health import (
     round_mp3_dir,
     round_pdf_dir,
 )
+from musicround.services import automation
+from musicround.services.automation import AutomationError
 
 rounds_bp = Blueprint('rounds', __name__, url_prefix='/rounds')
 
@@ -239,6 +241,21 @@ def _storage_failure_response(round_id, storage_health, status_code=503):
     return redirect(url_for('rounds.round_detail', round_id=round_id))
 
 
+def _automation_error_response(error, status_code=400):
+    details = getattr(error, 'details', None)
+    payload = {'success': False, 'error': str(error)}
+    if details:
+        payload['details'] = details
+    return jsonify(payload), status_code
+
+
+def _bool_form_value(name, default=False):
+    raw_value = request.form.get(name, request.args.get(name))
+    if raw_value is None:
+        return default
+    return str(raw_value).lower() in {'1', 'true', 'yes', 'on'}
+
+
 def _round_generation_failure_response(round_id, log_message, user_message, status_code=500):
     """Return safe render-generation errors while preserving details in logs."""
     current_app.logger.error(log_message)
@@ -295,6 +312,75 @@ def rounds_list():
         round_statuses=_rounds_list_statuses(rounds),
     )
 
+
+@rounds_bp.route('/calendar')
+@login_required
+def rounds_calendar():
+    """Show scheduled round email exports as a lightweight quiz calendar."""
+    visible_round_ids = _visible_rounds_query().with_entities(Round.id)
+    exports = (
+        RoundExport.query.filter(
+            RoundExport.round_id.in_(visible_round_ids),
+            RoundExport.export_type == 'email',
+            RoundExport.scheduled_for.isnot(None),
+        )
+        .order_by(RoundExport.scheduled_for.asc(), RoundExport.id.asc())
+        .limit(100)
+        .all()
+    )
+    return render_template('round_calendar.html', exports=exports)
+
+
+@rounds_bp.route('/analytics')
+@login_required
+def rounds_analytics():
+    """Show catalog and music-round fatigue signals for planning."""
+    months = _int_arg('months', default=6, minimum=1, maximum=36)
+    limit = _int_arg('limit', default=20, minimum=1, maximum=100)
+    try:
+        summary = automation.round_analytics_summary(months=months, limit=limit)
+    except AutomationError as exc:
+        flash(str(exc), 'error')
+        summary = None
+    return render_template(
+        'round_analytics.html',
+        summary=summary,
+        filters={'months': months, 'limit': limit},
+    )
+
+
+@rounds_bp.route('/planning')
+@login_required
+def round_planning():
+    """Render an agent-readable planning brief for the current quizmaster."""
+    months = _int_arg('months', default=3, minimum=1, maximum=24)
+    desired_song_count = _int_arg('desired_song_count', default=8, minimum=1, maximum=25)
+    theme = request.args.get('theme') or None
+    quiz_date = request.args.get('quiz_date') or None
+    brief = None
+    if theme or quiz_date:
+        try:
+            brief = automation.round_planning_brief(
+                user_id=current_user.id,
+                quiz_date=quiz_date,
+                theme=theme,
+                desired_song_count=desired_song_count,
+                months=months,
+            )
+        except AutomationError as exc:
+            flash(str(exc), 'error')
+    return render_template(
+        'round_planning.html',
+        brief=brief,
+        filters={
+            'theme': theme or '',
+            'quiz_date': quiz_date or '',
+            'months': months,
+            'desired_song_count': desired_song_count,
+        },
+    )
+
+
 @rounds_bp.route('/<int:round_id>')
 @login_required
 def round_detail(round_id):
@@ -318,7 +404,28 @@ def round_detail(round_id):
         except Exception as e:  # Catch a broader range of exceptions, including MissingTokenError
             current_app.logger.warning(f"Could not get Spotify user info using Authlib: {str(e)}")
         
-        return render_template('round_detail.html', round=rnd, songs=ordered_songs, user_info=user_info, email_error=email_error)
+        audio_scripts = (
+            RoundAudioScript.query.filter_by(round_id=rnd.id)
+            .order_by(RoundAudioScript.created_at.desc(), RoundAudioScript.id.desc())
+            .limit(25)
+            .all()
+        )
+        scheduled_exports = (
+            RoundExport.query.filter_by(round_id=rnd.id, export_type='email')
+            .order_by(RoundExport.timestamp.desc(), RoundExport.id.desc())
+            .limit(10)
+            .all()
+        )
+
+        return render_template(
+            'round_detail.html',
+            round=rnd,
+            songs=ordered_songs,
+            user_info=user_info,
+            email_error=email_error,
+            audio_scripts=audio_scripts,
+            scheduled_exports=scheduled_exports,
+        )
     else:
         return 'Round not found'
 
@@ -356,6 +463,164 @@ def update_round_songs(round_id):
     else:
         flash('No song order provided', 'error')
         
+    return redirect(url_for('rounds.round_detail', round_id=round_id))
+
+
+@rounds_bp.route('/<int:round_id>/review', methods=['POST'])
+@login_required
+def update_round_review(round_id):
+    """Update human review state for a round."""
+    rnd = _get_editable_round_or_404(round_id)
+    status = (request.form.get('review_status') or '').strip().lower()
+    notes = (request.form.get('review_notes') or '').strip() or None
+    if status not in {'draft', 'reviewed', 'approved', 'rejected'}:
+        return _automation_error_response(AutomationError('Invalid review status.'), 400)
+
+    rnd.review_status = status
+    rnd.review_notes = notes
+    if status == 'approved':
+        rnd.approved_at = datetime.utcnow()
+        rnd.approved_by_id = current_user.id
+    elif status in {'draft', 'rejected'}:
+        rnd.approved_at = None
+        rnd.approved_by_id = None
+    rnd.updated_at = datetime.utcnow()
+    db.session.commit()
+
+    if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
+        return jsonify({
+            'success': True,
+            'review_status': rnd.review_status,
+            'approved_at': rnd.approved_at.isoformat() if rnd.approved_at else None,
+        })
+    flash('Round review status updated', 'success')
+    return redirect(url_for('rounds.round_detail', round_id=round_id))
+
+
+@rounds_bp.route('/<int:round_id>/quality', methods=['GET'])
+@login_required
+def round_quality(round_id):
+    """Return package quality and repair guidance for a round."""
+    _get_visible_round_or_404(round_id)
+    try:
+        result = automation.round_repair_report(
+            round_id=round_id,
+            user_id=current_user.id,
+            expected_song_count=_int_arg('expected_song_count', default=8, minimum=1, maximum=25),
+            min_preview_seconds=float(request.args.get('min_preview_seconds', 20.0)),
+            max_preview_seconds=float(request.args.get('max_preview_seconds', 35.0)),
+        )
+    except ValueError:
+        return _automation_error_response(AutomationError('Preview duration values must be numeric.'), 400)
+    except AutomationError as exc:
+        return _automation_error_response(exc, 400)
+    return jsonify({'success': True, **result})
+
+
+@rounds_bp.route('/<int:round_id>/replacement-suggestions', methods=['GET'])
+@login_required
+def replacement_suggestions(round_id):
+    """Return replacement candidates for one round position."""
+    _get_visible_round_or_404(round_id)
+    position = _int_arg('position', default=None, minimum=1, maximum=25)
+    if position is None:
+        return _automation_error_response(AutomationError('position is required.'), 400)
+    try:
+        result = automation.suggest_replacement_songs(
+            round_id=round_id,
+            position=position,
+            limit=_int_arg('limit', default=8, minimum=1, maximum=25),
+            query=request.args.get('query') or None,
+            require_deezer_id=_bool_form_value('require_deezer_id', True),
+            verify_previews=_bool_form_value('verify_previews', False),
+        )
+    except AutomationError as exc:
+        return _automation_error_response(exc, 400)
+    return jsonify({'success': True, **result})
+
+
+@rounds_bp.route('/<int:round_id>/replace-song', methods=['POST'])
+@login_required
+def replace_round_song(round_id):
+    """Replace one song in a round from a reviewed suggestion."""
+    _get_editable_round_or_404(round_id)
+    position = request.form.get('position')
+    replacement_song_id = request.form.get('replacement_song_id')
+    try:
+        result = automation.replace_round_song(
+            round_id=round_id,
+            position=int(position),
+            replacement_song_id=int(replacement_song_id),
+            inspect_after=_bool_form_value('inspect_after', False),
+            user_id=current_user.id,
+        )
+    except (TypeError, ValueError):
+        return _automation_error_response(
+            AutomationError('position and replacement_song_id are required integers.'),
+            400,
+        )
+    except AutomationError as exc:
+        return _automation_error_response(exc, 400)
+    return jsonify({'success': True, **result})
+
+
+@rounds_bp.route('/<int:round_id>/draft-audio-scripts', methods=['POST'])
+@login_required
+def draft_audio_scripts(round_id):
+    """Draft and persist intro/replay/outro scripts for review."""
+    _get_editable_round_or_404(round_id)
+    try:
+        automation.draft_round_audio_scripts(
+            round_id=round_id,
+            user_id=current_user.id,
+            quiz_date=request.form.get('quiz_date') or None,
+            theme=request.form.get('theme') or None,
+            tone=request.form.get('tone') or 'warm, concise, lightly humorous',
+            persist=True,
+        )
+    except AutomationError as exc:
+        flash(str(exc), 'error')
+    else:
+        flash('Audio script drafts created', 'success')
+    return redirect(url_for('rounds.round_detail', round_id=round_id))
+
+
+@rounds_bp.route('/<int:round_id>/draft-track-hints', methods=['POST'])
+@login_required
+def draft_track_hints(round_id):
+    """Draft and persist per-track hint scripts for review."""
+    _get_editable_round_or_404(round_id)
+    try:
+        automation.draft_round_track_hints(
+            round_id=round_id,
+            user_id=current_user.id,
+            tone=request.form.get('tone') or 'concise, playful, no title or artist spoilers',
+            persist=True,
+        )
+    except AutomationError as exc:
+        flash(str(exc), 'error')
+    else:
+        flash('Track hint drafts created', 'success')
+    return redirect(url_for('rounds.round_detail', round_id=round_id))
+
+
+@rounds_bp.route('/<int:round_id>/audio-scripts/<int:script_id>', methods=['POST'])
+@login_required
+def update_audio_script(round_id, script_id):
+    """Review or edit one stored audio script."""
+    _get_editable_round_or_404(round_id)
+    script = RoundAudioScript.query.filter_by(id=script_id, round_id=round_id).first_or_404()
+    try:
+        automation.update_round_audio_script(
+            script.id,
+            text=request.form.get('text'),
+            status=request.form.get('status') or None,
+            selected=_bool_form_value('selected', False),
+        )
+    except AutomationError as exc:
+        flash(str(exc), 'error')
+    else:
+        flash('Audio script updated', 'success')
     return redirect(url_for('rounds.round_detail', round_id=round_id))
 
 @rounds_bp.route('/round/<int:round_id>/mp3', methods=['POST'])

--- a/musicround/routes/rounds.py
+++ b/musicround/routes/rounds.py
@@ -481,7 +481,7 @@ def update_round_review(round_id):
     if status == 'approved':
         rnd.approved_at = datetime.utcnow()
         rnd.approved_by_id = current_user.id
-    elif status in {'draft', 'rejected'}:
+    else:
         rnd.approved_at = None
         rnd.approved_by_id = None
     rnd.updated_at = datetime.utcnow()
@@ -532,7 +532,7 @@ def replacement_suggestions(round_id):
             limit=_int_arg('limit', default=8, minimum=1, maximum=25),
             query=request.args.get('query') or None,
             require_deezer_id=_bool_form_value('require_deezer_id', True),
-            verify_previews=_bool_form_value('verify_previews', False),
+            verify_previews=False,
         )
     except AutomationError as exc:
         return _automation_error_response(exc, 400)

--- a/musicround/templates/base.html
+++ b/musicround/templates/base.html
@@ -145,6 +145,16 @@
                                 <li>
                                     <a class="text-white hover:text-teal-500" href="{{ url_for('rounds.rounds_list') }}">View Rounds</a>
                                 </li>
+                                <li class="group relative">
+                                    <button class="peer flex items-center text-white hover:text-teal-500">
+                                        Round Ops <i class="fas fa-chevron-down ml-1"></i>
+                                    </button>
+                                    <ul class="hidden peer-hover:flex hover:flex flex-col absolute bg-white text-gray-800 shadow-md py-2 rounded-md w-48 z-10">
+                                        <li><a class="block px-4 py-2 hover:bg-navy-50" href="{{ url_for('rounds.rounds_calendar') }}">Calendar</a></li>
+                                        <li><a class="block px-4 py-2 hover:bg-navy-50" href="{{ url_for('rounds.rounds_analytics') }}">Analytics</a></li>
+                                        <li><a class="block px-4 py-2 hover:bg-navy-50" href="{{ url_for('rounds.round_planning') }}">Planning Brief</a></li>
+                                    </ul>
+                                </li>
                                 {% if current_user.is_admin %}
                                 <li class="group relative">
                                     <button class="peer flex items-center text-white hover:text-teal-500">
@@ -244,4 +254,3 @@
     {% endblock %}
 </body>
 </html>
-

--- a/musicround/templates/round_analytics.html
+++ b/musicround/templates/round_analytics.html
@@ -1,0 +1,70 @@
+{% extends 'base.html' %}
+
+{% block title %}Round Analytics - Quizzical Beats{% endblock %}
+
+{% block content %}
+<div class="max-w-7xl mx-auto px-4 py-8">
+    <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-3 mb-6">
+        <div>
+            <h1 class="text-3xl font-bold text-navy-800 font-montserrat">Round Analytics</h1>
+            <p class="text-gray-600 mt-1">Catalog coverage, fatigue signals, and replacement pressure.</p>
+        </div>
+        <form method="get" class="flex items-end gap-3">
+            <div>
+                <label class="block text-sm font-medium text-gray-700 mb-1" for="months">Months</label>
+                <input id="months" name="months" type="number" min="1" max="36" value="{{ filters.months }}" class="px-3 py-2 border border-gray-300 rounded-md">
+            </div>
+            <div>
+                <label class="block text-sm font-medium text-gray-700 mb-1" for="limit">Limit</label>
+                <input id="limit" name="limit" type="number" min="1" max="100" value="{{ filters.limit }}" class="px-3 py-2 border border-gray-300 rounded-md">
+            </div>
+            <button type="submit" class="bg-teal-500 hover:bg-teal-600 text-white py-2 px-4 rounded-md transition-colors">Apply</button>
+        </form>
+    </div>
+
+    {% if summary %}
+    <div class="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
+        <div class="bg-white shadow-md rounded-lg p-5"><div class="text-sm text-gray-500">Songs</div><div class="text-3xl font-bold text-navy-800">{{ summary.song_count }}</div></div>
+        <div class="bg-white shadow-md rounded-lg p-5"><div class="text-sm text-gray-500">Rounds</div><div class="text-3xl font-bold text-navy-800">{{ summary.round_count }}</div></div>
+        <div class="bg-white shadow-md rounded-lg p-5"><div class="text-sm text-gray-500">Recent Rounds</div><div class="text-3xl font-bold text-navy-800">{{ summary.recent_round_count }}</div></div>
+        <div class="bg-white shadow-md rounded-lg p-5"><div class="text-sm text-gray-500">Missing Previews</div><div class="text-3xl font-bold text-red-700">{{ summary.missing_preview_count }}</div></div>
+    </div>
+
+    <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <div class="bg-white shadow-md rounded-lg p-6">
+            <h2 class="text-xl font-bold text-navy-800 font-montserrat mb-3">Most Used</h2>
+            <div class="space-y-2">
+                {% for song in summary.most_used_songs %}
+                <div class="border-b border-gray-100 pb-2">
+                    <div class="font-semibold">{{ song.artist }} - {{ song.title }}</div>
+                    <div class="text-xs text-gray-500">Used {{ song.used_count or 0 }}x{% if song.last_used %} · {{ song.last_used }}{% endif %}</div>
+                </div>
+                {% endfor %}
+            </div>
+        </div>
+        <div class="bg-white shadow-md rounded-lg p-6">
+            <h2 class="text-xl font-bold text-navy-800 font-montserrat mb-3">Unused Candidates</h2>
+            <div class="space-y-2">
+                {% for song in summary.unused_candidates %}
+                <div class="border-b border-gray-100 pb-2">
+                    <div class="font-semibold">{{ song.artist }} - {{ song.title }}</div>
+                    <div class="text-xs text-gray-500">{{ song.year or 'Unknown year' }}{% if song.genre %} · {{ song.genre }}{% endif %}</div>
+                </div>
+                {% endfor %}
+            </div>
+        </div>
+        <div class="bg-white shadow-md rounded-lg p-6">
+            <h2 class="text-xl font-bold text-navy-800 font-montserrat mb-3">Genres</h2>
+            <div class="space-y-2">
+                {% for genre, count in summary.genre_counts.items() %}
+                <div>
+                    <div class="flex justify-between text-sm"><span>{{ genre }}</span><span>{{ count }}</span></div>
+                    <div class="h-2 bg-gray-100 rounded"><div class="h-2 bg-teal-500 rounded" style="width: {{ (count / summary.song_count * 100) if summary.song_count else 0 }}%"></div></div>
+                </div>
+                {% endfor %}
+            </div>
+        </div>
+    </div>
+    {% endif %}
+</div>
+{% endblock %}

--- a/musicround/templates/round_calendar.html
+++ b/musicround/templates/round_calendar.html
@@ -1,0 +1,56 @@
+{% extends 'base.html' %}
+
+{% block title %}Round Calendar - Quizzical Beats{% endblock %}
+
+{% block content %}
+<div class="max-w-6xl mx-auto px-4 py-8">
+    <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-3 mb-6">
+        <div>
+            <h1 class="text-3xl font-bold text-navy-800 font-montserrat">Round Calendar</h1>
+            <p class="text-gray-600 mt-1">Scheduled and processed email deliveries for visible rounds.</p>
+        </div>
+        <a href="{{ url_for('rounds.rounds_list') }}" class="bg-navy-700 hover:bg-navy-800 text-white py-2 px-4 rounded-md transition-colors text-sm font-semibold">
+            <i class="fas fa-list mr-1"></i> Rounds
+        </a>
+    </div>
+
+    <div class="bg-white shadow-md rounded-lg overflow-hidden">
+        <table class="w-full table-auto">
+            <thead class="bg-navy-50 text-navy-800">
+                <tr>
+                    <th class="px-4 py-3 text-left font-semibold">When</th>
+                    <th class="px-4 py-3 text-left font-semibold">Round</th>
+                    <th class="px-4 py-3 text-left font-semibold">Status</th>
+                    <th class="px-4 py-3 text-left font-semibold">Destination</th>
+                    <th class="px-4 py-3 text-left font-semibold">Action</th>
+                </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-200">
+                {% for export in exports %}
+                <tr class="hover:bg-gray-50">
+                    <td class="px-4 py-3">{{ export.scheduled_for.strftime('%Y-%m-%d %H:%M') if export.scheduled_for else '-' }}</td>
+                    <td class="px-4 py-3 font-medium">{{ export.round.name if export.round and export.round.name else 'Quiz #' + export.round_id|string }}</td>
+                    <td class="px-4 py-3">
+                        <span class="px-2 py-1 text-xs font-semibold rounded-full
+                            {% if export.status == 'scheduled' %}bg-blue-100 text-blue-800
+                            {% elif export.status == 'success' %}bg-green-100 text-green-800
+                            {% elif export.status == 'failed' %}bg-red-100 text-red-800
+                            {% else %}bg-gray-100 text-gray-800{% endif %}">
+                            {{ export.status|capitalize }}
+                        </span>
+                    </td>
+                    <td class="px-4 py-3 text-sm text-gray-600">{{ export.destination or '-' }}</td>
+                    <td class="px-4 py-3">
+                        <a href="{{ url_for('rounds.round_detail', round_id=export.round_id) }}" class="bg-teal-500 hover:bg-teal-600 text-white py-1.5 px-3 rounded text-sm transition-colors">Open</a>
+                    </td>
+                </tr>
+                {% else %}
+                <tr>
+                    <td colspan="5" class="px-4 py-8 text-center text-gray-500">No scheduled round emails yet.</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</div>
+{% endblock %}

--- a/musicround/templates/round_detail.html
+++ b/musicround/templates/round_detail.html
@@ -52,6 +52,19 @@
                 </p>
                 <p class="text-gray-700 mt-1"><span class="font-semibold text-teal-700">Criteria:</span> {{ round.round_criteria_used }}</p>
                 <p class="text-gray-700 mt-1"><span class="font-semibold text-teal-700">Created:</span> {{ round.created_at.strftime('%Y-%m-%d %H:%M:%S') }}</p>
+                <p class="text-gray-700 mt-1">
+                    <span class="font-semibold text-teal-700">Review:</span>
+                    <span class="px-2 py-1 text-xs font-semibold rounded-full
+                        {% if round.review_status == 'approved' %}bg-green-100 text-green-800
+                        {% elif round.review_status == 'reviewed' %}bg-blue-100 text-blue-800
+                        {% elif round.review_status == 'rejected' %}bg-red-100 text-red-800
+                        {% else %}bg-gray-100 text-gray-800{% endif %}">
+                        {{ round.review_status|capitalize }}
+                    </span>
+                    {% if round.approved_at %}
+                    <span class="ml-2 text-sm text-gray-500">{{ round.approved_at.strftime('%Y-%m-%d %H:%M') }}</span>
+                    {% endif %}
+                </p>
             </div>
             
             <div class="self-end mt-4 md:mt-0">
@@ -63,6 +76,69 @@
             <div class="text-center px-6 py-2 rounded-full bg-navy-100 text-navy-800 font-semibold inline-block">
                 <span>{{ songs|length }} Songs</span>
             </div>
+        </div>
+    </div>
+
+    <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-8">
+        <div class="bg-white shadow-md rounded-lg p-6 lg:col-span-2">
+            <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-3 mb-4">
+                <div>
+                    <h2 class="text-2xl font-bold text-navy-800 font-montserrat">Quality Gate</h2>
+                    <p class="text-sm text-gray-600">Package check before scheduling or email delivery.</p>
+                </div>
+                <button id="inspect-round-btn" class="bg-teal-500 hover:bg-teal-600 text-white py-2 px-4 rounded transition-colors font-semibold">
+                    <i class="fas fa-stethoscope mr-2"></i> Inspect Round
+                </button>
+            </div>
+            <div id="quality-result" class="border border-gray-200 rounded-md p-4 bg-gray-50 text-sm text-gray-700">
+                <p>Run the package check to see preview, MP3, PDF, and duration readiness.</p>
+            </div>
+            <div id="repair-suggestions" class="hidden mt-4 border border-orange-200 rounded-md p-4 bg-orange-50">
+                <h3 class="font-semibold text-orange-800 mb-3">Replacement Candidates</h3>
+                <div class="grid grid-cols-1 md:grid-cols-4 gap-3 mb-3">
+                    <input type="number" id="replacement-position" min="1" max="25" class="px-3 py-2 border border-gray-300 rounded-md" placeholder="Position">
+                    <input type="text" id="replacement-query" class="px-3 py-2 border border-gray-300 rounded-md md:col-span-2" placeholder="Optional artist/title filter">
+                    <button id="load-replacements-btn" class="bg-orange-500 hover:bg-orange-600 text-white py-2 px-4 rounded transition-colors">
+                        <i class="fas fa-search mr-2"></i> Find
+                    </button>
+                </div>
+                <div id="replacement-list" class="space-y-2"></div>
+            </div>
+        </div>
+
+        <div class="bg-white shadow-md rounded-lg p-6">
+            <h2 class="text-2xl font-bold text-navy-800 font-montserrat mb-4">Review State</h2>
+            <form method="POST" action="{{ url_for('rounds.update_round_review', round_id=round.id) }}" class="space-y-4">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+                <div>
+                    <label class="block text-sm font-medium text-gray-700 mb-1" for="review_status">Status</label>
+                    <select id="review_status" name="review_status" class="px-3 py-2 border border-gray-300 rounded-md">
+                        {% for status in ['draft', 'reviewed', 'approved', 'rejected'] %}
+                        <option value="{{ status }}" {% if round.review_status == status %}selected{% endif %}>{{ status|capitalize }}</option>
+                        {% endfor %}
+                    </select>
+                </div>
+                <div>
+                    <label class="block text-sm font-medium text-gray-700 mb-1" for="review_notes">Notes</label>
+                    <textarea id="review_notes" name="review_notes" rows="4" class="px-3 py-2 border border-gray-300 rounded-md">{{ round.review_notes or '' }}</textarea>
+                </div>
+                <button type="submit" class="w-full bg-navy-700 hover:bg-navy-800 text-white py-2 px-4 rounded transition-colors font-semibold">
+                    <i class="fas fa-check mr-2"></i> Save Review
+                </button>
+            </form>
+            {% if scheduled_exports %}
+            <div class="mt-6">
+                <h3 class="font-semibold text-navy-800 mb-2">Email History</h3>
+                <div class="space-y-2">
+                    {% for export in scheduled_exports %}
+                    <div class="text-xs border border-gray-200 rounded p-2">
+                        <div class="font-semibold">{{ export.status|capitalize }}{% if export.scheduled_for %} for {{ export.scheduled_for.strftime('%Y-%m-%d %H:%M') }}{% endif %}</div>
+                        <div class="text-gray-500">{{ export.destination or 'No destination' }}</div>
+                    </div>
+                    {% endfor %}
+                </div>
+            </div>
+            {% endif %}
         </div>
     </div>
 
@@ -171,6 +247,61 @@
             <button id="export-dropbox-btn" class="bg-blue-600 hover:bg-blue-700 text-white py-2 px-4 rounded transition-colors w-full font-semibold">
                 <i class="fab fa-dropbox mr-2"></i> Export to Dropbox
             </button>
+        </div>
+    </div>
+
+    <div class="bg-white shadow-md rounded-lg p-6 mb-8">
+        <div class="flex flex-col lg:flex-row lg:justify-between gap-6">
+            <div class="lg:w-1/2">
+                <h2 class="text-2xl font-bold text-navy-800 font-montserrat mb-4">Announcements & Hints</h2>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <form method="POST" action="{{ url_for('rounds.draft_audio_scripts', round_id=round.id) }}" class="border border-gray-200 rounded-md p-4 space-y-3">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+                        <h3 class="font-semibold text-navy-800">Intro, Replay, Outro</h3>
+                        <input type="text" name="theme" class="px-3 py-2 border border-gray-300 rounded-md" placeholder="Theme" value="{{ round.name or '' }}">
+                        <input type="datetime-local" name="quiz_date" class="px-3 py-2 border border-gray-300 rounded-md">
+                        <input type="text" name="tone" class="px-3 py-2 border border-gray-300 rounded-md" value="warm, concise, lightly humorous">
+                        <button type="submit" class="w-full bg-teal-500 hover:bg-teal-600 text-white py-2 px-4 rounded transition-colors">
+                            <i class="fas fa-pen-nib mr-2"></i> Draft Scripts
+                        </button>
+                    </form>
+                    <form method="POST" action="{{ url_for('rounds.draft_track_hints', round_id=round.id) }}" class="border border-gray-200 rounded-md p-4 space-y-3">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+                        <h3 class="font-semibold text-navy-800">Per-Track Hints</h3>
+                        <textarea name="tone" rows="4" class="px-3 py-2 border border-gray-300 rounded-md">concise, playful, no title or artist spoilers</textarea>
+                        <button type="submit" class="w-full bg-orange-500 hover:bg-orange-600 text-white py-2 px-4 rounded transition-colors">
+                            <i class="fas fa-lightbulb mr-2"></i> Draft Hints
+                        </button>
+                    </form>
+                </div>
+            </div>
+            <div class="lg:w-1/2">
+                <h3 class="font-semibold text-navy-800 mb-3">Script Review Queue</h3>
+                <div class="space-y-3 max-h-96 overflow-y-auto pr-2">
+                    {% for script in audio_scripts %}
+                    <form method="POST" action="{{ url_for('rounds.update_audio_script', round_id=round.id, script_id=script.id) }}" class="border border-gray-200 rounded-md p-3">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+                        <div class="flex flex-wrap items-center justify-between gap-2 mb-2">
+                            <span class="font-semibold text-sm">{{ script.script_type|replace('_', ' ')|title }}{% if script.cue_position %} #{{ script.cue_position }}{% endif %}</span>
+                            <select name="status" class="text-xs px-2 py-1 border border-gray-300 rounded-md w-auto">
+                                {% for status in ['draft', 'reviewed', 'approved', 'rejected', 'used'] %}
+                                <option value="{{ status }}" {% if script.status == status %}selected{% endif %}>{{ status|capitalize }}</option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                        <textarea name="text" rows="3" class="text-sm px-3 py-2 border border-gray-300 rounded-md">{{ script.text }}</textarea>
+                        <label class="mt-2 flex items-center text-sm text-gray-700">
+                            <input type="checkbox" name="selected" class="mr-2" {% if script.selected %}checked{% endif %}> Selected for playback
+                        </label>
+                        <button type="submit" class="mt-2 bg-navy-700 hover:bg-navy-800 text-white py-1.5 px-3 rounded text-sm transition-colors">
+                            Save Script
+                        </button>
+                    </form>
+                    {% else %}
+                    <p class="text-sm text-gray-500">No script drafts yet.</p>
+                    {% endfor %}
+                </div>
+            </div>
         </div>
     </div>
 
@@ -502,6 +633,7 @@
         const toastMessage = document.getElementById('toast-message');
         const toastIcon = document.getElementById('toast-icon');
         const toastCloseBtn = document.getElementById('toast-close-btn');
+        const csrfToken = '{{ csrf_token() }}';
         
         // Toast notification functions
         function showToast(message, type = 'success') {
@@ -534,6 +666,18 @@
         
         function hideToast() {
             toast.style.transform = 'translateX(100%)';
+        }
+
+        function escapeHtml(value) {
+            return String(value ?? '').replace(/[&<>"']/g, function(character) {
+                return {
+                    '&': '&amp;',
+                    '<': '&lt;',
+                    '>': '&gt;',
+                    '"': '&quot;',
+                    "'": '&#39;'
+                }[character];
+            });
         }
         
         // Close toast button event
@@ -728,6 +872,134 @@
             editTitleForm.classList.add('hidden');
             quizTitleDisplay.classList.remove('hidden');
         });
+
+        const inspectRoundBtn = document.getElementById('inspect-round-btn');
+        const qualityResult = document.getElementById('quality-result');
+        const repairSuggestions = document.getElementById('repair-suggestions');
+        const replacementPosition = document.getElementById('replacement-position');
+        const replacementQuery = document.getElementById('replacement-query');
+        const loadReplacementsBtn = document.getElementById('load-replacements-btn');
+        const replacementList = document.getElementById('replacement-list');
+
+        function renderQualityReport(data) {
+            const report = data.report || {};
+            const quality = data.quality || {};
+            const badgeClass = report.ok ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800';
+            const blockers = (report.blockers || []).map(item => `<li>${escapeHtml(item)}</li>`).join('');
+            const actions = (report.actions || []).map(item => `<li>${escapeHtml(item.message)}</li>`).join('');
+            const failed = (report.failed_positions || []).map(item => {
+                const position = Number(item.position) || '';
+                return `<button type="button" class="failed-position bg-orange-100 hover:bg-orange-200 text-orange-800 px-2 py-1 rounded text-xs mr-2 mb-2" data-position="${position}">Position ${position}</button>`;
+            }).join('');
+            qualityResult.innerHTML = `
+                <div class="flex flex-wrap items-center gap-3 mb-3">
+                    <span class="px-2 py-1 text-xs font-semibold rounded-full ${badgeClass}">${escapeHtml(quality.status || report.status || 'unknown')}</span>
+                    <span>${escapeHtml(report.summary || '')}</span>
+                </div>
+                ${blockers ? `<div class="mb-3"><h3 class="font-semibold text-red-800">Blockers</h3><ul class="list-disc pl-5">${blockers}</ul></div>` : ''}
+                ${actions ? `<div class="mb-3"><h3 class="font-semibold text-navy-800">Repair Actions</h3><ul class="list-disc pl-5">${actions}</ul></div>` : ''}
+                ${failed ? `<div><h3 class="font-semibold text-orange-800 mb-2">Failed Positions</h3>${failed}</div>` : ''}
+            `;
+            if ((report.failed_positions || []).length > 0) {
+                repairSuggestions.classList.remove('hidden');
+            }
+            document.querySelectorAll('.failed-position').forEach(button => {
+                button.addEventListener('click', function() {
+                    replacementPosition.value = this.dataset.position;
+                    loadReplacements();
+                });
+            });
+        }
+
+        if (inspectRoundBtn) {
+            inspectRoundBtn.addEventListener('click', function() {
+                qualityResult.innerHTML = '<p><i class="fas fa-spinner fa-spin mr-2"></i>Running package check...</p>';
+                fetch('{{ url_for("rounds.round_quality", round_id=round.id) }}')
+                    .then(response => response.json())
+                    .then(data => {
+                        if (!data.success) {
+                            throw new Error(data.error || 'Quality check failed');
+                        }
+                        renderQualityReport(data);
+                        showToast(data.report && data.report.ok ? 'Round passed quality gate' : 'Round needs repair', data.report && data.report.ok ? 'success' : 'warning');
+                    })
+                    .catch(error => {
+                        qualityResult.innerHTML = `<p class="text-red-700">${error.message}</p>`;
+                        showToast(error.message, 'error');
+                    });
+            });
+        }
+
+        function loadReplacements() {
+            const position = replacementPosition.value;
+            if (!position) {
+                showToast('Choose a failed position first', 'warning');
+                return;
+            }
+            replacementList.innerHTML = '<p><i class="fas fa-spinner fa-spin mr-2"></i>Loading candidates...</p>';
+            const params = new URLSearchParams({
+                position,
+                limit: '8',
+                require_deezer_id: 'true',
+                query: replacementQuery.value || ''
+            });
+            fetch(`{{ url_for("rounds.replacement_suggestions", round_id=round.id) }}?${params.toString()}`)
+                .then(response => response.json())
+                .then(data => {
+                    if (!data.success) {
+                        throw new Error(data.error || 'Could not load replacements');
+                    }
+                    if (!data.suggestions || data.suggestions.length === 0) {
+                        replacementList.innerHTML = '<p class="text-sm text-gray-600">No replacement candidates found.</p>';
+                        return;
+                    }
+                    replacementList.innerHTML = data.suggestions.map(song => `
+                        <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-2 bg-white border border-orange-100 rounded p-3">
+                            <div>
+                                <div class="font-semibold">${escapeHtml(song.artist)} - ${escapeHtml(song.title)}</div>
+                                <div class="text-xs text-gray-500">${escapeHtml(song.year || 'Unknown year')}${song.genre ? ' · ' + escapeHtml(song.genre) : ''} · used ${Number(song.used_count || 0)}x</div>
+                            </div>
+                            <button type="button" class="replace-song-btn bg-teal-500 hover:bg-teal-600 text-white py-1.5 px-3 rounded text-sm" data-song-id="${Number(song.id)}" data-position="${Number(position)}">
+                                Replace
+                            </button>
+                        </div>
+                    `).join('');
+                    document.querySelectorAll('.replace-song-btn').forEach(button => {
+                        button.addEventListener('click', function() {
+                            const body = new URLSearchParams({
+                                csrf_token: csrfToken,
+                                position: this.dataset.position,
+                                replacement_song_id: this.dataset.songId
+                            });
+                            fetch('{{ url_for("rounds.replace_round_song", round_id=round.id) }}', {
+                                method: 'POST',
+                                headers: {
+                                    'X-Requested-With': 'XMLHttpRequest',
+                                    'Content-Type': 'application/x-www-form-urlencoded'
+                                },
+                                body: body.toString()
+                            })
+                                .then(response => response.json())
+                                .then(result => {
+                                    if (!result.success) {
+                                        throw new Error(result.error || 'Replacement failed');
+                                    }
+                                    showToast('Song replaced; assets are stale and need regeneration', 'success');
+                                    window.location.reload();
+                                })
+                                .catch(error => showToast(error.message, 'error'));
+                        });
+                    });
+                })
+                .catch(error => {
+                    replacementList.innerHTML = `<p class="text-red-700">${error.message}</p>`;
+                    showToast(error.message, 'error');
+                });
+        }
+
+        if (loadReplacementsBtn) {
+            loadReplacementsBtn.addEventListener('click', loadReplacements);
+        }
 
         // MP3 generation with AJAX
         generateMp3Btn.addEventListener('click', function() {
@@ -1177,4 +1449,3 @@
     });
 </script>
 {% endblock %}
-

--- a/musicround/templates/round_detail.html
+++ b/musicround/templates/round_detail.html
@@ -96,7 +96,9 @@
             <div id="repair-suggestions" class="hidden mt-4 border border-orange-200 rounded-md p-4 bg-orange-50">
                 <h3 class="font-semibold text-orange-800 mb-3">Replacement Candidates</h3>
                 <div class="grid grid-cols-1 md:grid-cols-4 gap-3 mb-3">
+                    <label class="sr-only" for="replacement-position">Position</label>
                     <input type="number" id="replacement-position" min="1" max="25" class="px-3 py-2 border border-gray-300 rounded-md" placeholder="Position">
+                    <label class="sr-only" for="replacement-query">Optional artist/title filter</label>
                     <input type="text" id="replacement-query" class="px-3 py-2 border border-gray-300 rounded-md md:col-span-2" placeholder="Optional artist/title filter">
                     <button id="load-replacements-btn" class="bg-orange-500 hover:bg-orange-600 text-white py-2 px-4 rounded transition-colors">
                         <i class="fas fa-search mr-2"></i> Find
@@ -966,6 +968,10 @@
                     `).join('');
                     document.querySelectorAll('.replace-song-btn').forEach(button => {
                         button.addEventListener('click', function() {
+                            if (this.disabled) {
+                                return;
+                            }
+                            this.disabled = true;
                             const body = new URLSearchParams({
                                 csrf_token: csrfToken,
                                 position: this.dataset.position,
@@ -987,7 +993,10 @@
                                     showToast('Song replaced; assets are stale and need regeneration', 'success');
                                     window.location.reload();
                                 })
-                                .catch(error => showToast(error.message, 'error'));
+                                .catch(error => {
+                                    this.disabled = false;
+                                    showToast(error.message, 'error');
+                                });
                         });
                     });
                 })

--- a/musicround/templates/round_planning.html
+++ b/musicround/templates/round_planning.html
@@ -1,0 +1,74 @@
+{% extends 'base.html' %}
+
+{% block title %}Round Planning Brief - Quizzical Beats{% endblock %}
+
+{% block content %}
+<div class="max-w-5xl mx-auto px-4 py-8">
+    <h1 class="text-3xl font-bold text-navy-800 font-montserrat mb-2">Round Planning Brief</h1>
+    <p class="text-gray-600 mb-6">Agent-readable context for building a themed, robust music round.</p>
+
+    <form method="get" class="bg-white shadow-md rounded-lg p-6 grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
+        <div>
+            <label class="block text-sm font-medium text-gray-700 mb-1" for="theme">Theme</label>
+            <input id="theme" name="theme" type="text" value="{{ filters.theme }}" class="px-3 py-2 border border-gray-300 rounded-md" placeholder="festival headliners">
+        </div>
+        <div>
+            <label class="block text-sm font-medium text-gray-700 mb-1" for="quiz_date">Quiz Date</label>
+            <input id="quiz_date" name="quiz_date" type="datetime-local" value="{{ filters.quiz_date }}" class="px-3 py-2 border border-gray-300 rounded-md">
+        </div>
+        <div>
+            <label class="block text-sm font-medium text-gray-700 mb-1" for="desired_song_count">Songs</label>
+            <input id="desired_song_count" name="desired_song_count" type="number" min="1" max="25" value="{{ filters.desired_song_count }}" class="px-3 py-2 border border-gray-300 rounded-md">
+        </div>
+        <div>
+            <label class="block text-sm font-medium text-gray-700 mb-1" for="months">History Window</label>
+            <input id="months" name="months" type="number" min="1" max="24" value="{{ filters.months }}" class="px-3 py-2 border border-gray-300 rounded-md">
+        </div>
+        <div class="md:col-span-2">
+            <button type="submit" class="bg-teal-500 hover:bg-teal-600 text-white py-2 px-4 rounded-md transition-colors font-semibold">
+                <i class="fas fa-wand-magic-sparkles mr-2"></i> Build Brief
+            </button>
+        </div>
+    </form>
+
+    {% if brief %}
+    <div class="bg-white shadow-md rounded-lg p-6 space-y-5">
+        <div>
+            <h2 class="text-xl font-bold text-navy-800 font-montserrat mb-2">{{ brief.theme or 'Music round' }}</h2>
+            <p class="text-gray-700">{{ brief.agent_prompt }}</p>
+        </div>
+        <div>
+            <h3 class="font-semibold text-navy-800 mb-2">Constraints</h3>
+            <ul class="list-disc pl-5 text-gray-700">
+                {% for item in brief.constraints %}
+                <li>{{ item }}</li>
+                {% endfor %}
+            </ul>
+        </div>
+        {% if brief.date_notes %}
+        <div>
+            <h3 class="font-semibold text-navy-800 mb-2">Date Notes</h3>
+            <ul class="list-disc pl-5 text-gray-700">
+                {% for item in brief.date_notes %}
+                <li>{{ item }}</li>
+                {% endfor %}
+            </ul>
+        </div>
+        {% endif %}
+        <div>
+            <h3 class="font-semibold text-navy-800 mb-2">Recent Song Warnings</h3>
+            {% set warnings = brief.quizmaster_context.recent_usage.selected_song_warnings %}
+            {% if warnings %}
+            <ul class="list-disc pl-5 text-gray-700">
+                {% for warning in warnings %}
+                <li>{{ warning.warning }}</li>
+                {% endfor %}
+            </ul>
+            {% else %}
+            <p class="text-gray-500">No selected-song warnings in this brief.</p>
+            {% endif %}
+        </div>
+    </div>
+    {% endif %}
+</div>
+{% endblock %}

--- a/musicround/templates/rounds.html
+++ b/musicround/templates/rounds.html
@@ -32,6 +32,12 @@
                 <a href="{{ url_for('generate.build_music_round') }}" class="bg-orange-500 hover:bg-orange-600 text-white py-2 px-4 rounded-md transition-colors text-sm font-semibold">
                     <i class="fas fa-plus mr-1"></i> Create New Quiz
                 </a>
+                <a href="{{ url_for('rounds.rounds_calendar') }}" class="bg-navy-700 hover:bg-navy-800 text-white py-2 px-4 rounded-md transition-colors text-sm font-semibold">
+                    <i class="fas fa-calendar-alt mr-1"></i> Calendar
+                </a>
+                <a href="{{ url_for('rounds.rounds_analytics') }}" class="bg-teal-500 hover:bg-teal-600 text-white py-2 px-4 rounded-md transition-colors text-sm font-semibold">
+                    <i class="fas fa-chart-line mr-1"></i> Analytics
+                </a>
             </div>
         </div>
         

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -255,6 +255,40 @@ def test_add_round_collaboration_and_audio_scripts_to_legacy_database(tmp_path):
     assert "cue_position" in RoundAudioScript.__table__.columns.keys()
 
 
+def test_add_round_review_workflow_to_legacy_database(tmp_path):
+    """Legacy round tables get human review and approval columns."""
+    database_path = tmp_path / "legacy-round-review.db"
+    with sqlite3.connect(database_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE round (
+                id INTEGER PRIMARY KEY,
+                round_type VARCHAR(50) NOT NULL,
+                round_criteria_used VARCHAR(500) NOT NULL,
+                songs TEXT NOT NULL,
+                created_at DATETIME
+            )
+            """
+        )
+
+    app = _legacy_app(database_path)
+    with app.app_context():
+        from migrations import add_round_review_workflow
+
+        assert add_round_review_workflow.run_migration() is True
+        assert add_round_review_workflow.run_migration() is None
+
+    round_columns = set(_column_names(database_path, "round"))
+    assert {
+        "review_status",
+        "review_notes",
+        "approved_at",
+        "approved_by_id",
+    }.issubset(round_columns)
+    assert "idx_round_review_status" in _index_names(database_path, "round")
+    assert "review_status" in Round.__table__.columns.keys()
+
+
 def test_round_songs_comment_matches_storage_behavior():
     """Round.songs remains documented and parsed as comma-separated IDs."""
     round_ = Round(

--- a/tests/test_rounds_routes.py
+++ b/tests/test_rounds_routes.py
@@ -172,6 +172,50 @@ class TestRoundsListRoute:
         assert b'Paged Round 29' not in second_page.data
         assert b'Page 2 of 2' in second_page.data
 
+    def test_round_calendar_shows_scheduled_exports(self, app, client):
+        """Round calendar should expose scheduled delivery dates."""
+        _login(app, client)
+        song_ids = _create_songs(app, 8, title_prefix='Calendar Song')
+        round_id = _create_round(app, song_ids, name='Calendar Round')
+        with app.app_context():
+            db.session.add(RoundExport(
+                round_id=round_id,
+                export_type='email',
+                status='scheduled',
+                destination='rounds@example.test',
+                scheduled_for=datetime(2026, 7, 9, 17, 0),
+            ))
+            db.session.commit()
+
+        response = client.get('/rounds/calendar')
+
+        assert response.status_code == 200
+        assert b'Calendar Round' in response.data
+        assert b'2026-07-09 17:00' in response.data
+
+    def test_round_analytics_page_renders_summary(self, app, client):
+        """Round analytics should render catalog health signals."""
+        _login(app, client)
+        _create_song(app, title='Analytics Song')
+
+        response = client.get('/rounds/analytics?months=6&limit=5')
+
+        assert response.status_code == 200
+        assert b'Round Analytics' in response.data
+        assert b'Missing Previews' in response.data
+
+    def test_round_planning_page_renders_brief(self, app, client):
+        """Planning page should turn quizmaster context into a brief."""
+        _login(app, client)
+
+        response = client.get(
+            '/rounds/planning?theme=festival&quiz_date=2026-07-09T19:00&desired_song_count=8'
+        )
+
+        assert response.status_code == 200
+        assert b'Round Planning Brief' in response.data
+        assert b'Build exactly 8 songs' in response.data
+
     def test_rounds_list_only_shows_visible_owned_or_shared_rounds(self, app, client):
         """Round ownership should keep private rounds out of other quizmasters' lists."""
         _login(app, client, username='visible_owner', email='visible_owner@example.com')
@@ -255,6 +299,28 @@ class TestRoundDetailRoute:
         response = client.get(f'/rounds/{round_id}')
         assert response.status_code == 200
 
+    def test_round_detail_shows_review_and_audio_scripts(self, app, client):
+        """Round detail should surface review state and script drafts."""
+        _login(app, client)
+        song_id = _create_song(app, title='Script Detail Song')
+        round_id = _create_round(app, [song_id], name='Script Detail Round')
+        with app.app_context():
+            round_ = db.session.get(Round, round_id)
+            round_.review_status = 'reviewed'
+            db.session.add(RoundAudioScript(
+                round_id=round_id,
+                script_type='intro',
+                text='Welcome to the review round',
+                status='draft',
+            ))
+            db.session.commit()
+
+        response = client.get(f'/rounds/{round_id}')
+
+        assert response.status_code == 200
+        assert b'Reviewed' in response.data
+        assert b'Welcome to the review round' in response.data
+
     def test_round_detail_hides_private_round_owned_by_other_user(self, app, client):
         """Private owned rounds should not be visible to other quizmasters."""
         _login(app, client, username='viewer_one', email='viewer_one@example.com')
@@ -320,6 +386,116 @@ class TestRoundDetailRoute:
         assert response.status_code == 200
         with app.app_context():
             assert db.session.get(Round, round_id).name == 'Editor Updated Round'
+
+    def test_update_round_review_marks_approval(self, app, client):
+        """Review route should persist approved state and notes."""
+        _login(app, client)
+        song_id = _create_song(app, title='Approved Song')
+        round_id = _create_round(app, [song_id], name='Approval Round')
+
+        response = client.post(
+            f'/rounds/{round_id}/review',
+            data={'review_status': 'approved', 'review_notes': 'Ready for Thursday'},
+        )
+
+        assert response.status_code == 302
+        with app.app_context():
+            round_ = db.session.get(Round, round_id)
+            assert round_.review_status == 'approved'
+            assert round_.review_notes == 'Ready for Thursday'
+            assert round_.approved_at is not None
+
+    def test_round_quality_endpoint_returns_repair_report(self, app, client):
+        """Quality endpoint should expose automation repair feedback."""
+        _login(app, client)
+        song_id = _create_song(app, title='Quality Song')
+        round_id = _create_round(app, [song_id], name='Quality Round')
+        payload = {
+            'quality': {'status': 'needs_substitution'},
+            'report': {'ok': False, 'summary': 'Needs replacement', 'failed_positions': []},
+        }
+        with patch('musicround.routes.rounds.automation.round_repair_report', return_value=payload):
+            response = client.get(f'/rounds/{round_id}/quality')
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data['success'] is True
+        assert data['report']['summary'] == 'Needs replacement'
+
+    def test_replacement_endpoints_proxy_automation(self, app, client):
+        """Replacement routes should make repair candidates actionable."""
+        _login(app, client)
+        song_id = _create_song(app, title='Broken Song')
+        replacement_id = _create_song(app, title='Replacement Song')
+        round_id = _create_round(app, [song_id], name='Repair Round')
+        suggestions = {
+            'round_id': round_id,
+            'position': 1,
+            'suggestions': [{'id': replacement_id, 'title': 'Replacement Song'}],
+            'count': 1,
+        }
+        replacement = {
+            'round': {'id': round_id},
+            'position': 1,
+            'replacement_song': {'id': replacement_id},
+        }
+        with patch('musicround.routes.rounds.automation.suggest_replacement_songs', return_value=suggestions):
+            response = client.get(f'/rounds/{round_id}/replacement-suggestions?position=1')
+        assert response.status_code == 200
+        assert response.get_json()['suggestions'][0]['id'] == replacement_id
+
+        with patch('musicround.routes.rounds.automation.replace_round_song', return_value=replacement):
+            response = client.post(
+                f'/rounds/{round_id}/replace-song',
+                data={'position': '1', 'replacement_song_id': str(replacement_id)},
+            )
+        assert response.status_code == 200
+        assert response.get_json()['success'] is True
+
+    def test_audio_script_routes_create_and_update_review_records(self, app, client):
+        """Script routes should connect browser review to automation helpers."""
+        _login(app, client)
+        song_id = _create_song(app, title='Announcement Song')
+        round_id = _create_round(app, [song_id], name='Announcement Round')
+
+        with patch('musicround.routes.rounds.automation.draft_round_audio_scripts') as draft_scripts:
+            response = client.post(
+                f'/rounds/{round_id}/draft-audio-scripts',
+                data={'theme': 'summer', 'tone': 'warm'},
+            )
+        assert response.status_code == 302
+        draft_scripts.assert_called_once()
+
+        with patch('musicround.routes.rounds.automation.draft_round_track_hints') as draft_hints:
+            response = client.post(
+                f'/rounds/{round_id}/draft-track-hints',
+                data={'tone': 'playful'},
+            )
+        assert response.status_code == 302
+        draft_hints.assert_called_once()
+
+        with app.app_context():
+            script = RoundAudioScript(
+                round_id=round_id,
+                script_type='intro',
+                text='Draft',
+                status='draft',
+            )
+            db.session.add(script)
+            db.session.commit()
+            script_id = script.id
+
+        response = client.post(
+            f'/rounds/{round_id}/audio-scripts/{script_id}',
+            data={'text': 'Approved draft', 'status': 'approved', 'selected': 'on'},
+        )
+
+        assert response.status_code == 302
+        with app.app_context():
+            script = db.session.get(RoundAudioScript, script_id)
+            assert script.status == 'approved'
+            assert script.selected is True
+            assert script.text == 'Approved draft'
 
 
 class TestRoundUpdateName:

--- a/tests/test_rounds_routes.py
+++ b/tests/test_rounds_routes.py
@@ -404,6 +404,20 @@ class TestRoundDetailRoute:
             assert round_.review_status == 'approved'
             assert round_.review_notes == 'Ready for Thursday'
             assert round_.approved_at is not None
+            assert round_.approved_by_id is not None
+
+        response = client.post(
+            f'/rounds/{round_id}/review',
+            data={'review_status': 'reviewed', 'review_notes': 'Needs another pass'},
+        )
+
+        assert response.status_code == 302
+        with app.app_context():
+            round_ = db.session.get(Round, round_id)
+            assert round_.review_status == 'reviewed'
+            assert round_.review_notes == 'Needs another pass'
+            assert round_.approved_at is None
+            assert round_.approved_by_id is None
 
     def test_round_quality_endpoint_returns_repair_report(self, app, client):
         """Quality endpoint should expose automation repair feedback."""


### PR DESCRIPTION
## Summary
- add round review/approval state with an idempotent migration
- expose round package quality, repair suggestions, replacement actions, calendar, analytics, and planning brief in the browser
- add browser review flows for intro/replay/outro scripts and per-track hint drafts

## Validation
- SECRET_KEY=test-secret-key-for-testing-only AUTOMATION_TOKEN=test-automation-token-for-testing .venv/bin/python -m pytest tests/test_migrations.py tests/test_rounds_routes.py
- SECRET_KEY=test-secret-key-for-testing-only AUTOMATION_TOKEN=test-automation-token-for-testing .venv/bin/python -m pytest
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Round Ops” area with calendar, analytics, and planning views.
  * Round pages now show review status, approval details, quality checks, replacement suggestions, and draft audio/script review tools.
  * Added actions to update review state, inspect round quality, replace songs, and generate draft announcements and hints.

* **Bug Fixes**
  * Improved support for older databases by adding missing review/approval fields and related indexing automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->