### PR TITLE
[codex] Clean up Spotify search and tag lookup

### DIFF
--- a/musicround/helpers/import_queue.py
+++ b/musicround/helpers/import_queue.py
@@ -18,7 +18,6 @@ from musicround.helpers.spotify_helper import get_spotify_token
 
 
 IMPORT_JOB_FAILURE_MESSAGE = "Import job failed. Check the server logs."
-IMPORT_JOB_RESULT_ERROR_MESSAGE = "Import completed with errors. Check the server logs."
 
 
 def _safe_result_error_summary(errors: list[Any]) -> str | None:

--- a/musicround/routes/core.py
+++ b/musicround/routes/core.py
@@ -354,7 +354,7 @@ def search_results():
                 "Please try again or reconnect Spotify if the problem persists."
             ),
             back_url=url_for('core.search'),
-        )
+        ), 500
 
 @core_bp.route('/view-songs')
 @login_required

--- a/musicround/routes/generate.py
+++ b/musicround/routes/generate.py
@@ -63,21 +63,15 @@ def get_songs_by_tag(tag_name, limit=8):
     if not normalized_tag_name:
         return []
 
-    songs = []
-    seen_song_ids = set()
-    for tag in Tag.query.all():
-        if _normalize_tag_name(tag.name).casefold() != normalized_tag_name.casefold():
-            continue
-
-        for song in tag.songs:
-            song_key = song.id or (song.title, song.artist)
-            if song_key in seen_song_ids:
-                continue
-            seen_song_ids.add(song_key)
-            songs.append(song)
-            if len(songs) >= limit:
-                return songs
-    return songs
+    normalized_sql = db.func.lower(db.func.trim(Tag.name))
+    return (
+        Song.query.join(Song.tags)
+        .filter(normalized_sql == normalized_tag_name.casefold())
+        .order_by(Song.id.asc())
+        .distinct()
+        .limit(limit)
+        .all()
+    )
 
 def get_least_used_genres():
     """

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -688,7 +688,7 @@ class TestSpotifySearchInvalidGrant:
             )
 
         body = response.get_data(as_text=True)
-        assert response.status_code == 200
+        assert response.status_code == 500
         assert 'An error occurred while searching Spotify.' in body
         assert 'Please try again or reconnect Spotify if the problem persists.' in body
         assert 'search-secret' not in body


### PR DESCRIPTION
## Summary
- return HTTP 500 for generic Spotify search failures while keeping provider details out of the response
- make tag-based round generation filter tags in SQL instead of loading every tag in Python
- remove the dead import queue result-error constant

## Validation
- `SECRET_KEY=test-secret AUTOMATION_TOKEN=test-automation-token .venv/bin/python -m pytest tests/test_generate.py tests/test_routes.py -k 'GetSongsByTag or generic_search_error or login_page_accessible' -q`
- `SECRET_KEY=test-secret AUTOMATION_TOKEN=test-automation-token .venv/bin/python -m pytest tests/test_import_helper.py tests/test_import_queue.py tests/test_routes.py -k 'legacy_use_refresh_token or deezer or import_item' -q`
- `SECRET_KEY=test-secret AUTOMATION_TOKEN=test-automation-token .venv/bin/python -m pytest -q` → 681 passed, 2 skipped

Closes #143


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Search and error pages now return the correct HTTP 500 status when a server-side issue occurs.
  * Tag-based song results are now matched more reliably, improving consistency and reducing duplicate or missed results.

* **Tests**
  * Updated coverage to verify error responses use the proper status code and continue to hide internal exception details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->