### PR TITLE
Optimize decade lookup and migration imports

### DIFF
--- a/musicround/routes/generate.py
+++ b/musicround/routes/generate.py
@@ -15,19 +15,18 @@ songs_per_round = 8
 # Helper functions
 def get_all_decades():
     """
-    Return a list of 'decade' strings (e.g. '1970', '1980')
-    based on the first 3 digits of the year + '0'.
+    Return unique decade strings for songs with real, positive years.
     """
     all_decades = []
     years = (
         Song.query.with_entities(Song.year)
-        .filter(Song.year.isnot(None))
+        .filter(Song.year.isnot(None), Song.year > 0)
         .order_by(Song.year.asc())
         .distinct()
         .all()
     )
     for (year,) in years:
-        decade = str(year)[:3] + '0'
+        decade = str((year // 10) * 10)
         if decade not in all_decades:
             all_decades.append(decade)
     return all_decades

--- a/musicround/routes/generate.py
+++ b/musicround/routes/generate.py
@@ -19,11 +19,17 @@ def get_all_decades():
     based on the first 3 digits of the year + '0'.
     """
     all_decades = []
-    for song in Song.query.all():
-        if song.year:
-            decade = str(song.year)[:3] + '0'
-            if decade not in all_decades:
-                all_decades.append(decade)
+    years = (
+        Song.query.with_entities(Song.year)
+        .filter(Song.year.isnot(None))
+        .order_by(Song.year.asc())
+        .distinct()
+        .all()
+    )
+    for (year,) in years:
+        decade = str(year)[:3] + '0'
+        if decade not in all_decades:
+            all_decades.append(decade)
     return all_decades
 
 def get_all_genres():

--- a/run_migration.py
+++ b/run_migration.py
@@ -3,7 +3,6 @@ Manually run the OAuth providers migration script
 """
 import os
 import sys
-from flask import Flask
 import logging
 
 # Set up logging
@@ -22,7 +21,7 @@ def run_spotify_oauth_migration():
     """Run the migration to add Spotify OAuth columns"""
     try:
         # Create a minimal Flask app with database connection
-        from musicround import db, create_app
+        from musicround import create_app
         app = create_app()
         
         with app.app_context():

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -77,6 +77,14 @@ class TestGetAllDecades:
             result = get_all_decades()
         assert result == []
 
+    def test_zero_year_excluded(self, app):
+        """Test that a zero year sentinel does not create a fake decade."""
+        from musicround.routes.generate import get_all_decades
+        _add_songs(app, [{'title': 'Zero Year', 'artist': 'A', 'genre': 'Rock', 'year': 0}])
+        with app.app_context():
+            result = get_all_decades()
+        assert result == []
+
 
 class TestGetAllGenres:
     """Tests for generate.get_all_genres helper."""


### PR DESCRIPTION
Addresses the concrete Jules suggestions from the latest proactive mail and the follow-up CodeRabbit review:

- avoid fetching full `Song` records when building the decade picker; query distinct positive years only
- compute decades with integer arithmetic and exclude `year=0` sentinels
- remove unused migration-script imports
- add focused coverage for excluding zero-year sentinels

Validation:
- `python3 -m py_compile musicround/routes/generate.py run_migration.py tests/test_generate.py`
- `git diff --check`

Focused pytest was not available in the clean temporary checkout (`No module named pytest`).