### PR TITLE
[codex] Follow up PR 145 review comments

### DIFF
--- a/musicround/routes/core.py
+++ b/musicround/routes/core.py
@@ -354,6 +354,7 @@ def search_results():
                 "Please try again or reconnect Spotify if the problem persists."
             ),
             back_url=url_for('core.search'),
+            code=500,
         ), 500
 
 @core_bp.route('/view-songs')

--- a/musicround/routes/generate.py
+++ b/musicround/routes/generate.py
@@ -66,7 +66,7 @@ def get_songs_by_tag(tag_name, limit=8):
     normalized_sql = db.func.lower(db.func.trim(Tag.name))
     return (
         Song.query.join(Song.tags)
-        .filter(normalized_sql == normalized_tag_name.casefold())
+        .filter(normalized_sql == normalized_tag_name.lower())
         .order_by(Song.id.asc())
         .distinct()
         .limit(limit)

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -187,7 +187,7 @@ class TestGetSongsByTag:
         assert result[0].title == 'Tagged Generate Song'
 
     def test_matches_normalized_tag_name(self, app):
-        """Test get_songs_by_tag matches tags after trimming and case folding."""
+        """Test get_songs_by_tag matches tags after trimming and lowercasing."""
         from musicround.routes.generate import get_songs_by_tag
         with app.app_context():
             tag1 = Tag(name=' rock ')

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -689,7 +689,7 @@ class TestSpotifySearchInvalidGrant:
 
         body = response.get_data(as_text=True)
         assert response.status_code == 500
-        assert '<title>Error 500</title>' in body
+        assert 'Error 500' in body
         assert 'An error occurred while searching Spotify.' in body
         assert 'Please try again or reconnect Spotify if the problem persists.' in body
         assert 'search-secret' not in body

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -689,6 +689,7 @@ class TestSpotifySearchInvalidGrant:
 
         body = response.get_data(as_text=True)
         assert response.status_code == 500
+        assert '<title>Error 500</title>' in body
         assert 'An error occurred while searching Spotify.' in body
         assert 'Please try again or reconnect Spotify if the problem persists.' in body
         assert 'search-secret' not in body


### PR DESCRIPTION
## Summary
- align tag lookup normalization with the SQL `lower(trim(...))` expression
- pass `code=500` into the generic Spotify search error template
- update focused coverage for the 500 error rendering

## Validation
- `python3 -m py_compile musicround/routes/generate.py musicround/routes/core.py tests/test_generate.py tests/test_routes.py`
- `SECRET_KEY=test-secret AUTOMATION_TOKEN=test-automation-token python3 -m pytest tests/test_generate.py::TestGetSongsByTag tests/test_routes.py::TestSpotifySearch::test_generic_search_error_hides_exception_details -q` (not run: pytest is not installed in the temporary worktree environment)

Follow-up to #145 review comments.