### PR TITLE
[codex] support component Postgres database config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,15 @@ PERMANENT_SESSION_LIFETIME_HOURS=12
 # ============================================================================
 SQLALCHEMY_DATABASE_URI=sqlite:///data/song_data.db
 SQLALCHEMY_TRACK_MODIFICATIONS=False
+# Production can alternatively set PGHOST, PGDATABASE, PGUSER, and PGPASSWORD
+# instead of one full SQLALCHEMY_DATABASE_URI. This keeps generated database
+# credentials split when using CNPG/Kubernetes secretKeyRef entries.
+# DATABASE_REQUIRE_MANAGED=true
+# PGHOST=postgres-rw.namespace.svc.cluster.local
+# PGPORT=5432
+# PGDATABASE=quizzicalbeats
+# PGUSER=quizzicalbeats
+# PGPASSWORD=change-me
 
 # ============================================================================
 # HTTPS CONFIGURATION

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added headered CSV playlist parsing for text-import automation, including `artist,title` and `title;artist` layouts.
 - Added planned quiz round records plus MCP tools to create, list, update, and link upcoming quiz dates before a round exists.
 - Added planned quiz dates to the browser round calendar with quizmaster visibility and linked-round actions.
+- Added PostgreSQL component-variable database configuration so Kubernetes/CNPG deployments can use `PGHOST`, `PGDATABASE`, `PGUSER`, and `PGPASSWORD` without storing one full database URI secret.
 
 ### Fixed
 - Hid internal/noisy import tags from the music-round builder while keeping raw tags in storage, and mapped common public aliases such as `hip hop` to `Hip-Hop`.
@@ -82,6 +83,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed Spotify playlist imports so already-cataloged tracks count as resolved positions and successful imports always return their result payload.
 - Added credential-safe health and CLI warnings when production still points at the legacy `/data/song_data.db` SQLite file.
 - Hardened the managed-database guard so common truthy `DATABASE_REQUIRE_MANAGED` values fail fast before container startup can fall back to SQLite.
+- Added a PostgreSQL driver dependency required for managed PostgreSQL deployments.
 - Hardened login and OAuth redirect targets against open redirects.
 - Escaped browser error metadata instead of injecting raw JSON into the error template.
 - Normalized Dropbox API paths for folder browsing, folder creation, upload, and shared-link creation.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -12,11 +12,16 @@ import os
 import sys
 from musicround.helpers.database_config import (
     bool_from_config,
+    database_uri_from_postgres_env,
     database_summary,
     managed_database_requirement_error,
 )
 
-db_uri = os.environ.get("SQLALCHEMY_DATABASE_URI")
+try:
+    db_uri = os.environ.get("SQLALCHEMY_DATABASE_URI") or database_uri_from_postgres_env(os.environ)
+except ValueError as exc:
+    print(f"Database configuration error: {exc}", file=sys.stderr)
+    sys.exit(78)
 require_managed = bool_from_config(os.environ.get("DATABASE_REQUIRE_MANAGED"))
 summary = database_summary(db_uri)
 print(f"Database backend: {summary['backend']}")

--- a/docs/admin-guide/managed-database-migration.md
+++ b/docs/admin-guide/managed-database-migration.md
@@ -7,11 +7,14 @@ database to a managed SQL database without exposing credentials in logs or Git.
 
 - Secret owner: `quizzicalbeats/quizzicalbeats-secrets` in the existing
   1Password-backed ExternalSecret flow.
-- Required secret key: `SQLALCHEMY_DATABASE_URI`.
+- Required database config: either `SQLALCHEMY_DATABASE_URI` or the standard
+  PostgreSQL component variables `PGHOST`, `PGDATABASE`, `PGUSER`, and
+  `PGPASSWORD`. `PGPORT` defaults to `5432`.
 - Production guard: set `DATABASE_REQUIRE_MANAGED=true` in Kubernetes config.
   The app accepts common truthy values such as `true`, `1`, `yes`, and `on`.
-- The URI value must stay in 1Password or the generated Kubernetes Secret. Do
-  not commit it to Git and do not print it in logs.
+- Database credentials must stay in 1Password, CNPG-generated Kubernetes
+  Secrets, or equivalent secretKeyRef entries. Do not commit them to Git and
+  do not print them in logs.
 
 ## Preflight
 
@@ -30,9 +33,11 @@ database to a managed SQL database without exposing credentials in logs or Git.
 3. Copy `/data/song_data.db` out of the pod or snapshot the PVC before any
    import into the managed database.
 
-4. Add or update `SQLALCHEMY_DATABASE_URI` in the 1Password item
-   `quizzicalbeats/quizzicalbeats-secrets`. The target should be a managed SQL
-   database. PostgreSQL is preferred for production.
+4. Add the managed database configuration. For PostgreSQL/CNPG, prefer
+   `PGHOST`, `PGDATABASE`, `PGUSER`, and `PGPASSWORD` from Kubernetes
+   `secretKeyRef` entries so no full URI secret needs to be stored. A complete
+   `SQLALCHEMY_DATABASE_URI` in the 1Password item
+   `quizzicalbeats/quizzicalbeats-secrets` is still supported.
 
 ## Dry Run
 
@@ -59,8 +64,18 @@ database to a managed SQL database without exposing credentials in logs or Git.
      -o jsonpath='{.data.SQLALCHEMY_DATABASE_URI}' >/dev/null
    ```
 
+   If using CNPG component variables instead, verify the app deployment has
+   `PGHOST`, `PGDATABASE`, `PGUSER`, and `PGPASSWORD` configured without
+   printing their values:
+
+   ```bash
+   kubectl -n quizzicalbeats get deploy quizzicalbeats \
+     -o jsonpath='{range .spec.template.spec.containers[?(@.name=="web")].env[*]}{.name}{"\n"}{end}' \
+     | grep -E '^(PGHOST|PGDATABASE|PGUSER|PGPASSWORD)$'
+   ```
+
 2. Deploy the app with `DATABASE_REQUIRE_MANAGED=true` and without a ConfigMap
-   `SQLALCHEMY_DATABASE_URI` fallback.
+   `SQLALCHEMY_DATABASE_URI` SQLite fallback.
 3. Restart the web deployment after the secret has synced:
 
    ```bash

--- a/musicround/__init__.py
+++ b/musicround/__init__.py
@@ -13,6 +13,7 @@ from musicround.config import Config
 from musicround.helpers.database_config import (
     bool_from_config,
     database_backend,
+    database_uri_from_postgres_env,
     database_summary,
     managed_database_requirement_error,
 )
@@ -39,6 +40,12 @@ def _configure_database_uri(app):
     configured_uri = os.environ.get('SQLALCHEMY_DATABASE_URI') or app.config.get(
         'SQLALCHEMY_DATABASE_URI'
     )
+    if not configured_uri:
+        try:
+            configured_uri = database_uri_from_postgres_env(os.environ)
+        except ValueError as exc:
+            raise RuntimeError(str(exc)) from exc
+
     if configured_uri:
         managed_error = managed_database_requirement_error(configured_uri, require_managed)
         if managed_error:

--- a/musicround/helpers/database_config.py
+++ b/musicround/helpers/database_config.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from urllib.parse import urlsplit, urlunsplit
+from urllib.parse import quote, urlencode, urlsplit, urlunsplit
 
 
 def bool_from_config(value) -> bool:
@@ -43,15 +43,53 @@ def managed_database_requirement_error(
         return None
     if not uri:
         return (
-            "DATABASE_REQUIRE_MANAGED is enabled, but SQLALCHEMY_DATABASE_URI "
-            "is not configured."
+            "DATABASE_REQUIRE_MANAGED is enabled, but neither "
+            "SQLALCHEMY_DATABASE_URI nor a complete PGHOST/PGDATABASE/PGUSER/"
+            "PGPASSWORD configuration is available."
         )
     if is_sqlite_database_uri(uri):
         return (
             "DATABASE_REQUIRE_MANAGED is enabled, but SQLALCHEMY_DATABASE_URI "
-            "points at SQLite. Configure a managed SQL URI via secrets."
+            "points at SQLite. Configure a managed SQL URI or complete PG* "
+            "database credentials via secrets."
         )
     return None
+
+
+def database_uri_from_postgres_env(environ) -> str | None:
+    """Build a SQLAlchemy PostgreSQL URI from standard PG* environment variables."""
+    values = {
+        "PGHOST": environ.get("PGHOST"),
+        "PGDATABASE": environ.get("PGDATABASE"),
+        "PGUSER": environ.get("PGUSER"),
+        "PGPASSWORD": environ.get("PGPASSWORD"),
+    }
+    if not any(values.values()):
+        return None
+
+    missing = [name for name, value in values.items() if not value]
+    if missing:
+        raise ValueError(
+            "PostgreSQL environment is incomplete; missing "
+            + ", ".join(sorted(missing))
+            + "."
+        )
+
+    scheme = environ.get("SQLALCHEMY_POSTGRES_SCHEME", "postgresql+psycopg2")
+    host = str(values["PGHOST"]).strip()
+    port = str(environ.get("PGPORT") or "5432").strip()
+    database = quote(str(values["PGDATABASE"]).strip(), safe="")
+    username = quote(str(values["PGUSER"]).strip(), safe="")
+    password = quote(str(values["PGPASSWORD"]), safe="")
+    netloc = f"{username}:{password}@{host}:{port}"
+
+    query_params = {}
+    sslmode = environ.get("PGSSLMODE")
+    if sslmode:
+        query_params["sslmode"] = sslmode
+    query = urlencode(query_params)
+
+    return urlunsplit((scheme, netloc, f"/{database}", query, ""))
 
 
 def redact_database_uri(uri: str | None) -> str:

--- a/musicround/helpers/service_health.py
+++ b/musicround/helpers/service_health.py
@@ -77,8 +77,9 @@ def database_service_health() -> dict[str, Any]:
                 "Database is still configured to use the legacy /data SQLite file.",
                 severity="warning",
                 hint=(
-                    "Move SQLALCHEMY_DATABASE_URI to the managed database secret "
-                    "and enable DATABASE_REQUIRE_MANAGED=True for production."
+                    "Configure SQLALCHEMY_DATABASE_URI or complete PG* managed "
+                    "database credentials via secrets and enable "
+                    "DATABASE_REQUIRE_MANAGED=True for production."
                 ),
             )
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ Flask
 Flask-WTF
 Flask-SQLAlchemy
 flask_migrate
+psycopg2-binary>=2.9.9
 requests
 pydub
 reportlab

--- a/run.py
+++ b/run.py
@@ -81,7 +81,8 @@ def main():
         if is_legacy_data_sqlite_uri(db_uri):
             print(
                 "Warning: legacy /data SQLite database is configured; "
-                "move SQLALCHEMY_DATABASE_URI to the managed database secret for production."
+                "configure a managed SQL URI or complete PG* credentials via "
+                "secrets for production."
             )
         return 0
     elif args.command == 'health':

--- a/tests/test_additional_branches.py
+++ b/tests/test_additional_branches.py
@@ -224,7 +224,7 @@ class TestSystemHealthRoute:
         assert health['ok'] is True
         assert health['status'] == 'warning'
         assert health['issues'][0]['code'] == 'legacy_sqlite_data_store'
-        assert 'managed database secret' in health['issues'][0]['details']['hint']
+        assert 'complete PG* managed database credentials' in health['issues'][0]['details']['hint']
 
     def test_system_health_requires_admin(self, app, client):
         """Test that system-health requires admin access."""

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -16,6 +16,7 @@ from musicround import (
     _store_spotify_authlib_token,
 )
 from musicround.helpers.database_config import (
+    database_uri_from_postgres_env,
     database_summary,
     is_legacy_data_sqlite_uri,
     managed_database_requirement_error,
@@ -46,6 +47,56 @@ def test_configure_database_uri_preserves_explicit_config_uri(monkeypatch):
     assert app.config['DATABASE_BACKEND'] == 'postgresql'
 
 
+def test_configure_database_uri_builds_from_postgres_env(monkeypatch):
+    """Managed deployments can avoid storing one full URI secret."""
+    monkeypatch.delenv('SQLALCHEMY_DATABASE_URI', raising=False)
+    monkeypatch.setenv('PGHOST', 'quizzicalbeats-db-rw.quizzicalbeats.svc.cluster.local')
+    monkeypatch.setenv('PGPORT', '5432')
+    monkeypatch.setenv('PGDATABASE', 'quizzicalbeats')
+    monkeypatch.setenv('PGUSER', 'qb_user')
+    monkeypatch.setenv('PGPASSWORD', 'super secret/pass')
+    app = Flask(__name__)
+    app.config['DATABASE_REQUIRE_MANAGED'] = True
+
+    _configure_database_uri(app)
+
+    assert app.config['DATABASE_BACKEND'] == 'postgresql'
+    assert app.config['SQLALCHEMY_DATABASE_URI'].startswith('postgresql+psycopg2://qb_user:')
+    assert 'super secret/pass' not in app.config['SQLALCHEMY_DATABASE_URI']
+    assert app.config['DATABASE_URI_REDACTED'] == (
+        'postgresql+psycopg2://qb_user:***@'
+        'quizzicalbeats-db-rw.quizzicalbeats.svc.cluster.local:5432/quizzicalbeats'
+    )
+
+
+def test_configure_database_uri_explicit_uri_wins_over_postgres_env(monkeypatch):
+    """Existing SQLALCHEMY_DATABASE_URI deployments keep their current contract."""
+    monkeypatch.setenv('SQLALCHEMY_DATABASE_URI', 'postgresql://explicit.example/qb')
+    monkeypatch.setenv('PGHOST', 'ignored.example')
+    monkeypatch.setenv('PGDATABASE', 'ignored')
+    monkeypatch.setenv('PGUSER', 'ignored')
+    monkeypatch.setenv('PGPASSWORD', 'ignored')
+    app = Flask(__name__)
+
+    _configure_database_uri(app)
+
+    assert app.config['SQLALCHEMY_DATABASE_URI'] == 'postgresql://explicit.example/qb'
+
+
+def test_configure_database_uri_rejects_partial_postgres_env(monkeypatch):
+    """Partial PG* configuration should fail before falling back to SQLite."""
+    monkeypatch.delenv('SQLALCHEMY_DATABASE_URI', raising=False)
+    monkeypatch.setenv('PGHOST', 'postgres.example')
+    monkeypatch.setenv('PGDATABASE', 'quizzicalbeats')
+    monkeypatch.delenv('PGUSER', raising=False)
+    monkeypatch.delenv('PGPASSWORD', raising=False)
+    app = Flask(__name__)
+
+    import pytest
+    with pytest.raises(RuntimeError, match='PostgreSQL environment is incomplete'):
+        _configure_database_uri(app)
+
+
 def test_configure_database_uri_uses_sqlite_fallback(monkeypatch):
     """Test fallback SQLite path is only used when no URI is configured."""
     monkeypatch.delenv('SQLALCHEMY_DATABASE_URI', raising=False)
@@ -72,7 +123,7 @@ def test_configure_database_uri_requires_managed_database(monkeypatch):
     app.config['DATABASE_REQUIRE_MANAGED'] = True
 
     import pytest
-    with pytest.raises(RuntimeError, match='SQLALCHEMY_DATABASE_URI is not configured'):
+    with pytest.raises(RuntimeError, match='complete PGHOST/PGDATABASE/PGUSER'):
         _configure_database_uri(app)
 
 
@@ -120,6 +171,7 @@ def test_managed_database_requirement_error_is_credential_safe():
     assert 'super-secret' not in managed_database_requirement_error(None, True)
     sqlite_error = managed_database_requirement_error('sqlite:////data/song_data.db', 'on')
     assert 'points at SQLite' in sqlite_error
+    assert 'complete PG* database credentials' in sqlite_error
     assert '/data/song_data.db' not in sqlite_error
 
 
@@ -135,6 +187,26 @@ def test_database_uri_redaction_hides_credentials():
     assert summary['backend'] == 'postgresql'
     assert summary['host'] == 'postgres.example'
     assert summary['database'] == 'quizzicalbeats'
+
+
+def test_database_uri_from_postgres_env_quotes_secret_components():
+    """Generated URIs must be valid and never include raw secret text."""
+    environ = {
+        'PGHOST': 'postgres.example',
+        'PGPORT': '5432',
+        'PGDATABASE': 'quiz db',
+        'PGUSER': 'qb user',
+        'PGPASSWORD': 'pass/with spaces',
+        'PGSSLMODE': 'require',
+    }
+
+    uri = database_uri_from_postgres_env(environ)
+
+    assert uri == (
+        'postgresql+psycopg2://qb%20user:pass%2Fwith%20spaces@'
+        'postgres.example:5432/quiz%20db?sslmode=require'
+    )
+    assert 'pass/with spaces' not in uri
 
 
 def test_legacy_sqlite_uri_detection_is_specific_to_data_file():

--- a/tests/test_run_cli.py
+++ b/tests/test_run_cli.py
@@ -39,6 +39,7 @@ def test_database_status_warns_for_legacy_data_sqlite(monkeypatch, capsys):
     assert "Database backend: sqlite" in output
     assert "Managed database required: False" in output
     assert "legacy /data SQLite database is configured" in output
+    assert "complete PG* credentials" in output
 
 
 def test_database_status_returns_safe_error_when_managed_guard_fails(monkeypatch, capsys):


### PR DESCRIPTION
## Summary
- build `SQLALCHEMY_DATABASE_URI` from complete `PGHOST`/`PGDATABASE`/`PGUSER`/`PGPASSWORD` secrets when no full URI is set
- keep the managed database guard fail-closed for missing or SQLite-backed production config
- update health, CLI, runbook, and example env guidance for component-based Postgres secrets

## Why
Production is still warning on the legacy `/data/song_data.db` SQLite configuration. This slice prepares a safer managed database cutover without requiring one combined database URI secret and without exposing raw credentials in logs, health output, or CLI errors.

## Validation
- `git diff --check`
- `SECRET_KEY=test-secret AUTOMATION_TOKEN=test-token .venv/bin/pytest tests/test_app_factory.py tests/test_run_cli.py tests/test_additional_branches.py::TestSystemHealthRoute::test_database_health_warns_for_legacy_data_sqlite -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the app’s database using PostgreSQL environment variables, including managed deployment setups.
  * Added clearer guidance for production database configuration and secret handling.

* **Bug Fixes**
  * Improved startup behavior when database settings are incomplete, with clearer error handling and safer fallback prevention.
  * Updated warnings and health messages to better reflect valid production database options.

* **Documentation**
  * Expanded setup and migration docs to cover PostgreSQL-based configuration and managed database requirements.
  * Updated the changelog with the new database configuration options and driver requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->