### PR TITLE
[codex] consolidate QB roadmap fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added browser round ownership filtering, owner/visibility indicators, and route-level edit checks for shared rounds.
 - Added headered CSV playlist parsing for text-import automation, including `artist,title` and `title;artist` layouts.
 - Added planned quiz round records plus MCP tools to create, list, update, and link upcoming quiz dates before a round exists.
+- Added planned quiz dates to the browser round calendar with quizmaster visibility and linked-round actions.
 
 ### Fixed
 - Hid internal/noisy import tags from the music-round builder while keeping raw tags in storage, and mapped common public aliases such as `hip hop` to `Hip-Hop`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added round owner/share models and MCP helpers for quizmaster collaboration handoff.
 - Added persisted round-audio script drafts, review status, and MCP helpers to approve script text before TTS audio generation.
 - Added browser round ownership filtering, owner/visibility indicators, and route-level edit checks for shared rounds.
+- Added headered CSV playlist parsing for text-import automation, including `artist,title` and `title;artist` layouts.
 
 ### Fixed
+- Hid internal/noisy import tags from the music-round builder while keeping raw tags in storage, and mapped common public aliases such as `hip hop` to `Hip-Hop`.
+- Stopped headered CSV playlist imports from treating the header row as a song and now flags missing artist/title cells for review.
 - Removed dead duplicate import and export helpers, and made the legacy Spotify diagnostics route use the configured Authlib client instead of a missing app-level Spotify client.
 - Normalized Spotify profile display names on the connection-management page and removed the obsolete admin token-wizard template.
 - Required login for Spotify playlist import, direct-token, and diagnostic routes before resolving user, manual, or system fallback tokens.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added playlist import position maps to MCP round-creation success and repair payloads.
 - Fixed Spotify playlist imports so already-cataloged tracks count as resolved positions and successful imports always return their result payload.
 - Added credential-safe health and CLI warnings when production still points at the legacy `/data/song_data.db` SQLite file.
+- Hardened the managed-database guard so common truthy `DATABASE_REQUIRE_MANAGED` values fail fast before container startup can fall back to SQLite.
 
 ## [1.9.0] - 2026-02-06 - "Security Hardening"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added persisted round-audio script drafts, review status, and MCP helpers to approve script text before TTS audio generation.
 - Added browser round ownership filtering, owner/visibility indicators, and route-level edit checks for shared rounds.
 - Added headered CSV playlist parsing for text-import automation, including `artist,title` and `title;artist` layouts.
+- Added planned quiz round records plus MCP tools to create, list, update, and link upcoming quiz dates before a round exists.
 
 ### Fixed
 - Hid internal/noisy import tags from the music-round builder while keeping raw tags in storage, and mapped common public aliases such as `hip hop` to `Hip-Hop`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed Spotify playlist imports so already-cataloged tracks count as resolved positions and successful imports always return their result payload.
 - Added credential-safe health and CLI warnings when production still points at the legacy `/data/song_data.db` SQLite file.
 - Hardened the managed-database guard so common truthy `DATABASE_REQUIRE_MANAGED` values fail fast before container startup can fall back to SQLite.
+- Hardened login and OAuth redirect targets against open redirects.
+- Escaped browser error metadata instead of injecting raw JSON into the error template.
+- Normalized Dropbox API paths for folder browsing, folder creation, upload, and shared-link creation.
+- Optimized genre picker and least-used genre helpers to avoid loading full song and round tables.
 
 ## [1.9.0] - 2026-02-06 - "Security Hardening"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Preserved Spotify playlist import order when the importer returns database song IDs directly.
 - Kept round package preview failures aligned to stored round positions even when unresolved song IDs create gaps.
 - Added playlist import position maps to MCP round-creation success and repair payloads.
+- Fixed Spotify playlist imports so already-cataloged tracks count as resolved positions and successful imports always return their result payload.
 - Added credential-safe health and CLI warnings when production still points at the legacy `/data/song_data.db` SQLite file.
 
 ## [1.9.0] - 2026-02-06 - "Security Hardening"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,7 @@
 # Quizzical Beats - Project Roadmap
 
 **Version**: 2026.Q3
-**Last Updated**: July 5, 2026
+**Last Updated**: July 6, 2026
 
 ## Vision Statement
 
@@ -175,16 +175,16 @@ Quizzical Beats aims to be the premier platform for creating, managing, and deli
 ---
 
 #### v2.2 - "Server Stability" *(Q1 2026 - HIGH PRIORITY)*
-**Status**: 🔴 Not Started  
+**Status**: 🟡 In Progress
 **Priority**: Critical  
 **Effort**: 1 week
 
 **Goals**: Production-grade web server
 
 **Features**:
-- [ ] Replace Flask dev server with Gunicorn
-- [ ] Configure worker processes (4-8 workers)
-- [ ] Graceful shutdown/restart
+- [x] Replace Flask dev server with Gunicorn
+- [x] Configure worker processes and threads
+- [x] Graceful shutdown/restart through Gunicorn entrypoint
 - [ ] Nginx reverse proxy configuration
 - [ ] SSL termination
 - [ ] Static file optimization
@@ -482,23 +482,23 @@ Quizzical Beats aims to be the premier platform for creating, managing, and deli
 - [x] Persistent user settings
 - [ ] Default round format preferences
 - [ ] Personal tag system
-- [x] Tag filtering and sorting in the round builder
+- [x] Curated tag filtering and sorting in the round builder, including internal/noisy tag suppression
 - [ ] Dark mode toggle
 - [ ] UI customization
 
 ---
 
 #### v4.3 - "Deployment Dynamo" *(Q4 2026 - HIGH PRIORITY)*
-**Status**: 🔴 Not Started  
+**Status**: 🟡 In Progress
 **Priority**: High  
 **Effort**: 2 weeks
 
 **Goals**: CI/CD and automation
 
 **Features**:
-- [ ] GitHub Actions CI/CD pipeline
-- [ ] Automated testing
-- [ ] Automated builds
+- [x] GitHub Actions CI/CD pipeline
+- [x] Automated testing
+- [x] Automated Docker builds
 - [ ] Nightly backup jobs
 - [ ] Sentry error tracking
 - [ ] Auto-updater script

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -328,6 +328,7 @@ Quizzical Beats aims to be the premier platform for creating, managing, and deli
 - [x] Complete round creation from fully resolved text playlists
 - [ ] User review/edit interface
 - [x] Recent usage and fatigue context for prompt optimization
+- [x] Planned quiz date records for agentic scheduled generation
 - [x] Draft intro/replay/outro script support for generated rounds
 - [x] Persisted script review workflow before TTS assignment
 - [ ] AI provider abstraction (OpenAI, Anthropic, local)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -329,6 +329,7 @@ Quizzical Beats aims to be the premier platform for creating, managing, and deli
 - [ ] User review/edit interface
 - [x] Recent usage and fatigue context for prompt optimization
 - [x] Planned quiz date records for agentic scheduled generation
+- [x] Browser round calendar for planned quiz dates
 - [x] Draft intro/replay/outro script support for generated rounds
 - [x] Persisted script review workflow before TTS assignment
 - [ ] AI provider abstraction (OpenAI, Anthropic, local)

--- a/TODO.md
+++ b/TODO.md
@@ -180,6 +180,7 @@
   * [x] Create quiz rounds from fully resolved text playlists
   * [x] Let users prompt AI with a theme or vibe (e.g., "Chill 80s", "Dancefloor Divas")
   * [x] Provide recent usage/fatigue context for agentic song selection
+  * [x] Store planned quiz dates and link them to generated rounds/scheduled exports
   * [x] Draft intro/replay/outro scripts for later TTS generation
   * [x] Store and review generated intro/replay/outro scripts before assigning TTS audio
   * [ ] Include fallback logic when metadata is sparse

--- a/TODO.md
+++ b/TODO.md
@@ -112,7 +112,7 @@
 ### 🎯 Milestone 12: **"Search Supercharge" Release** – Enhanced Search
 
 * [ ] Improve search algorithm and relevance scoring
-* [x] Normalize and de-duplicate tag choices in the round builder
+* [x] Normalize, de-duplicate, and curate tag choices in the round builder
 * [x] Add advanced song catalog filtering options (year, genre, preview, usage)
 * [ ] Implement caching for frequent searches
 * [x] Add server-side song catalog pagination for API and agent workflows
@@ -125,7 +125,7 @@
 * [x] Confidence scoring for matches
 * [x] MCP review payload for low-confidence matches
 * [ ] Manual review interface for low-confidence matches
-* [x] Support for various text formats (CSV, plain text, etc.)
+* [x] Support for various text formats, including headered CSV and plain text
 * [x] Create complete rounds from fully resolved text playlists
 
 ### 🎯 Milestone 14: **"Curated Collector" Release** – Playlist Scraper
@@ -137,9 +137,9 @@
 
 ### 🎯 Milestone 15: **"Server Stability" Release** – Production Web Server
 
-* [ ] Replace Flask development server with Gunicorn/uWSGI
-* [ ] Configure proper worker processes and threads
-* [ ] Implement graceful shutdown and restart capabilities
+* [x] Replace Flask development server with Gunicorn/uWSGI
+* [x] Configure proper worker processes and threads
+* [x] Implement graceful shutdown and restart capabilities through Gunicorn
 * [ ] Add Nginx as reverse proxy with proper caching
 * [ ] Set up proper SSL termination and security headers
 * [ ] Optimize static file serving
@@ -236,7 +236,7 @@
 
 ### 🎯 Milestone 24: **"Deployment Dynamo" Release** – CI/CD and Maintenance
 
-* [ ] GitHub Actions or GitLab CI/CD pipeline for builds and tests
+* [x] GitHub Actions CI/CD pipeline for builds and tests
 * [ ] Nightly backup job with status alert
 * [ ] Add Sentry or similar for exception tracking
 * [ ] Updater script for pulling latest Git commits safely
@@ -258,4 +258,4 @@
   * [ ] Implement keyboard shortcuts in the application
   * [ ] Document keyboard shortcuts for power users when implemented
 
-*Last updated: July 5, 2026*
+*Last updated: July 6, 2026*

--- a/TODO.md
+++ b/TODO.md
@@ -181,6 +181,7 @@
   * [x] Let users prompt AI with a theme or vibe (e.g., "Chill 80s", "Dancefloor Divas")
   * [x] Provide recent usage/fatigue context for agentic song selection
   * [x] Store planned quiz dates and link them to generated rounds/scheduled exports
+  * [x] Show planned quiz dates in the browser round calendar
   * [x] Draft intro/replay/outro scripts for later TTS generation
   * [x] Store and review generated intro/replay/outro scripts before assigning TTS audio
   * [ ] Include fallback logic when metadata is sparse

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -9,11 +9,22 @@ echo "Flask environment: $FLASK_ENV"
 mkdir -p "${ROUND_MP3_DIR:-/data/rounds}" "${ROUND_PDF_DIR:-/data/pdfs}"
 python - <<'PY'
 import os
-from musicround.helpers.database_config import database_summary
+import sys
+from musicround.helpers.database_config import (
+    bool_from_config,
+    database_summary,
+    managed_database_requirement_error,
+)
 
-summary = database_summary(os.environ.get("SQLALCHEMY_DATABASE_URI"))
+db_uri = os.environ.get("SQLALCHEMY_DATABASE_URI")
+require_managed = bool_from_config(os.environ.get("DATABASE_REQUIRE_MANAGED"))
+summary = database_summary(db_uri)
 print(f"Database backend: {summary['backend']}")
 print(f"Database target: {summary['redacted_uri']}")
+managed_error = managed_database_requirement_error(db_uri, require_managed)
+if managed_error:
+    print(f"Database configuration error: {managed_error}", file=sys.stderr)
+    sys.exit(78)
 PY
 
 if [ "${LOG_ENV:-0}" = "1" ]; then

--- a/docs/admin-guide/managed-database-migration.md
+++ b/docs/admin-guide/managed-database-migration.md
@@ -8,7 +8,8 @@ database to a managed SQL database without exposing credentials in logs or Git.
 - Secret owner: `quizzicalbeats/quizzicalbeats-secrets` in the existing
   1Password-backed ExternalSecret flow.
 - Required secret key: `SQLALCHEMY_DATABASE_URI`.
-- Production guard: set `DATABASE_REQUIRE_MANAGED=True` in Kubernetes config.
+- Production guard: set `DATABASE_REQUIRE_MANAGED=true` in Kubernetes config.
+  The app accepts common truthy values such as `true`, `1`, `yes`, and `on`.
 - The URI value must stay in 1Password or the generated Kubernetes Secret. Do
   not commit it to Git and do not print it in logs.
 
@@ -58,7 +59,7 @@ database to a managed SQL database without exposing credentials in logs or Git.
      -o jsonpath='{.data.SQLALCHEMY_DATABASE_URI}' >/dev/null
    ```
 
-2. Deploy the app with `DATABASE_REQUIRE_MANAGED=True` and without a ConfigMap
+2. Deploy the app with `DATABASE_REQUIRE_MANAGED=true` and without a ConfigMap
    `SQLALCHEMY_DATABASE_URI` fallback.
 3. Restart the web deployment after the secret has synced:
 

--- a/docs/developer-guide/database-schema.md
+++ b/docs/developer-guide/database-schema.md
@@ -270,6 +270,32 @@ The `RoundExport` table tracks exports of rounds to various destinations.
 - `idx_round_export_schedule` supports due scheduled-email processing.
 - `idx_round_export_round_timestamp` supports round export history views.
 
+### PlannedQuizRound
+
+The `PlannedQuizRound` table stores upcoming quiz dates before a concrete round
+or scheduled export exists.
+
+| Column              | Type         | Description                                      |
+|---------------------|--------------|--------------------------------------------------|
+| id                  | Integer      | Primary key                                      |
+| quiz_date           | DateTime     | Planned quiz date                                |
+| quizmaster_id       | Integer      | Optional foreign key to User                     |
+| theme               | String(200)  | Optional theme or planning label                 |
+| brief               | Text         | Agent-facing planning notes                      |
+| source_playlist_url | String(500)  | Optional source playlist URL                     |
+| due_at              | DateTime     | Optional internal due time before send           |
+| status              | String(20)   | planned, drafted, blocked, approved, scheduled, or sent |
+| round_id            | Integer      | Optional foreign key to generated Round          |
+| export_id           | Integer      | Optional foreign key to scheduled RoundExport    |
+| created_at          | DateTime     | Creation timestamp                               |
+| updated_at          | DateTime     | Last update timestamp                            |
+
+**Query indexes:**
+- `idx_planned_quiz_round_status_due` supports production-board and due-soon
+  lookups.
+- `idx_planned_quiz_round_quizmaster_date` supports per-quizmaster planning
+  views.
+
 ### SystemSetting
 
 The `SystemSetting` table stores application-wide settings.
@@ -287,6 +313,8 @@ The `SystemSetting` table stores application-wide settings.
 - **User → UserPreferences**: One-to-one. A user has one set of preferences.
 - **User ↔ Roles**: Many-to-many through user_roles. A user can have multiple roles, and a role can be assigned to multiple users.
 - **User → RoundExports**: One-to-many. A user can create multiple exports.
+- **User → PlannedQuizRounds**: One-to-many. A quizmaster can own multiple
+  planned quiz dates.
 
 ### Song Relationships
 
@@ -297,6 +325,8 @@ The `SystemSetting` table stores application-wide settings.
 
 - **Round → RoundExports**: One-to-many. A round can have multiple exports.
 - **Round → Songs**: Many-to-many (implicit). A round contains multiple songs referenced by ID.
+- **Round → PlannedQuizRounds**: One-to-many. A planned quiz date can point at
+  the generated round once it exists.
 
 ## Data Model Features
 

--- a/docs/developer-guide/mcp.md
+++ b/docs/developer-guide/mcp.md
@@ -113,7 +113,10 @@ explicitly set.
    every row resolves.
 5. Create the round with `compile_round` or `create_round_from_playlist`.
    Playlist imports return `needs_more_songs` instead of creating a partial
-   round when fewer than the requested eight tracks resolve.
+   round when fewer than the requested eight tracks resolve. Spotify playlist
+   imports include `resolved_positions` with playlist position, Spotify track
+   ID, artist, title, QB song ID, status, and failure reason so agents can
+   repair specific positions.
 6. Link the plan to the generated round with `link_planned_quiz_round`.
 7. Generate PDF and MP3 files with `generate_round_assets`.
 8. Inspect the generated files and previews with `inspect_round_package`.

--- a/docs/developer-guide/mcp.md
+++ b/docs/developer-guide/mcp.md
@@ -61,6 +61,10 @@ The MCP server exposes these tools:
 | `recent_usage_summary` | Summarize recent rounds, frequently used songs, and selected-song warnings. |
 | `quizmaster_context` | Return quizmaster preferences and recent usage for personalized planning. |
 | `round_planning_brief` | Build an agent-readable brief for a robust themed round. |
+| `create_planned_quiz_round` | Create a planned quiz date before a concrete round exists. |
+| `list_planned_quiz_rounds` | List planned quiz dates for agents and production-board views. |
+| `update_planned_quiz_round` | Update a planned quiz date and optional linked deliverables. |
+| `link_planned_quiz_round` | Link a planned quiz date to a generated round or scheduled export. |
 | `draft_round_audio_scripts` | Draft intro, replay, and outro text before TTS generation. |
 | `save_round_audio_scripts` | Persist reviewable intro, replay, and outro script drafts. |
 | `list_round_audio_scripts` | List stored script drafts by round, user, or review status. |
@@ -89,27 +93,31 @@ previews.
 
 The generic datastore CRUD tools operate on mapped SQLAlchemy models, including
 `song`, `round`, `round_share`, `round_audio_script`, `tag`, `song_tag`, `user`,
-`role`, `user_preferences`, `round_export`, `system_setting`, and
-`import_job_record`. Read results redact fields whose names contain `password`,
-`token`, or `secret` unless `include_sensitive` is explicitly set.
+`role`, `user_preferences`, `planned_quiz_round`, `round_export`,
+`system_setting`, and `import_job_record`. Read results redact fields whose
+names contain `password`, `token`, or `secret` unless `include_sensitive` is
+explicitly set.
 
 ## Intended Workflow
 
-1. Start with `quizmaster_context`, `recent_usage_summary`, or
+1. Create or load upcoming quiz work with `create_planned_quiz_round` and
+   `list_planned_quiz_rounds` when the date is known before the round exists.
+2. Start with `quizmaster_context`, `recent_usage_summary`, or
    `round_planning_brief` so repeated songs and personalization constraints are
    visible before selecting tracks.
-2. Search with `find_songs` to avoid duplicates.
-3. Add missing tracks with `add_song` or import platform content with
+3. Search with `find_songs` to avoid duplicates.
+4. Add missing tracks with `add_song` or import platform content with
    `import_catalog_item`.
    For pasted lists, run `parse_text_playlist` first, then
    `resolve_text_playlist`; use `create_round_from_text_playlist` only after
    every row resolves.
-4. Create the round with `compile_round` or `create_round_from_playlist`.
+5. Create the round with `compile_round` or `create_round_from_playlist`.
    Playlist imports return `needs_more_songs` instead of creating a partial
    round when fewer than the requested eight tracks resolve.
-5. Generate PDF and MP3 files with `generate_round_assets`.
-6. Inspect the generated files and previews with `inspect_round_package`.
-7. Send the completed bundle with `send_round_email`; it reruns the package
+6. Link the plan to the generated round with `link_planned_quiz_round`.
+7. Generate PDF and MP3 files with `generate_round_assets`.
+8. Inspect the generated files and previews with `inspect_round_package`.
+9. Send the completed bundle with `send_round_email`; it reruns the package
    checks and refuses to send if previews or generated assets look wrong.
    To defer delivery, call `schedule_round_email` with an ISO timestamp such as
    `2026-07-09T19:00:00+02:00`; it generates PDF/MP3 and must pass the package

--- a/migrations/add_planned_quiz_rounds.py
+++ b/migrations/add_planned_quiz_rounds.py
@@ -1,0 +1,82 @@
+"""Add planned quiz rounds for agentic scheduling workflows."""
+
+import logging
+
+from sqlalchemy import inspect, text
+
+logger = logging.getLogger(__name__)
+
+
+def _table_exists(inspector, table_name):
+    return table_name in set(inspector.get_table_names())
+
+
+def _index_exists(inspector, table_name, index_name):
+    return any(index.get("name") == index_name for index in inspector.get_indexes(table_name))
+
+
+def _create_index(conn, inspector, table_name, index_name, columns):
+    if _index_exists(inspector, table_name, index_name):
+        return False
+    preparer = conn.dialect.identifier_preparer
+    quoted_table = preparer.quote(table_name)
+    quoted_index = preparer.quote(index_name)
+    quoted_columns = ", ".join(preparer.quote(column) for column in columns)
+    conn.execute(text(f"CREATE INDEX {quoted_index} ON {quoted_table} ({quoted_columns})"))
+    return True
+
+
+def run_migration():
+    """Create the planned quiz round table on existing databases."""
+    try:
+        from musicround import db
+
+        inspector = inspect(db.engine)
+        changes_made = False
+        with db.engine.connect() as conn:
+            if not _table_exists(inspector, "planned_quiz_round"):
+                conn.execute(
+                    text(
+                        """
+                        CREATE TABLE planned_quiz_round (
+                            id INTEGER PRIMARY KEY,
+                            quiz_date DATETIME NOT NULL,
+                            quizmaster_id INTEGER,
+                            theme VARCHAR(200),
+                            brief TEXT,
+                            source_playlist_url VARCHAR(500),
+                            due_at DATETIME,
+                            status VARCHAR(20) NOT NULL DEFAULT 'planned',
+                            round_id INTEGER,
+                            export_id INTEGER,
+                            created_at DATETIME,
+                            updated_at DATETIME
+                        )
+                        """
+                    )
+                )
+                changes_made = True
+
+            inspector = inspect(db.engine)
+            if _table_exists(inspector, "planned_quiz_round"):
+                for index_name, columns in (
+                    ("idx_planned_quiz_round_status_due", ["status", "due_at", "quiz_date"]),
+                    ("idx_planned_quiz_round_quizmaster_date", ["quizmaster_id", "quiz_date"]),
+                ):
+                    changes_made = (
+                        _create_index(conn, inspector, "planned_quiz_round", index_name, columns)
+                        or changes_made
+                    )
+
+            if changes_made:
+                conn.commit()
+
+        return True if changes_made else None
+    except Exception as exc:
+        logger.error("Migration add_planned_quiz_rounds failed: %s", exc)
+        return False
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    run_migration()

--- a/musicround/__init__.py
+++ b/musicround/__init__.py
@@ -14,7 +14,7 @@ from musicround.helpers.database_config import (
     bool_from_config,
     database_backend,
     database_summary,
-    is_sqlite_database_uri,
+    managed_database_requirement_error,
 )
 from musicround.version import VERSION_INFO, get_version_str
 from datetime import datetime
@@ -40,20 +40,17 @@ def _configure_database_uri(app):
         'SQLALCHEMY_DATABASE_URI'
     )
     if configured_uri:
-        if require_managed and is_sqlite_database_uri(configured_uri):
-            raise RuntimeError(
-                "DATABASE_REQUIRE_MANAGED is enabled, but SQLALCHEMY_DATABASE_URI "
-                "points at SQLite. Configure a managed SQL URI via secrets."
-            )
+        managed_error = managed_database_requirement_error(configured_uri, require_managed)
+        if managed_error:
+            raise RuntimeError(managed_error)
         app.config['SQLALCHEMY_DATABASE_URI'] = configured_uri
         app.config['DATABASE_BACKEND'] = database_backend(configured_uri)
         app.config['DATABASE_URI_REDACTED'] = database_summary(configured_uri)['redacted_uri']
         return
 
-    if require_managed:
-        raise RuntimeError(
-            "DATABASE_REQUIRE_MANAGED is enabled, but SQLALCHEMY_DATABASE_URI is not configured."
-        )
+    managed_error = managed_database_requirement_error(configured_uri, require_managed)
+    if managed_error:
+        raise RuntimeError(managed_error)
 
     if not os.path.exists(DEFAULT_DATABASE_DIR):
         os.makedirs(DEFAULT_DATABASE_DIR, exist_ok=True)

--- a/musicround/config.py
+++ b/musicround/config.py
@@ -4,6 +4,8 @@ from dotenv import load_dotenv
 import tempfile
 from datetime import timedelta
 
+from musicround.helpers.database_config import bool_from_config
+
 # Load environment variables from .env file
 load_dotenv()
 
@@ -42,7 +44,7 @@ class Config:
     
     SQLALCHEMY_DATABASE_URI = os.environ.get('SQLALCHEMY_DATABASE_URI')
     SQLALCHEMY_TRACK_MODIFICATIONS = False
-    DATABASE_REQUIRE_MANAGED = os.getenv("DATABASE_REQUIRE_MANAGED", "False") == "True"
+    DATABASE_REQUIRE_MANAGED = bool_from_config(os.getenv("DATABASE_REQUIRE_MANAGED", "False"))
 
     
     # Spotify API credentials    

--- a/musicround/config.py
+++ b/musicround/config.py
@@ -1,7 +1,6 @@
 import os
 import openai
 from dotenv import load_dotenv
-import tempfile
 from datetime import timedelta
 
 from musicround.helpers.database_config import bool_from_config

--- a/musicround/helpers/database_config.py
+++ b/musicround/helpers/database_config.py
@@ -34,6 +34,26 @@ def is_legacy_data_sqlite_uri(uri: str | None) -> bool:
     return normalized_path == "/data/song_data.db"
 
 
+def managed_database_requirement_error(
+    uri: str | None,
+    require_managed,
+) -> str | None:
+    """Return a safe error message when managed DB mode is misconfigured."""
+    if not bool_from_config(require_managed):
+        return None
+    if not uri:
+        return (
+            "DATABASE_REQUIRE_MANAGED is enabled, but SQLALCHEMY_DATABASE_URI "
+            "is not configured."
+        )
+    if is_sqlite_database_uri(uri):
+        return (
+            "DATABASE_REQUIRE_MANAGED is enabled, but SQLALCHEMY_DATABASE_URI "
+            "points at SQLite. Configure a managed SQL URI via secrets."
+        )
+    return None
+
+
 def redact_database_uri(uri: str | None) -> str:
     """Redact credentials from a database URI without hiding the backend."""
     if not uri:

--- a/musicround/helpers/dropbox_helper.py
+++ b/musicround/helpers/dropbox_helper.py
@@ -7,6 +7,7 @@ from musicround.helpers.logging_utils import redact_authorization_header
 import requests
 import json
 import os
+import re
 from datetime import datetime, timedelta
 from flask_login import current_user
 
@@ -19,6 +20,19 @@ DROPBOX_REFRESH_ERROR_MESSAGE = 'Dropbox token refresh failed. Please try again 
 DROPBOX_UPLOAD_ERROR_MESSAGE = 'Dropbox upload failed. Please try again or reconnect Dropbox.'
 DROPBOX_SHARED_LINK_ERROR_MESSAGE = 'Dropbox shared-link creation failed. Please try again or reconnect Dropbox.'
 DROPBOX_API_TIMEOUT_SECONDS = 10
+
+
+def format_dropbox_path(path):
+    """Normalize a path for Dropbox APIs."""
+    if not path or path == '/':
+        return ""
+
+    normalized = re.sub(r'/+', '/', str(path).strip())
+    if not normalized.startswith('/'):
+        normalized = '/' + normalized
+    if len(normalized) > 1:
+        normalized = normalized.rstrip('/')
+    return "" if normalized == '/' else normalized
 
 
 def get_dropbox_auth_url():
@@ -169,9 +183,7 @@ def upload_and_share(file_path, dropbox_path):
         current_app.logger.error("No valid Dropbox token available")
         return None
     
-    # Make sure dropbox_path starts with /
-    if not dropbox_path.startswith('/'):
-        dropbox_path = '/' + dropbox_path
+    dropbox_path = format_dropbox_path(dropbox_path)
     
     # First, upload the file
     try:
@@ -338,9 +350,7 @@ def upload_to_dropbox(access_token, dropbox_path, data, mode='binary'):
     Returns:
         dict: {'success': True/False, 'message': 'success or error message', 'metadata': file metadata if successful}
     """
-    # Make sure dropbox_path starts with /
-    if not dropbox_path.startswith('/'):
-        dropbox_path = '/' + dropbox_path
+    dropbox_path = format_dropbox_path(dropbox_path)
     
     try:
         # Convert string data to bytes if text mode
@@ -425,9 +435,7 @@ def create_shared_link(access_token, dropbox_path):
     Returns:
         dict: {'success': True/False, 'message': 'success or error message', 'url': shared link URL if successful}
     """
-    # Make sure dropbox_path starts with /
-    if not dropbox_path.startswith('/'):
-        dropbox_path = '/' + dropbox_path
+    dropbox_path = format_dropbox_path(dropbox_path)
     
     try:
         current_app.logger.debug(

--- a/musicround/helpers/import_helper.py
+++ b/musicround/helpers/import_helper.py
@@ -339,7 +339,14 @@ class ImportHelper:
                     imported_songs = ImportHelper.import_spotify_playlist(spotify_client, item_id, token=auth_token)
                     if imported_songs and imported_songs.get('error_count', 0) > 0:
                         return imported_songs
-                    if not imported_songs or imported_songs.get('imported_count', 0) == 0:
+                    if (
+                        not imported_songs
+                        or (
+                            imported_songs.get('imported_count', 0) == 0
+                            and imported_songs.get('skipped_count', 0) == 0
+                            and not imported_songs.get('imported_song_ids')
+                        )
+                    ):
                         current_app.logger.warning(f"Spotify playlist import returned empty result for playlist ID: {item_id}")
                         item_label = ImportHelper._safe_item_label(item_id)
                         return {
@@ -526,6 +533,7 @@ class ImportHelper:
             if existing_song:
                 current_app.logger.info(f'Spotify track ID {track_id} already exists as song: {existing_song.title} by {existing_song.artist}')
                 result['skipped_count'] += 1
+                result['song_id'] = existing_song.id
                 return result
                 
             resp = sp.get(f'tracks/{track_id}', token=authlib_token_for_request)
@@ -557,6 +565,7 @@ class ImportHelper:
                     # Potentially update other Spotify-specific fields if they are missing or different
                     db.session.commit()
                     result['skipped_count'] += 1
+                    result['song_id'] = existing_by_isrc.id
                     return result
                 
                 current_app.logger.info(f"Looking up comprehensive metadata for ISRC: {isrc}")
@@ -799,7 +808,8 @@ class ImportHelper:
             'skipped_count': 0,
             'error_count': 0,
             'errors': [],
-            'imported_song_ids': []  # Track IDs of successfully imported songs
+            'imported_song_ids': [],  # Database song IDs in playlist order
+            'playlist_positions': [],
         }
 
         authlib_token_for_request = ImportHelper._resolve_spotify_auth_token(token)
@@ -846,20 +856,45 @@ class ImportHelper:
                     current_app.logger.warning(f"No tracks found in playlist '{playlist_name}' (ID: {playlist_id}). It might be empty.")
                 
                 for item_wrapper in track_items:
+                    position = len(result['playlist_positions']) + 1
                     track_info_obj = item_wrapper.get('track')
                     if not track_info_obj or not isinstance(track_info_obj, dict): # Skip if track is None (e.g., local file) or not a dict
                         current_app.logger.warning(f"Skipping item in playlist '{playlist_name}' (ID: {playlist_id}) as it's not a valid track object or is unavailable: {track_info_obj}")
                         item_label = ImportHelper._safe_item_label(playlist_id)
                         result['errors'].append(f"Skipped an invalid/unavailable item in Spotify playlist {item_label}.")
+                        result['playlist_positions'].append({
+                            'position': position,
+                            'spotify_track_id': None,
+                            'artist': None,
+                            'title': None,
+                            'song_id': None,
+                            'status': 'failed',
+                            'reason': 'unavailable_track',
+                        })
                         # Not necessarily an error_count increment unless we want to be strict
                         continue
 
                     track_id = track_info_obj.get('id')
+                    artists = ", ".join(
+                        artist.get('name', '')
+                        for artist in track_info_obj.get('artists', [])
+                        if artist.get('name')
+                    ) or None
+                    title = track_info_obj.get('name')
                     if not track_id: # Should not happen if track_info_obj is valid
                         current_app.logger.warning(f"Skipping track with no ID in playlist '{playlist_name}' (ID: {playlist_id})")
                         item_label = ImportHelper._safe_item_label(playlist_id)
                         result['errors'].append(f"Found a track with no ID in Spotify playlist {item_label}.")
                         result['error_count'] +=1
+                        result['playlist_positions'].append({
+                            'position': position,
+                            'spotify_track_id': None,
+                            'artist': artists,
+                            'title': title,
+                            'song_id': None,
+                            'status': 'failed',
+                            'reason': 'missing_spotify_track_id',
+                        })
                         continue
                     track_import_result = ImportHelper.import_spotify_track(
                         sp,
@@ -874,9 +909,18 @@ class ImportHelper:
                     if track_import_result.get('errors'):
                         result['errors'].extend(track_import_result['errors'])
                     
-                    # Track the song ID if it was successfully imported
-                    if track_import_result.get('imported_count', 0) > 0 and track_import_result.get('song_id'):
-                        result['imported_song_ids'].append(track_import_result['song_id'])
+                    song_id = track_import_result.get('song_id')
+                    if song_id:
+                        result['imported_song_ids'].append(song_id)
+                    result['playlist_positions'].append({
+                        'position': position,
+                        'spotify_track_id': track_id,
+                        'artist': artists,
+                        'title': title,
+                        'song_id': song_id,
+                        'status': 'resolved' if song_id else 'failed',
+                        'reason': None if song_id else 'import_failed',
+                    })
                 
                 tracks_url = tracks_data.get('next')
                 if tracks_url:
@@ -884,6 +928,7 @@ class ImportHelper:
                 else:
                     current_app.logger.info(f"No more track pages for playlist '{playlist_name}' (ID: {playlist_id}).")
             db.session.commit() # Commit any changes made by track imports
+            return result
         except Exception as e:
             current_app.logger.error(
                 "Error importing Spotify playlist %s: %s",

--- a/musicround/helpers/utils.py
+++ b/musicround/helpers/utils.py
@@ -4,10 +4,29 @@ General utility functions used throughout the application.
 import secrets
 import string
 import os
+from urllib.parse import urlparse
 from flask import current_app
 from werkzeug.utils import secure_filename
 import requests
 import json
+
+
+def is_safe_url(target):
+    """Return whether a redirect target is an app-local absolute path."""
+    if not target or not isinstance(target, str):
+        return False
+    if not target.startswith('/'):
+        return False
+    if target.startswith(('//', r'\\', r'/\\', r'\\/')):
+        return False
+    if '\\' in target:
+        return False
+    try:
+        parsed = urlparse(target)
+    except ValueError:
+        return False
+    return not parsed.scheme and not parsed.netloc
+
 
 def generate_token(length=32):
     """

--- a/musicround/mcp_server.py
+++ b/musicround/mcp_server.py
@@ -450,6 +450,92 @@ def round_planning_brief(
 
 
 @mcp.tool()
+def create_planned_quiz_round(
+    quiz_date: str,
+    quizmaster_id: int | None = None,
+    theme: str | None = None,
+    brief: str | None = None,
+    due_at: str | None = None,
+    source_playlist_url: str | None = None,
+    status: str = "planned",
+) -> dict[str, Any]:
+    """Create a planned quiz date before a concrete round exists."""
+    return _with_app_context(
+        automation.create_planned_quiz_round,
+        quiz_date=quiz_date,
+        quizmaster_id=quizmaster_id,
+        theme=theme,
+        brief=brief,
+        due_at=due_at,
+        source_playlist_url=source_playlist_url,
+        status=status,
+    )
+
+
+@mcp.tool()
+def list_planned_quiz_rounds(
+    quizmaster_id: int | None = None,
+    status: str | None = None,
+    include_past: bool = True,
+    limit: int = 50,
+) -> dict[str, Any]:
+    """List planned quiz dates for agents and production-board views."""
+    return _with_app_context(
+        automation.list_planned_quiz_rounds,
+        quizmaster_id=quizmaster_id,
+        status=status,
+        include_past=include_past,
+        limit=limit,
+    )
+
+
+@mcp.tool()
+def update_planned_quiz_round(
+    plan_id: int,
+    quiz_date: str | None = None,
+    quizmaster_id: int | None = None,
+    theme: str | None = None,
+    brief: str | None = None,
+    due_at: str | None = None,
+    source_playlist_url: str | None = None,
+    status: str | None = None,
+    round_id: int | None = None,
+    export_id: int | None = None,
+) -> dict[str, Any]:
+    """Update a planned quiz date and optional linked deliverables."""
+    return _with_app_context(
+        automation.update_planned_quiz_round,
+        plan_id=plan_id,
+        quiz_date=quiz_date,
+        quizmaster_id=quizmaster_id,
+        theme=theme,
+        brief=brief,
+        due_at=due_at,
+        source_playlist_url=source_playlist_url,
+        status=status,
+        round_id=round_id,
+        export_id=export_id,
+    )
+
+
+@mcp.tool()
+def link_planned_quiz_round(
+    plan_id: int,
+    round_id: int | None = None,
+    export_id: int | None = None,
+    status: str | None = None,
+) -> dict[str, Any]:
+    """Link a planned quiz date to a generated round or scheduled export."""
+    return _with_app_context(
+        automation.link_planned_quiz_round,
+        plan_id=plan_id,
+        round_id=round_id,
+        export_id=export_id,
+        status=status,
+    )
+
+
+@mcp.tool()
 def draft_round_audio_scripts(
     round_id: int | None = None,
     user_id: int | None = None,

--- a/musicround/models.py
+++ b/musicround/models.py
@@ -428,6 +428,48 @@ class RoundExport(db.Model):
         return f"RoundExport(id={self.id}, round_id={self.round_id}, type='{self.export_type}', timestamp='{self.timestamp}')"
 
 
+class PlannedQuizRound(db.Model):
+    """
+    Planned quiz dates before a concrete round/export exists.
+    """
+    __tablename__ = 'planned_quiz_round'
+
+    id = db.Column(db.Integer, primary_key=True)
+    quiz_date = db.Column(db.DateTime, nullable=False)
+    quizmaster_id = db.Column(db.Integer, db.ForeignKey('user.id', ondelete='SET NULL'), nullable=True)
+    theme = db.Column(db.String(200), nullable=True)
+    brief = db.Column(db.Text, nullable=True)
+    source_playlist_url = db.Column(db.String(500), nullable=True)
+    due_at = db.Column(db.DateTime, nullable=True)
+    status = db.Column(db.String(20), default='planned', nullable=False)
+    round_id = db.Column(db.Integer, db.ForeignKey('round.id', ondelete='SET NULL'), nullable=True)
+    export_id = db.Column(db.Integer, db.ForeignKey('round_export.id', ondelete='SET NULL'), nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = db.Column(db.DateTime, onupdate=datetime.utcnow)
+
+    __table_args__ = (
+        db.Index('idx_planned_quiz_round_status_due', 'status', 'due_at', 'quiz_date'),
+        db.Index('idx_planned_quiz_round_quizmaster_date', 'quizmaster_id', 'quiz_date'),
+    )
+
+    quizmaster = db.relationship('User', backref=db.backref('planned_quiz_rounds', lazy='dynamic'))
+    round = db.relationship('Round', backref=db.backref('planned_entries', lazy='dynamic'))
+    export = db.relationship('RoundExport', backref=db.backref('planned_entries', lazy='dynamic'))
+
+    @validates('status')
+    def _validate_status(self, key, value):
+        allowed_statuses = {'planned', 'drafted', 'blocked', 'approved', 'scheduled', 'sent'}
+        if value not in allowed_statuses:
+            raise ValueError(f"Invalid planned quiz status: {value!r}")
+        return value
+
+    def __repr__(self):
+        return (
+            f"PlannedQuizRound(id={self.id}, quiz_date='{self.quiz_date}', "
+            f"status='{self.status}')"
+        )
+
+
 class SystemSetting(db.Model):
     __tablename__ = 'system_settings'
     id = db.Column(db.Integer, primary_key=True)

--- a/musicround/routes/api.py
+++ b/musicround/routes/api.py
@@ -1039,13 +1039,10 @@ def list_dropbox_folders():
     # Get the path from query params, default to empty string (root)
     path = request.args.get('path', '')
     
-    # Fix path format for Dropbox API
-    # Dropbox API requires empty string for root, not "/"
-    if path == '/' or not path:
-        path = ""
-        display_path = "/"
-    else:
-        display_path = path
+    from musicround.helpers.dropbox_helper import format_dropbox_path
+
+    display_path = path if path else "/"
+    path = format_dropbox_path(path)
         
     current_app.logger.info(f"Listing Dropbox folders for path: {display_path}")
         
@@ -1206,12 +1203,9 @@ def create_dropbox_folder():
     if any(char in folder_name for char in ['/', '\\', ':', '*', '?', '"', '<', '>', '|']):
         return jsonify({'error': 'Folder name contains invalid characters'}), 400
     
-    # Construct full path
-    # If parent is root, we need special handling
-    if parent_path == '/' or parent_path == '':
-        full_path = '/' + folder_name
-    else:
-        full_path = parent_path + '/' + folder_name
+    from musicround.helpers.dropbox_helper import format_dropbox_path
+
+    full_path = format_dropbox_path(parent_path + '/' + folder_name)
     
     current_app.logger.info(f"Creating Dropbox folder: {full_path}")
     

--- a/musicround/routes/auth.py
+++ b/musicround/routes/auth.py
@@ -11,6 +11,7 @@ import requests
 import secrets
 from musicround.helpers.auth_helpers import oauth, find_or_create_user, update_oauth_tokens, get_spotify_user_info, get_oauth_redirect_uri
 from musicround.helpers.logging_utils import oauth_token_log_summary
+from musicround.helpers.utils import is_safe_url
 
 # Create blueprint
 auth_bp = Blueprint('auth', __name__)
@@ -81,7 +82,7 @@ def callback():
             current_app.logger.info(f"User {user.username} logged in via Spotify ({spotify_info.get('name')})")
             
             next_page = request.args.get('next') or session.pop('next_url', None)
-            if not next_page or not next_page.startswith('/'):
+            if not is_safe_url(next_page):
                 next_page = url_for('core.index')
             return redirect(next_page)
         else:

--- a/musicround/routes/generate.py
+++ b/musicround/routes/generate.py
@@ -72,11 +72,13 @@ def get_all_genres():
     """
     Return a list of all genres in the Song table.
     """
-    all_genres = []
-    for song in Song.query.all():
-        if song.genre and song.genre not in all_genres:
-            all_genres.append(song.genre)
-    return all_genres
+    rows = (
+        Song.query.with_entities(Song.genre)
+        .filter(Song.genre.isnot(None), Song.genre != '')
+        .distinct()
+        .all()
+    )
+    return [genre for (genre,) in rows]
 
 def get_all_tags():
     """
@@ -157,11 +159,16 @@ def get_least_used_genres():
     genre_usage = {g: 0 for g in all_genres_list}
 
     # Count how many times each genre appears in Rounds of type 'genre'
-    used_genre_rounds = Round.query.filter_by(round_type='genre').all()
-    for rnd in used_genre_rounds:
+    used_genre_counts = (
+        db.session.query(Round.round_criteria_used, db.func.count(Round.id))
+        .filter_by(round_type='genre')
+        .group_by(Round.round_criteria_used)
+        .all()
+    )
+    for genre, count in used_genre_counts:
         # Ensure we only increment if it exists in genre_usage
-        if rnd.round_criteria_used in genre_usage:
-            genre_usage[rnd.round_criteria_used] += 1
+        if genre in genre_usage:
+            genre_usage[genre] += count
 
     # If we have no genres at all, return an empty list
     if not genre_usage:

--- a/musicround/routes/generate.py
+++ b/musicround/routes/generate.py
@@ -1,4 +1,5 @@
 import random
+import re
 from datetime import datetime
 from flask import Blueprint, render_template, request, redirect, url_for, flash, current_app
 from flask_login import current_user, login_required
@@ -11,6 +12,42 @@ generate_bp = Blueprint('generate', __name__)
 
 # Constants
 songs_per_round = 8
+_TAG_ALIAS_MAP = {
+    'hip-hop': 'Hip-Hop',
+    'hip hop': 'Hip-Hop',
+    'hiphop': 'Hip-Hop',
+    'r&b': 'R&B',
+    'rnb': 'R&B',
+    'rhythm and blues': 'R&B',
+    'rock': 'Rock',
+    'metal': 'Metal',
+    'country': 'Country',
+    'pop': 'Pop',
+    'punk': 'Punk',
+    'indie': 'Indie',
+    'electronic': 'Electronic',
+    'edm': 'Electronic',
+    'dance': 'Dance',
+    'soul': 'Soul',
+    'funk': 'Funk',
+    'jazz': 'Jazz',
+    'blues': 'Blues',
+    'folk': 'Folk',
+    'disco': 'Disco',
+    'new wave': 'New Wave',
+    'alternative': 'Alternative',
+    'classic rock': 'Classic Rock',
+    'hard rock': 'Hard Rock',
+}
+_INTERNAL_TAG_PREFIXES = (
+    'seed:',
+    'source:',
+    'import:',
+    'spotify:',
+    'deezer:',
+    'lastfm:',
+    'chart-source:',
+)
 
 # Helper functions
 def get_all_decades():
@@ -56,8 +93,39 @@ def get_all_tags():
 
 
 def _normalize_tag_name(tag_name):
-    """Trim tag names before matching or showing them in builder controls."""
-    return (tag_name or '').strip()
+    """Return a quizmaster-facing tag label, or None for internal/noisy tags."""
+    normalized = re.sub(r'\s+', ' ', (tag_name or '').strip())
+    if not normalized:
+        return None
+
+    lowered = normalized.casefold()
+    if lowered.startswith(_INTERNAL_TAG_PREFIXES):
+        return None
+    if '://' in lowered or lowered.startswith(('www.', '#')):
+        return None
+    if '@' in normalized:
+        return None
+    if len(normalized) > 40:
+        return None
+    if len(normalized.split()) > 4:
+        return None
+
+    return _TAG_ALIAS_MAP.get(lowered, normalized)
+
+
+def _tag_lookup_variants(tag_name):
+    """Return normalized DB comparison values for a public tag label."""
+    normalized_tag_name = _normalize_tag_name(tag_name)
+    if not normalized_tag_name:
+        return []
+
+    variants = {normalized_tag_name.casefold()}
+    variants.update(
+        alias.casefold()
+        for alias, canonical in _TAG_ALIAS_MAP.items()
+        if canonical.casefold() == normalized_tag_name.casefold()
+    )
+    return sorted(variants)
 
 
 def get_songs_by_tag(tag_name, limit=8):
@@ -68,10 +136,11 @@ def get_songs_by_tag(tag_name, limit=8):
     if not normalized_tag_name:
         return []
 
+    lookup_variants = _tag_lookup_variants(normalized_tag_name)
     normalized_sql = db.func.lower(db.func.trim(Tag.name))
     return (
         Song.query.join(Song.tags)
-        .filter(normalized_sql == normalized_tag_name.lower())
+        .filter(normalized_sql.in_(lookup_variants))
         .order_by(Song.id.asc())
         .distinct()
         .limit(limit)

--- a/musicround/routes/import_songs.py
+++ b/musicround/routes/import_songs.py
@@ -1,6 +1,5 @@
 import random
 import os
-import requests
 import json
 from flask import Blueprint, session, redirect, request, render_template, url_for, current_app, flash
 from flask_login import login_required, current_user

--- a/musicround/routes/rounds.py
+++ b/musicround/routes/rounds.py
@@ -14,7 +14,7 @@ import json
 from flask import Blueprint, session, redirect, request, render_template, url_for, current_app, send_file, jsonify, flash, abort
 from flask_login import current_user, login_required
 from sqlalchemy import or_
-from musicround.models import Round, RoundAudioScript, RoundExport, RoundShare, Song, db
+from musicround.models import PlannedQuizRound, Round, RoundAudioScript, RoundExport, RoundShare, Song, db
 from pydub import AudioSegment
 from reportlab.lib.pagesizes import A4
 from reportlab.pdfgen import canvas
@@ -316,8 +316,23 @@ def rounds_list():
 @rounds_bp.route('/calendar')
 @login_required
 def rounds_calendar():
-    """Show scheduled round email exports as a lightweight quiz calendar."""
+    """Show planned quiz dates and scheduled email exports as a lightweight calendar."""
     visible_round_ids = _visible_rounds_query().with_entities(Round.id)
+    planned_query = PlannedQuizRound.query
+    if not current_user.is_admin:
+        planned_query = planned_query.filter(
+            or_(
+                PlannedQuizRound.quizmaster_id == current_user.id,
+                PlannedQuizRound.quizmaster_id.is_(None),
+                PlannedQuizRound.round_id.in_(visible_round_ids),
+            )
+        )
+    planned_rounds = (
+        planned_query
+        .order_by(PlannedQuizRound.quiz_date.asc(), PlannedQuizRound.id.asc())
+        .limit(100)
+        .all()
+    )
     exports = (
         RoundExport.query.filter(
             RoundExport.round_id.in_(visible_round_ids),
@@ -328,7 +343,7 @@ def rounds_calendar():
         .limit(100)
         .all()
     )
-    return render_template('round_calendar.html', exports=exports)
+    return render_template('round_calendar.html', exports=exports, planned_rounds=planned_rounds)
 
 
 @rounds_bp.route('/analytics')

--- a/musicround/routes/users.py
+++ b/musicround/routes/users.py
@@ -12,7 +12,7 @@ from werkzeug.security import generate_password_hash, check_password_hash
 from sqlalchemy.exc import IntegrityError
 
 from musicround.models import db, User, Role, SystemSetting
-from musicround.helpers.utils import get_available_voices
+from musicround.helpers.utils import get_available_voices, is_safe_url
 from musicround.helpers.auth_helpers import oauth, find_or_create_user, update_oauth_tokens, get_google_user_info, get_authentik_user_info, get_spotify_user_info, get_oauth_redirect_uri
 from musicround.helpers.oauth_status import dropbox_token_status, spotify_token_status, token_notice
 from musicround.helpers.spotify_helper import (
@@ -238,7 +238,7 @@ def google_callback():
         
         # Redirect to next page or home
         next_page = request.args.get('next')
-        if not next_page or not next_page.startswith('/'):
+        if not is_safe_url(next_page):
             next_page = url_for('core.index')
             
         flash('You have been logged in via Google!', 'success')
@@ -295,7 +295,7 @@ def authentik_callback():
         
         # Redirect to next page or home
         next_page = request.args.get('next')
-        if not next_page or not next_page.startswith('/'):
+        if not is_safe_url(next_page):
             next_page = url_for('core.index')
             
         flash('You have been logged in via Authentik!', 'success')
@@ -536,7 +536,7 @@ def login():
         db.session.commit()
         
         next_page = request.args.get('next')
-        if not next_page or not next_page.startswith('/'):
+        if not is_safe_url(next_page):
             next_page = url_for('core.index')
             
         flash('You have been logged in!', 'success')

--- a/musicround/services/automation.py
+++ b/musicround/services/automation.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import re
+import csv
 import tempfile
 from datetime import datetime, timedelta, timezone
 from typing import Any, Iterable
@@ -2089,6 +2090,74 @@ def _split_playlist_line(line: str) -> tuple[str | None, str | None, float, list
     return text, None, 0.35, issues
 
 
+def _playlist_candidate(
+    line_number: int,
+    raw_line: str,
+    title: str | None,
+    artist: str | None,
+    confidence: float = 0.95,
+    issues: list[str] | None = None,
+) -> dict[str, Any] | None:
+    title = (title or "").strip()
+    artist = (artist or "").strip()
+    issues = list(issues or [])
+    if not title and not artist:
+        return None
+    if not title:
+        if "missing_title" not in issues:
+            issues.append("missing_title")
+        confidence = min(confidence, 0.35)
+    if not artist:
+        if "missing_artist" not in issues:
+            issues.append("missing_artist")
+        confidence = min(confidence, 0.35)
+    return {
+        "line": line_number,
+        "raw": raw_line.strip(),
+        "title": title or None,
+        "artist": artist or None,
+        "confidence": confidence,
+        "needs_review": confidence < 0.8 or bool(issues),
+        "issues": issues,
+    }
+
+
+def _parse_headered_csv_playlist(text: str, limit: int) -> list[dict[str, Any]] | None:
+    """Parse CSV-like rows only when explicit artist/title headers are present."""
+    non_empty_lines = [line for line in text.splitlines() if line.strip()]
+    if not non_empty_lines:
+        return None
+
+    delimiter = ";" if non_empty_lines[0].count(";") > non_empty_lines[0].count(",") else ","
+    header = next(csv.reader([non_empty_lines[0]], delimiter=delimiter), [])
+    normalized_header = [column.strip().casefold() for column in header]
+    title_headers = {"title", "song", "song title", "track", "track title"}
+    artist_headers = {"artist", "artists", "artist name", "performer"}
+    if not title_headers.intersection(normalized_header):
+        return None
+    if not artist_headers.intersection(normalized_header):
+        return None
+
+    reader = csv.DictReader(text.splitlines(), delimiter=delimiter)
+    fieldnames = reader.fieldnames or []
+    title_field = next(field for field in fieldnames if field.strip().casefold() in title_headers)
+    artist_field = next(field for field in fieldnames if field.strip().casefold() in artist_headers)
+    candidates: list[dict[str, Any]] = []
+    for line_number, row in enumerate(reader, start=2):
+        if len(candidates) >= limit:
+            break
+        raw_line = non_empty_lines[line_number - 1] if line_number - 1 < len(non_empty_lines) else ""
+        candidate = _playlist_candidate(
+            line_number,
+            raw_line,
+            row.get(title_field),
+            row.get(artist_field),
+        )
+        if candidate:
+            candidates.append(candidate)
+    return candidates
+
+
 def parse_text_playlist(text: str, limit: int = 100) -> dict[str, Any]:
     """Parse pasted text or CSV-like playlist rows into reviewable candidates."""
     if not text or not text.strip():
@@ -2096,26 +2165,18 @@ def parse_text_playlist(text: str, limit: int = 100) -> dict[str, Any]:
     if limit < 1 or limit > 500:
         raise AutomationError("limit must be between 1 and 500.")
 
-    candidates = []
-    low_confidence = []
-    for line_number, raw_line in enumerate(text.splitlines(), start=1):
-        if len(candidates) >= limit:
-            break
-        title, artist, confidence, issues = _split_playlist_line(raw_line)
-        if title is None:
-            continue
-        candidate = {
-            "line": line_number,
-            "raw": raw_line.strip(),
-            "title": title,
-            "artist": artist,
-            "confidence": confidence,
-            "needs_review": confidence < 0.8 or bool(issues),
-            "issues": issues,
-        }
-        candidates.append(candidate)
-        if candidate["needs_review"]:
-            low_confidence.append(candidate)
+    candidates = _parse_headered_csv_playlist(text, limit)
+    if candidates is None:
+        candidates = []
+        for line_number, raw_line in enumerate(text.splitlines(), start=1):
+            if len(candidates) >= limit:
+                break
+            title, artist, confidence, issues = _split_playlist_line(raw_line)
+            candidate = _playlist_candidate(line_number, raw_line, title, artist, confidence, issues)
+            if candidate:
+                candidates.append(candidate)
+
+    low_confidence = [candidate for candidate in candidates if candidate["needs_review"]]
 
     return {
         "count": len(candidates),

--- a/musicround/services/automation.py
+++ b/musicround/services/automation.py
@@ -72,23 +72,69 @@ def _ordered_round_songs(round_obj: Round) -> list[Song]:
     return [songs_by_id[song_id] for song_id in ids if song_id in songs_by_id]
 
 
-def _playlist_position_map(song_ids: list[int], expected_count: int | None = None) -> list[dict[str, Any]]:
+def _playlist_position_map(
+    song_ids: list[int],
+    expected_count: int | None = None,
+    source_positions: list[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
     limit = expected_count if expected_count is not None else len(song_ids)
-    return [
-        {
+    if source_positions:
+        positions = []
+        selected = source_positions[:limit]
+        for index, source in enumerate(selected):
+            song_id = source.get("song_id")
+            try:
+                song_id = int(song_id) if song_id is not None else None
+            except (TypeError, ValueError):
+                song_id = None
+            status = source.get("status") or ("resolved" if song_id else "failed")
+            positions.append({
+                "position": source.get("position") or index + 1,
+                "song_id": song_id,
+                "resolved": bool(song_id) and status == "resolved",
+                "status": status,
+                "spotify_track_id": source.get("spotify_track_id"),
+                "artist": source.get("artist"),
+                "title": source.get("title"),
+                "reason": source.get("reason"),
+            })
+        for index in range(len(selected), limit):
+            positions.append({
+                "position": index + 1,
+                "song_id": None,
+                "resolved": False,
+                "status": "missing",
+                "spotify_track_id": None,
+                "artist": None,
+                "title": None,
+                "reason": "no_playlist_position",
+            })
+        return positions
+
+    positions = []
+    for index, song_id in enumerate(song_ids[:limit]):
+        positions.append({
             "position": index + 1,
-            "song_id": song_id if index < len(song_ids) else None,
-            "resolved": index < len(song_ids),
-        }
-        for index, song_id in enumerate(song_ids[:limit])
-    ] + [
-        {
+            "song_id": song_id,
+            "resolved": True,
+            "status": "resolved",
+            "spotify_track_id": None,
+            "artist": None,
+            "title": None,
+            "reason": None,
+        })
+    for index in range(len(song_ids), limit):
+        positions.append({
             "position": index + 1,
             "song_id": None,
             "resolved": False,
-        }
-        for index in range(len(song_ids), limit)
-    ]
+            "status": "missing",
+            "spotify_track_id": None,
+            "artist": None,
+            "title": None,
+            "reason": "not_resolved",
+        })
+    return positions
 
 
 def _song_summary(song: Song) -> dict[str, Any]:
@@ -1213,15 +1259,24 @@ def create_round_from_playlist(
     """Import a playlist and create a manual round from the imported songs."""
     imported = import_catalog_item(service_name, "playlist", playlist_id_or_url, user_id=user_id)
     playlist_id = imported["item_id"]
-    if service_name.lower() == "spotify":
+    source_positions = imported.get("result", {}).get("playlist_positions") or []
+    if source_positions:
+        position_map = _playlist_position_map([], count, source_positions=source_positions)
+        song_ids = [
+            item["song_id"]
+            for item in position_map
+            if item["resolved"] and item.get("song_id") is not None
+        ]
+    elif service_name.lower() == "spotify":
         song_ids = _spotify_playlist_song_ids(playlist_id, count, user_id)
+        position_map = _playlist_position_map(song_ids, count)
     else:
         song_ids = imported.get("result", {}).get(
             "imported_song_ids"
         ) or _deezer_playlist_song_ids(playlist_id, count)
-    if not song_ids:
+        position_map = _playlist_position_map(song_ids, count)
+    if not song_ids and not position_map:
         raise AutomationError("Playlist import did not return song IDs to build a round.")
-    position_map = _playlist_position_map(song_ids, count)
     if len(song_ids) < count:
         message = (
             f"Playlist import resolved {len(song_ids)} songs; "

--- a/musicround/services/automation.py
+++ b/musicround/services/automation.py
@@ -35,6 +35,7 @@ from musicround.helpers.utils import generate_tts_mp3, get_mp3_path
 from musicround import models as datastore_models
 from musicround.models import (
     ImportJobRecord,
+    PlannedQuizRound,
     Round,
     RoundAudioScript,
     RoundExport,
@@ -158,6 +159,26 @@ def _round_summary(round_obj: Round) -> dict[str, Any]:
         "last_generated_at": (
             round_obj.last_generated_at.isoformat() if round_obj.last_generated_at else None
         ),
+    }
+
+
+def _planned_quiz_round_summary(plan: PlannedQuizRound) -> dict[str, Any]:
+    return {
+        "id": plan.id,
+        "quiz_date": _datetime_payload(plan.quiz_date),
+        "quizmaster_id": plan.quizmaster_id,
+        "quizmaster": _user_summary(plan.quizmaster),
+        "theme": plan.theme,
+        "brief": plan.brief,
+        "source_playlist_url": plan.source_playlist_url,
+        "due_at": _datetime_payload(plan.due_at),
+        "status": plan.status,
+        "round_id": plan.round_id,
+        "round": _round_summary(plan.round) if plan.round else None,
+        "export_id": plan.export_id,
+        "export": _round_export_summary(plan.export) if plan.export else None,
+        "created_at": _datetime_payload(plan.created_at),
+        "updated_at": _datetime_payload(plan.updated_at),
     }
 
 
@@ -2417,6 +2438,131 @@ def quizmaster_context(user_id: int, months: int = 3) -> dict[str, Any]:
         },
         "recent_usage": recent_usage_summary(user_id=user.id, months=months, limit=25),
     }
+
+
+def create_planned_quiz_round(
+    quiz_date: str | datetime,
+    quizmaster_id: int | None = None,
+    theme: str | None = None,
+    brief: str | None = None,
+    due_at: str | datetime | None = None,
+    source_playlist_url: str | None = None,
+    status: str = "planned",
+) -> dict[str, Any]:
+    """Create a planned quiz entry before a concrete round exists."""
+    quizmaster = _find_user(quizmaster_id) if quizmaster_id is not None else None
+    plan = PlannedQuizRound(
+        quiz_date=_parse_datetime_utc(quiz_date),
+        quizmaster_id=quizmaster.id if quizmaster else None,
+        theme=(theme or "").strip() or None,
+        brief=(brief or "").strip() or None,
+        source_playlist_url=(source_playlist_url or "").strip() or None,
+        due_at=_parse_datetime_utc(due_at) if due_at else None,
+        status=status,
+    )
+    db.session.add(plan)
+    db.session.commit()
+    return {"created": True, "plan": _planned_quiz_round_summary(plan)}
+
+
+def list_planned_quiz_rounds(
+    quizmaster_id: int | None = None,
+    status: str | None = None,
+    include_past: bool = True,
+    limit: int = 50,
+) -> dict[str, Any]:
+    """List planned quiz entries for production-board and MCP callers."""
+    if limit < 1 or limit > 200:
+        raise AutomationError("limit must be between 1 and 200.")
+
+    query = PlannedQuizRound.query
+    if quizmaster_id is not None:
+        _find_user(quizmaster_id)
+        query = query.filter_by(quizmaster_id=quizmaster_id)
+    if status:
+        status = status.strip().lower()
+        if status not in {'planned', 'drafted', 'blocked', 'approved', 'scheduled', 'sent'}:
+            raise AutomationError(f"Invalid planned quiz status: {status!r}.")
+        query = query.filter_by(status=status)
+    if not include_past:
+        query = query.filter(PlannedQuizRound.quiz_date >= datetime.utcnow())
+
+    plans = (
+        query.order_by(PlannedQuizRound.quiz_date.asc(), PlannedQuizRound.id.asc())
+        .limit(limit)
+        .all()
+    )
+    return {
+        "count": len(plans),
+        "plans": [_planned_quiz_round_summary(plan) for plan in plans],
+        "filters": {
+            "quizmaster_id": quizmaster_id,
+            "status": status,
+            "include_past": include_past,
+            "limit": limit,
+        },
+    }
+
+
+def update_planned_quiz_round(
+    plan_id: int,
+    quiz_date: str | datetime | None = None,
+    quizmaster_id: int | None = None,
+    theme: str | None = None,
+    brief: str | None = None,
+    due_at: str | datetime | None = None,
+    source_playlist_url: str | None = None,
+    status: str | None = None,
+    round_id: int | None = None,
+    export_id: int | None = None,
+) -> dict[str, Any]:
+    """Update a planned quiz entry and optionally link generated artifacts."""
+    plan = db.session.get(PlannedQuizRound, plan_id)
+    if not plan:
+        raise AutomationError(f"Planned quiz round {plan_id} was not found.")
+
+    if quiz_date is not None:
+        plan.quiz_date = _parse_datetime_utc(quiz_date)
+    if quizmaster_id is not None:
+        plan.quizmaster_id = _find_user(quizmaster_id).id
+    if theme is not None:
+        plan.theme = theme.strip() or None
+    if brief is not None:
+        plan.brief = brief.strip() or None
+    if due_at is not None:
+        plan.due_at = _parse_datetime_utc(due_at) if due_at else None
+    if source_playlist_url is not None:
+        plan.source_playlist_url = source_playlist_url.strip() or None
+    if status is not None:
+        plan.status = status.strip().lower()
+    if round_id is not None:
+        if not db.session.get(Round, round_id):
+            raise AutomationError(f"Round {round_id} was not found.")
+        plan.round_id = round_id
+    if export_id is not None:
+        if not db.session.get(RoundExport, export_id):
+            raise AutomationError(f"RoundExport {export_id} was not found.")
+        plan.export_id = export_id
+    plan.updated_at = datetime.utcnow()
+    db.session.commit()
+    return {"updated": True, "plan": _planned_quiz_round_summary(plan)}
+
+
+def link_planned_quiz_round(
+    plan_id: int,
+    round_id: int | None = None,
+    export_id: int | None = None,
+    status: str | None = None,
+) -> dict[str, Any]:
+    """Link a planned quiz entry to a generated round and/or scheduled export."""
+    if round_id is None and export_id is None and status is None:
+        raise AutomationError("Provide round_id, export_id, or status to update the plan.")
+    return update_planned_quiz_round(
+        plan_id,
+        round_id=round_id,
+        export_id=export_id,
+        status=status,
+    )
 
 
 def round_planning_brief(

--- a/musicround/templates/error.html
+++ b/musicround/templates/error.html
@@ -119,7 +119,7 @@ TRACEBACK:
     </div>
 
     <!-- Store error info for JS -->
-    <div id="error-info-data" class="hidden" data-error-info='{{ error_info_for_js|safe }}'></div>
+    <div id="error-info-data" class="hidden" data-error-info="{{ error_info_for_js }}"></div>
 {% endblock %}
 
 {% block scripts %}

--- a/musicround/templates/round_calendar.html
+++ b/musicround/templates/round_calendar.html
@@ -7,14 +7,60 @@
     <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-3 mb-6">
         <div>
             <h1 class="text-3xl font-bold text-navy-800 font-montserrat">Round Calendar</h1>
-            <p class="text-gray-600 mt-1">Scheduled and processed email deliveries for visible rounds.</p>
+            <p class="text-gray-600 mt-1">Planned quiz dates and scheduled email deliveries for visible rounds.</p>
         </div>
         <a href="{{ url_for('rounds.rounds_list') }}" class="bg-navy-700 hover:bg-navy-800 text-white py-2 px-4 rounded-md transition-colors text-sm font-semibold">
             <i class="fas fa-list mr-1"></i> Rounds
         </a>
     </div>
 
+    <div class="bg-white shadow-md rounded-lg overflow-hidden mb-8">
+        <div class="px-4 py-3 bg-navy-700 text-white font-semibold">Planned Quiz Dates</div>
+        <table class="w-full table-auto">
+            <thead class="bg-navy-50 text-navy-800">
+                <tr>
+                    <th class="px-4 py-3 text-left font-semibold">Quiz Date</th>
+                    <th class="px-4 py-3 text-left font-semibold">Theme</th>
+                    <th class="px-4 py-3 text-left font-semibold">Quizmaster</th>
+                    <th class="px-4 py-3 text-left font-semibold">Status</th>
+                    <th class="px-4 py-3 text-left font-semibold">Action</th>
+                </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-200">
+                {% for plan in planned_rounds %}
+                <tr class="hover:bg-gray-50">
+                    <td class="px-4 py-3">{{ plan.quiz_date.strftime('%Y-%m-%d %H:%M') if plan.quiz_date else '-' }}</td>
+                    <td class="px-4 py-3 font-medium">{{ plan.theme or 'Unthemed quiz round' }}</td>
+                    <td class="px-4 py-3 text-sm text-gray-600">{{ plan.quizmaster.username if plan.quizmaster else 'Unassigned' }}</td>
+                    <td class="px-4 py-3">
+                        <span class="px-2 py-1 text-xs font-semibold rounded-full
+                            {% if plan.status == 'scheduled' %}bg-blue-100 text-blue-800
+                            {% elif plan.status == 'approved' %}bg-green-100 text-green-800
+                            {% elif plan.status == 'blocked' %}bg-red-100 text-red-800
+                            {% elif plan.status == 'sent' %}bg-gray-100 text-gray-800
+                            {% else %}bg-yellow-100 text-yellow-800{% endif %}">
+                            {{ plan.status|capitalize }}
+                        </span>
+                    </td>
+                    <td class="px-4 py-3">
+                        {% if plan.round_id %}
+                        <a href="{{ url_for('rounds.round_detail', round_id=plan.round_id) }}" class="bg-teal-500 hover:bg-teal-600 text-white py-1.5 px-3 rounded text-sm transition-colors">Open Round</a>
+                        {% else %}
+                        <span class="text-sm text-gray-500">No round yet</span>
+                        {% endif %}
+                    </td>
+                </tr>
+                {% else %}
+                <tr>
+                    <td colspan="5" class="px-4 py-8 text-center text-gray-500">No planned quiz dates yet.</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+
     <div class="bg-white shadow-md rounded-lg overflow-hidden">
+        <div class="px-4 py-3 bg-navy-700 text-white font-semibold">Scheduled Email Deliveries</div>
         <table class="w-full table-auto">
             <thead class="bg-navy-50 text-navy-800">
                 <tr>

--- a/run.py
+++ b/run.py
@@ -68,7 +68,11 @@ def main():
 
         app = Flask(__name__)
         app.config.from_object(Config)
-        _configure_database_uri(app)
+        try:
+            _configure_database_uri(app)
+        except RuntimeError as exc:
+            print(f"Database configuration error: {exc}", file=sys.stderr)
+            return 78
         db_uri = app.config.get('SQLALCHEMY_DATABASE_URI')
         summary = database_summary(db_uri)
         print(f"Database backend: {summary['backend']}")

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -1,6 +1,7 @@
 """Tests for Flask app factory configuration helpers."""
 import os
 import json
+import importlib
 from datetime import datetime, timedelta
 
 from flask import Flask
@@ -17,6 +18,7 @@ from musicround import (
 from musicround.helpers.database_config import (
     database_summary,
     is_legacy_data_sqlite_uri,
+    managed_database_requirement_error,
     redact_database_uri,
 )
 from musicround.models import User, db
@@ -83,6 +85,42 @@ def test_configure_database_uri_rejects_sqlite_when_managed_required(monkeypatch
     import pytest
     with pytest.raises(RuntimeError, match='points at SQLite'):
         _configure_database_uri(app)
+
+
+def test_configure_database_uri_accepts_lowercase_managed_flag(monkeypatch):
+    """Managed DB guard should accept env-style lowercase booleans."""
+    monkeypatch.setenv('SQLALCHEMY_DATABASE_URI', 'sqlite:////data/song_data.db')
+    app = Flask(__name__)
+    app.config['DATABASE_REQUIRE_MANAGED'] = 'true'
+
+    import pytest
+    with pytest.raises(RuntimeError, match='points at SQLite'):
+        _configure_database_uri(app)
+
+
+def test_config_bool_parses_common_managed_database_values(monkeypatch):
+    """Config should parse the same DATABASE_REQUIRE_MANAGED values as runtime."""
+    monkeypatch.setenv('SECRET_KEY', 'test-secret-key-for-testing-only')
+    monkeypatch.setenv('DATABASE_REQUIRE_MANAGED', 'yes')
+
+    import musicround.config as config_module
+
+    reloaded = importlib.reload(config_module)
+
+    assert reloaded.Config.DATABASE_REQUIRE_MANAGED is True
+    monkeypatch.setenv('DATABASE_REQUIRE_MANAGED', 'False')
+    importlib.reload(config_module)
+
+
+def test_managed_database_requirement_error_is_credential_safe():
+    """Managed DB guard errors must not include raw database credentials."""
+    uri = 'postgresql://qb_user:super-secret@postgres.example/qb'
+
+    assert managed_database_requirement_error(uri, True) is None
+    assert 'super-secret' not in managed_database_requirement_error(None, True)
+    sqlite_error = managed_database_requirement_error('sqlite:////data/song_data.db', 'on')
+    assert 'points at SQLite' in sqlite_error
+    assert '/data/song_data.db' not in sqlite_error
 
 
 def test_database_uri_redaction_hides_credentials():

--- a/tests/test_automation_service.py
+++ b/tests/test_automation_service.py
@@ -1292,6 +1292,45 @@ class TestAgentPlanningAutomation:
             assert result["low_confidence"][0]["issues"] == ["missing_artist"]
             assert result["ready_for_import"] is False
 
+    def test_parse_text_playlist_reads_headered_csv_columns(self, app):
+        with app.app_context():
+            result = automation.parse_text_playlist(
+                "artist,title\n"
+                "Harry Styles,As It Was\n"
+                "Shania Twain,Man! I Feel Like A Woman!\n"
+            )
+
+            assert result["count"] == 2
+            assert result["candidates"][0]["line"] == 2
+            assert result["candidates"][0]["artist"] == "Harry Styles"
+            assert result["candidates"][0]["title"] == "As It Was"
+            assert result["candidates"][1]["artist"] == "Shania Twain"
+            assert result["low_confidence_count"] == 0
+            assert result["ready_for_import"] is True
+
+    def test_parse_text_playlist_reads_semicolon_csv_title_artist(self, app):
+        with app.app_context():
+            result = automation.parse_text_playlist(
+                "title;artist\n"
+                "As It Was;Harry Styles\n"
+            )
+
+            assert result["candidates"][0]["title"] == "As It Was"
+            assert result["candidates"][0]["artist"] == "Harry Styles"
+
+    def test_parse_text_playlist_marks_csv_rows_with_missing_values(self, app):
+        with app.app_context():
+            result = automation.parse_text_playlist(
+                "artist,title\n"
+                "Harry Styles,\n"
+                ",Man! I Feel Like A Woman!\n"
+            )
+
+            assert result["count"] == 2
+            assert result["low_confidence_count"] == 2
+            assert result["low_confidence"][0]["issues"] == ["missing_title"]
+            assert result["low_confidence"][1]["issues"] == ["missing_artist"]
+
     def test_retry_import_job_requeues_dead_letter_job(self, app):
         with app.app_context():
             user = _create_user()

--- a/tests/test_automation_service.py
+++ b/tests/test_automation_service.py
@@ -15,6 +15,7 @@ os.environ.setdefault("AUTOMATION_TOKEN", "test-automation-token-for-testing")
 from musicround.helpers.import_queue import ImportQueue
 from musicround.models import (
     ImportJobRecord,
+    PlannedQuizRound,
     Round,
     RoundAudioScript,
     RoundExport,
@@ -1474,6 +1475,80 @@ class TestAgentPlanningAutomation:
             assert any("exactly 8 songs" in item for item in result["constraints"])
             assert any("summer" in item for item in result["date_notes"])
             assert "agent_prompt" in result
+
+    def test_planned_quiz_round_lifecycle(self, app):
+        with app.app_context():
+            user = _create_user(username="planner", email="planner@example.test")
+            song = _create_song(title="As It Was", artist="Harry Styles")
+            round_id = automation.create_round(
+                name="Planned Round",
+                round_type="manual",
+                song_ids=[song.id],
+                user_id=user.id,
+            )["round"]["id"]
+            export = RoundExport(
+                round_id=round_id,
+                user_id=user.id,
+                export_type="email",
+                destination="planner@example.test",
+                status="scheduled",
+                scheduled_for=datetime(2026, 7, 9, 17, 0),
+            )
+            db.session.add(export)
+            db.session.commit()
+
+            created = automation.create_planned_quiz_round(
+                quiz_date="2026-07-09T19:00:00+02:00",
+                quizmaster_id=user.id,
+                theme="festival headliners",
+                brief="Build eight robust songs.",
+                due_at="2026-07-09T17:00:00+02:00",
+                source_playlist_url="https://open.spotify.com/playlist/example",
+            )
+            plan_id = created["plan"]["id"]
+            listed = automation.list_planned_quiz_rounds(quizmaster_id=user.id)
+            linked = automation.link_planned_quiz_round(
+                plan_id,
+                round_id=round_id,
+                export_id=export.id,
+                status="scheduled",
+            )
+
+            assert created["created"] is True
+            assert created["plan"]["quiz_date"] == "2026-07-09T17:00:00Z"
+            assert created["plan"]["due_at"] == "2026-07-09T15:00:00Z"
+            assert listed["count"] == 1
+            assert linked["plan"]["round_id"] == round_id
+            assert linked["plan"]["export_id"] == export.id
+            assert linked["plan"]["status"] == "scheduled"
+            assert PlannedQuizRound.query.get(plan_id).round_id == round_id
+
+    def test_planned_quiz_round_rejects_invalid_links(self, app):
+        with app.app_context():
+            user = _create_user()
+            created = automation.create_planned_quiz_round(
+                quiz_date="2026-07-09T19:00:00+02:00",
+                quizmaster_id=user.id,
+            )
+
+            with pytest.raises(automation.AutomationError) as exc_info:
+                automation.link_planned_quiz_round(created["plan"]["id"], round_id=9999)
+
+            assert "Round 9999 was not found" in str(exc_info.value)
+
+    def test_planned_quiz_round_can_be_unassigned(self, app):
+        with app.app_context():
+            _create_user(username="planner-a", email="planner-a@example.test")
+            _create_user(username="planner-b", email="planner-b@example.test")
+
+            created = automation.create_planned_quiz_round(
+                quiz_date="2026-07-09T19:00:00+02:00",
+                theme="unassigned production slot",
+            )
+
+            assert created["created"] is True
+            assert created["plan"]["quizmaster_id"] is None
+            assert created["plan"]["quizmaster"] is None
 
     def test_draft_round_audio_scripts_uses_round_context(self, app):
         with app.app_context():

--- a/tests/test_automation_service.py
+++ b/tests/test_automation_service.py
@@ -209,11 +209,10 @@ class TestRoundAutomation:
             assert exc_info.value.details["status"] == "needs_more_songs"
             assert exc_info.value.details["expected_song_count"] == 8
             assert exc_info.value.details["resolved_song_count"] == 1
-            assert exc_info.value.details["resolved_positions"][0] == {
-                "position": 1,
-                "song_id": song.id,
-                "resolved": True,
-            }
+            assert exc_info.value.details["resolved_positions"][0]["position"] == 1
+            assert exc_info.value.details["resolved_positions"][0]["song_id"] == song.id
+            assert exc_info.value.details["resolved_positions"][0]["resolved"] is True
+            assert exc_info.value.details["resolved_positions"][1]["reason"] == "not_resolved"
             assert exc_info.value.details["missing_positions"] == [2, 3, 4, 5, 6, 7, 8]
 
     def test_create_round_from_playlist_returns_resolved_position_map(self, app):
@@ -224,7 +223,31 @@ class TestRoundAutomation:
             with (
                 patch(
                     "musicround.services.automation.import_catalog_item",
-                    return_value={"item_id": "playlist123", "result": {}},
+                    return_value={
+                        "item_id": "playlist123",
+                        "result": {
+                            "playlist_positions": [
+                                {
+                                    "position": 1,
+                                    "spotify_track_id": "spotify-first",
+                                    "artist": "A",
+                                    "title": "First",
+                                    "song_id": first_song.id,
+                                    "status": "resolved",
+                                    "reason": None,
+                                },
+                                {
+                                    "position": 2,
+                                    "spotify_track_id": "spotify-second",
+                                    "artist": "B",
+                                    "title": "Second",
+                                    "song_id": second_song.id,
+                                    "status": "resolved",
+                                    "reason": None,
+                                },
+                            ],
+                        },
+                    },
                 ),
                 patch(
                     "musicround.services.automation._spotify_playlist_song_ids",
@@ -238,10 +261,84 @@ class TestRoundAutomation:
                 )
 
             assert result["round"]["song_ids"] == [first_song.id, second_song.id]
-            assert result["resolved_positions"] == [
-                {"position": 1, "song_id": first_song.id, "resolved": True},
-                {"position": 2, "song_id": second_song.id, "resolved": True},
-            ]
+            assert result["resolved_positions"][0] == {
+                "position": 1,
+                "song_id": first_song.id,
+                "resolved": True,
+                "status": "resolved",
+                "spotify_track_id": "spotify-first",
+                "artist": "A",
+                "title": "First",
+                "reason": None,
+            }
+            assert result["resolved_positions"][1]["spotify_track_id"] == "spotify-second"
+
+    def test_create_round_from_playlist_preserves_failed_source_positions(self, app):
+        with app.app_context():
+            first_song = _create_song(title="First", artist="A")
+            third_song = _create_song(title="Third", artist="C")
+
+            with (
+                patch(
+                    "musicround.services.automation.import_catalog_item",
+                    return_value={
+                        "item_id": "playlist123",
+                        "result": {
+                            "playlist_positions": [
+                                {
+                                    "position": 1,
+                                    "spotify_track_id": "spotify-first",
+                                    "artist": "A",
+                                    "title": "First",
+                                    "song_id": first_song.id,
+                                    "status": "resolved",
+                                    "reason": None,
+                                },
+                                {
+                                    "position": 2,
+                                    "spotify_track_id": None,
+                                    "artist": "B",
+                                    "title": "Broken",
+                                    "song_id": None,
+                                    "status": "failed",
+                                    "reason": "missing_spotify_track_id",
+                                },
+                                {
+                                    "position": 3,
+                                    "spotify_track_id": "spotify-third",
+                                    "artist": "C",
+                                    "title": "Third",
+                                    "song_id": third_song.id,
+                                    "status": "resolved",
+                                    "reason": None,
+                                },
+                            ],
+                        },
+                    },
+                ),
+                patch("musicround.services.automation._spotify_playlist_song_ids") as mock_song_ids,
+            ):
+                with pytest.raises(automation.AutomationError) as exc_info:
+                    automation.create_round_from_playlist(
+                        "spotify",
+                        "playlist123",
+                        count=3,
+                    )
+
+            mock_song_ids.assert_not_called()
+            assert exc_info.value.details["resolved_song_count"] == 2
+            assert exc_info.value.details["missing_positions"] == [2]
+            assert exc_info.value.details["resolved_positions"][1] == {
+                "position": 2,
+                "song_id": None,
+                "resolved": False,
+                "status": "failed",
+                "spotify_track_id": None,
+                "artist": "B",
+                "title": "Broken",
+                "reason": "missing_spotify_track_id",
+            }
+            assert Round.query.count() == 0
 
     def test_replace_round_song_updates_position_and_invalidates_assets(self, app):
         with app.app_context():

--- a/tests/test_dropbox_helper.py
+++ b/tests/test_dropbox_helper.py
@@ -31,6 +31,21 @@ def _make_dropbox_user():
     return user
 
 
+@pytest.mark.parametrize(
+    ('raw_path', 'expected'),
+    [
+        ('', ''),
+        ('/', ''),
+        ('folder/file.pdf', '/folder/file.pdf'),
+        ('/folder/file.pdf', '/folder/file.pdf'),
+        ('//folder///nested/', '/folder/nested'),
+        (' /folder/ ', '/folder'),
+    ],
+)
+def test_format_dropbox_path_normalizes_api_paths(raw_path, expected):
+    assert dropbox_helper.format_dropbox_path(raw_path) == expected
+
+
 def test_refresh_dropbox_token_raises_on_invalid_grant(app):
     with app.app_context():
         with patch('musicround.helpers.dropbox_helper.requests.post') as mock_post:

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -161,12 +161,31 @@ class TestGetAllTags:
                 Tag(name=' rock '),
                 Tag(name='Rock'),
                 Tag(name='Country'),
+                Tag(name='hip hop'),
             ])
             db.session.commit()
 
             result = get_all_tags()
 
-        assert result == ['Country', 'rock']
+        assert result == ['Country', 'Hip-Hop', 'Rock']
+
+    def test_filters_internal_and_noisy_tags(self, app):
+        """Builder tags should hide import internals and obvious free-text noise."""
+        from musicround.routes.generate import get_all_tags
+        with app.app_context():
+            db.session.add_all([
+                Tag(name='seed:wacken-2026'),
+                Tag(name='source:billboard'),
+                Tag(name='https://example.test/playlist'),
+                Tag(name='not actually a usable quiz tag'),
+                Tag(name='Metal'),
+                Tag(name='Pop'),
+            ])
+            db.session.commit()
+
+            result = get_all_tags()
+
+        assert result == ['Metal', 'Pop']
 
 
 class TestGetSongsByTag:
@@ -211,6 +230,36 @@ class TestGetSongsByTag:
             result = get_songs_by_tag('ROCK')
 
         assert {song.title for song in result} == {'Trimmed Rock Song', 'Cased Rock Song'}
+
+    def test_matches_public_tag_aliases(self, app):
+        """Test public tag aliases resolve to raw imported tag variants."""
+        from musicround.routes.generate import get_songs_by_tag
+        with app.app_context():
+            tag = Tag(name='hip hop')
+            song = Song(title='Alias Tag Song', artist='A', genre='Hip-Hop')
+            db.session.add_all([tag, song])
+            db.session.commit()
+            song.tags.append(tag)
+            db.session.commit()
+
+            result = get_songs_by_tag('Hip-Hop')
+
+        assert [song.title for song in result] == ['Alias Tag Song']
+
+    def test_rejects_internal_tag_round_selection(self, app):
+        """Internal tags should not be selectable even if they exist in storage."""
+        from musicround.routes.generate import get_songs_by_tag
+        with app.app_context():
+            tag = Tag(name='seed:wacken')
+            song = Song(title='Internal Tag Song', artist='A', genre='Metal')
+            db.session.add_all([tag, song])
+            db.session.commit()
+            song.tags.append(tag)
+            db.session.commit()
+
+            result = get_songs_by_tag('seed:wacken')
+
+        assert result == []
 
     def test_respects_limit(self, app):
         """Test get_songs_by_tag respects the limit parameter."""

--- a/tests/test_import_helper.py
+++ b/tests/test_import_helper.py
@@ -87,6 +87,44 @@ class FakeSpotifyClient:
         raise AssertionError(f'Unexpected Spotify path: {path}')
 
 
+class FakeSpotifyPlaylistClient:
+    """Spotify client stub for playlist position mapping."""
+
+    token = None
+
+    def __init__(self):
+        self.calls = []
+
+    def get(self, path, token=None):
+        self.calls.append((path, token))
+        if path == 'playlists/playlist-positions?fields=name,tracks.next':
+            return FakeSpotifyResponse({
+                'name': 'Position Test',
+                'tracks': {'next': None},
+            })
+        if path == 'playlists/playlist-positions/tracks':
+            return FakeSpotifyResponse({
+                'items': [
+                    {
+                        'track': {
+                            'id': 'spotify-existing',
+                            'name': 'Existing Track',
+                            'artists': [{'name': 'Existing Artist'}],
+                        }
+                    },
+                    {
+                        'track': {
+                            'id': None,
+                            'name': 'Broken Track',
+                            'artists': [{'name': 'Broken Artist'}],
+                        }
+                    },
+                ],
+                'next': None,
+            })
+        raise AssertionError(f'Unexpected Spotify path: {path}')
+
+
 class FailingSpotifyClient:
     """Spotify client stub that fails every request."""
 
@@ -386,6 +424,49 @@ class TestImportHelperSpotifyTokens:
         ]
         assert 'secret' not in response['errors'][0]
         assert 'refresh_token' not in response['errors'][0]
+
+    def test_spotify_playlist_returns_position_mapping_for_existing_and_failed_tracks(self, app):
+        """Playlist imports should expose repairable per-position mapping details."""
+        spotify = FakeSpotifyPlaylistClient()
+        with app.test_request_context():
+            existing = Song(
+                title='Existing Track',
+                artist='Existing Artist',
+                spotify_id='spotify-existing',
+            )
+            db.session.add(existing)
+            db.session.commit()
+
+            response = ImportHelper.import_item(
+                'spotify',
+                'playlist',
+                'playlist-positions',
+                oauth_spotify=spotify,
+                spotify_token='manual-token',
+            )
+
+        assert response['imported_count'] == 0
+        assert response['skipped_count'] == 1
+        assert response['error_count'] == 1
+        assert response['imported_song_ids'] == [existing.id]
+        assert response['playlist_positions'][0] == {
+            'position': 1,
+            'spotify_track_id': 'spotify-existing',
+            'artist': 'Existing Artist',
+            'title': 'Existing Track',
+            'song_id': existing.id,
+            'status': 'resolved',
+            'reason': None,
+        }
+        assert response['playlist_positions'][1] == {
+            'position': 2,
+            'spotify_track_id': None,
+            'artist': 'Broken Artist',
+            'title': 'Broken Track',
+            'song_id': None,
+            'status': 'failed',
+            'reason': 'missing_spotify_track_id',
+        }
 
     def test_spotify_track_http_status_returns_sanitized_error(self, app):
         """Spotify HTTP errors must not expose provider response details."""

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -5,7 +5,15 @@ import sqlite3
 from flask import Flask
 
 from musicround import db
-from musicround.models import ImportJobRecord, Round, RoundAudioScript, RoundExport, RoundShare, Song
+from musicround.models import (
+    ImportJobRecord,
+    PlannedQuizRound,
+    Round,
+    RoundAudioScript,
+    RoundExport,
+    RoundShare,
+    Song,
+)
 
 
 def _legacy_app(database_path):
@@ -287,6 +295,41 @@ def test_add_round_review_workflow_to_legacy_database(tmp_path):
     }.issubset(round_columns)
     assert "idx_round_review_status" in _index_names(database_path, "round")
     assert "review_status" in Round.__table__.columns.keys()
+
+
+def test_add_planned_quiz_rounds_to_legacy_database(tmp_path):
+    """Existing databases get planned quiz production-board schema."""
+    database_path = tmp_path / "legacy-planned-quiz.db"
+    app = _legacy_app(database_path)
+    with app.app_context():
+        db.create_all()
+        db.session.remove()
+        db.drop_all()
+
+        from migrations import add_planned_quiz_rounds
+
+        assert add_planned_quiz_rounds.run_migration() is True
+        assert add_planned_quiz_rounds.run_migration() is None
+
+    assert "planned_quiz_round" in _table_names(database_path)
+    columns = set(_column_names(database_path, "planned_quiz_round"))
+    assert {
+        "quiz_date",
+        "quizmaster_id",
+        "theme",
+        "brief",
+        "source_playlist_url",
+        "due_at",
+        "status",
+        "round_id",
+        "export_id",
+    }.issubset(columns)
+    assert "idx_planned_quiz_round_status_due" in _index_names(database_path, "planned_quiz_round")
+    assert "idx_planned_quiz_round_quizmaster_date" in _index_names(
+        database_path,
+        "planned_quiz_round",
+    )
+    assert PlannedQuizRound.__tablename__ == "planned_quiz_round"
 
 
 def test_round_songs_comment_matches_storage_behavior():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,7 +3,8 @@ import pytest
 from datetime import datetime, timedelta
 from musicround.models import (
     db, User, Role, UserPreferences, Tag, SongTag, Song,
-    Round, RoundAudioScript, RoundExport, RoundShare, SystemSetting, ImportJobRecord,
+    PlannedQuizRound, Round, RoundAudioScript, RoundExport, RoundShare, SystemSetting,
+    ImportJobRecord,
 )
 
 
@@ -751,3 +752,34 @@ class TestImportJobRecordModel:
             item_id='something', user_id=user.id, priority=10,
         )
         assert job.item_url is None
+
+
+class TestPlannedQuizRoundModel:
+    """Tests for planned quiz production entries."""
+
+    def test_planned_quiz_round_creation(self, app):
+        user = User(username='planner', email='planner@example.com')
+        db.session.add(user)
+        db.session.commit()
+
+        plan = PlannedQuizRound(
+            quiz_date=datetime(2026, 7, 9, 17, 0),
+            quizmaster_id=user.id,
+            theme='festival headliners',
+            brief='Eight robust songs.',
+            due_at=datetime(2026, 7, 9, 15, 0),
+        )
+        db.session.add(plan)
+        db.session.commit()
+
+        fetched = PlannedQuizRound.query.first()
+        assert fetched.status == 'planned'
+        assert fetched.quizmaster.username == 'planner'
+        assert fetched.theme == 'festival headliners'
+
+    def test_planned_quiz_round_rejects_invalid_status(self, app):
+        with pytest.raises(ValueError):
+            PlannedQuizRound(
+                quiz_date=datetime(2026, 7, 9, 17, 0),
+                status='not-a-real-status',
+            )

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1,0 +1,48 @@
+"""Tests for process blueprint routes."""
+import base64
+
+from musicround.models import User, db
+
+
+def _login(app, client):
+    """Create and log in a user."""
+    with app.app_context():
+        user = User.query.filter_by(username='processtest').first()
+        if not user:
+            user = User(username='processtest', email='processtest@example.com')
+            user.password = 'ProcessPass123!'
+            db.session.add(user)
+            db.session.commit()
+    client.post('/users/login', data={
+        'username': 'processtest',
+        'password': 'ProcessPass123!',
+    })
+
+
+class TestProcessRoutes:
+    """Tests for process blueprint routes."""
+
+    def test_base64_encode_requires_login(self, client):
+        response = client.post('/process/base64', data=b'some data')
+
+        assert response.status_code in (302, 401)
+        if response.status_code == 302:
+            assert 'login' in response.headers.get('Location', '').lower()
+
+    def test_base64_encode_no_data(self, app, client):
+        _login(app, client)
+
+        response = client.post('/process/base64', data=b'')
+
+        assert response.status_code == 400
+        assert response.get_json() == {'error': 'No data provided'}
+
+    def test_base64_encode_success(self, app, client):
+        _login(app, client)
+        test_data = b'Hello, world! 123 \x00\x01\x02'
+        expected_encoded = base64.b64encode(test_data).decode('utf-8')
+
+        response = client.post('/process/base64', data=test_data)
+
+        assert response.status_code == 200
+        assert response.get_json() == {'encoded': expected_encoded}

--- a/tests/test_rounds_routes.py
+++ b/tests/test_rounds_routes.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from unittest.mock import patch, mock_open
 from flask import jsonify
 from pydub import AudioSegment
-from musicround.models import db, User, Song, Round, RoundAudioScript, RoundExport, RoundShare
+from musicround.models import db, PlannedQuizRound, User, Song, Round, RoundAudioScript, RoundExport, RoundShare
 
 
 def _login(app, client, username='roundsuser', email='rounds@example.com'):
@@ -192,6 +192,44 @@ class TestRoundsListRoute:
         assert response.status_code == 200
         assert b'Calendar Round' in response.data
         assert b'2026-07-09 17:00' in response.data
+
+    def test_round_calendar_shows_visible_planned_quiz_dates(self, app, client):
+        """Round calendar should expose own and unassigned planned quiz dates."""
+        _login(app, client, username='planner', email='planner@example.test')
+        planner_id = _user_id(app, 'planner')
+        with app.app_context():
+            other = User(username='otherplanner', email='otherplanner@example.test')
+            other.password = 'RoundsPass123!'
+            db.session.add(other)
+            db.session.commit()
+            db.session.add_all([
+                PlannedQuizRound(
+                    quiz_date=datetime(2026, 7, 9, 17, 0),
+                    quizmaster_id=planner_id,
+                    theme='Festival repair night',
+                    status='planned',
+                ),
+                PlannedQuizRound(
+                    quiz_date=datetime(2026, 7, 16, 17, 0),
+                    theme='Unassigned Thursday',
+                    status='blocked',
+                ),
+                PlannedQuizRound(
+                    quiz_date=datetime(2026, 7, 23, 17, 0),
+                    quizmaster_id=other.id,
+                    theme='Hidden other quizmaster',
+                    status='planned',
+                ),
+            ])
+            db.session.commit()
+
+        response = client.get('/rounds/calendar')
+
+        assert response.status_code == 200
+        assert b'Planned Quiz Dates' in response.data
+        assert b'Festival repair night' in response.data
+        assert b'Unassigned Thursday' in response.data
+        assert b'Hidden other quizmaster' not in response.data
 
     def test_round_analytics_page_renders_summary(self, app, client):
         """Round analytics should render catalog health signals."""

--- a/tests/test_run_cli.py
+++ b/tests/test_run_cli.py
@@ -39,3 +39,25 @@ def test_database_status_warns_for_legacy_data_sqlite(monkeypatch, capsys):
     assert "Database backend: sqlite" in output
     assert "Managed database required: False" in output
     assert "legacy /data SQLite database is configured" in output
+
+
+def test_database_status_returns_safe_error_when_managed_guard_fails(monkeypatch, capsys):
+    """The database runbook command should fail without a Python traceback."""
+    import run
+
+    monkeypatch.setenv("SECRET_KEY", "test-secret-key-for-testing-only")
+    monkeypatch.setenv("AUTOMATION_TOKEN", "test-automation-token-for-testing")
+    monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", "sqlite:////data/song_data.db")
+    monkeypatch.setenv("DATABASE_REQUIRE_MANAGED", "true")
+    from musicround.config import Config
+    monkeypatch.setattr(Config, "DATABASE_REQUIRE_MANAGED", True)
+    monkeypatch.setattr(sys, "argv", ["run.py", "database", "status"])
+
+    exit_code = run.main()
+    captured = capsys.readouterr()
+
+    assert exit_code == 78
+    assert "Database configuration error:" in captured.err
+    assert "points at SQLite" in captured.err
+    assert "Traceback" not in captured.err
+    assert "/data/song_data.db" not in captured.err

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -49,6 +49,32 @@ class TestGenerateToken:
             generate_token(length=length)
 
 
+class TestSafeRedirectUrl:
+    """Tests for local redirect URL validation."""
+
+    @pytest.mark.parametrize('target', ['/rounds/', '/users/profile?next=/rounds', '/'])
+    def test_accepts_local_absolute_paths(self, target):
+        from musicround.helpers.utils import is_safe_url
+        assert is_safe_url(target) is True
+
+    @pytest.mark.parametrize(
+        'target',
+        [
+            None,
+            '',
+            'rounds/',
+            'https://evil.example/rounds',
+            '//evil.example/rounds',
+            '/\\evil.example',
+            '\\/evil.example',
+            '/rounds\\evil',
+        ],
+    )
+    def test_rejects_external_or_ambiguous_targets(self, target):
+        from musicround.helpers.utils import is_safe_url
+        assert is_safe_url(target) is False
+
+
 class TestAllowedFile:
     """Tests for the allowed_file function."""
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -59,3 +59,15 @@ class TestGetVersionStr:
         """Test that the version string contains the release name."""
         result = get_version_str()
         assert VERSION_INFO['release_name'] in result
+
+    def test_truthy_non_boolean_values(self):
+        """Truthy include_build values should include the build number."""
+        for value in ['yes', 1, [1], {'a': 1}]:
+            result = get_version_str(include_build=value)
+            assert VERSION_INFO['build_number'] in result
+
+    def test_falsy_non_boolean_values(self):
+        """Falsy include_build values should omit the build number."""
+        for value in [None, '', 0, [], {}]:
+            result = get_version_str(include_build=value)
+            assert VERSION_INFO['build_number'] not in result


### PR DESCRIPTION
## Summary
- consolidates the local QuizzicalBeats roadmap fixes already built on this branch
- backports the useful agent PR changes from #148-#159 into one coherent branch
- hardens redirect targets, error-template escaping, Dropbox path handling, generator queries, and small route/test cleanups

## Validation
- SECRET_KEY=test-secret AUTOMATION_TOKEN=test-token .venv/bin/pytest tests/test_utils.py tests/test_dropbox_helper.py tests/test_version.py tests/test_process.py tests/test_generate.py tests/test_routes.py -q
- 156 passed

## Notes
- PRs #152, #153, #154, and #159 overlap; this branch uses one consolidated redirect helper rather than four duplicate variants.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for headered CSV playlist imports.
  * Added planned quiz dates to the calendar, with new planning tools to track upcoming rounds.
* **Bug Fixes**
  * Improved playlist imports so existing tracks resolve correctly and successful imports return usable results.
  * Fixed playlist parsing so header rows aren’t treated as songs, and missing artist/title fields are flagged.
  * Strengthened login redirects, browser error handling, Dropbox path handling, and database safety checks.
* **Performance**
  * Optimized genre and tag lookups to reduce unnecessary loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->