### PR TITLE
fix: address managed db review follow-ups

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,8 @@ PERMANENT_SESSION_LIFETIME_HOURS=12
 # DATABASE CONFIGURATION
 # ============================================================================
 SQLALCHEMY_DATABASE_URI=sqlite:///data/song_data.db
+# Clear or remove SQLALCHEMY_DATABASE_URI before using PGHOST/PGDATABASE/
+# PGUSER/PGPASSWORD in production; the full URI takes precedence when set.
 SQLALCHEMY_TRACK_MODIFICATIONS=False
 # Production can alternatively set PGHOST, PGDATABASE, PGUSER, and PGPASSWORD
 # instead of one full SQLALCHEMY_DATABASE_URI. This keeps generated database

--- a/docs/admin-guide/managed-database-migration.md
+++ b/docs/admin-guide/managed-database-migration.md
@@ -10,6 +10,9 @@ database to a managed SQL database without exposing credentials in logs or Git.
 - Required database config: either `SQLALCHEMY_DATABASE_URI` or the standard
   PostgreSQL component variables `PGHOST`, `PGDATABASE`, `PGUSER`, and
   `PGPASSWORD`. `PGPORT` defaults to `5432`.
+- Precedence rule: the database resolver uses `SQLALCHEMY_DATABASE_URI` first
+  whenever it is set. Remove or blank the URI before relying on the PG*
+  component variables.
 - Production guard: set `DATABASE_REQUIRE_MANAGED=true` in Kubernetes config.
   The app accepts common truthy values such as `true`, `1`, `yes`, and `on`.
 - Database credentials must stay in 1Password, CNPG-generated Kubernetes
@@ -35,9 +38,11 @@ database to a managed SQL database without exposing credentials in logs or Git.
 
 4. Add the managed database configuration. For PostgreSQL/CNPG, prefer
    `PGHOST`, `PGDATABASE`, `PGUSER`, and `PGPASSWORD` from Kubernetes
-   `secretKeyRef` entries so no full URI secret needs to be stored. A complete
-   `SQLALCHEMY_DATABASE_URI` in the 1Password item
-   `quizzicalbeats/quizzicalbeats-secrets` is still supported.
+   `secretKeyRef` entries so no full URI secret needs to be stored. Remove or
+   blank `SQLALCHEMY_DATABASE_URI` before using the component variables; a set
+   URI wins over PG* values by design. A complete `SQLALCHEMY_DATABASE_URI` in
+   the 1Password item `quizzicalbeats/quizzicalbeats-secrets` is still
+   supported.
 
 ## Dry Run
 
@@ -66,11 +71,16 @@ database to a managed SQL database without exposing credentials in logs or Git.
 
    If using CNPG component variables instead, verify the app deployment has
    `PGHOST`, `PGDATABASE`, `PGUSER`, and `PGPASSWORD` configured without
-   printing their values:
+   printing their values, then confirm the referenced Secret exposes those keys
+   without printing the secret data:
 
    ```bash
    kubectl -n quizzicalbeats get deploy quizzicalbeats \
      -o jsonpath='{range .spec.template.spec.containers[?(@.name=="web")].env[*]}{.name}{"\n"}{end}' \
+     | grep -E '^(PGHOST|PGDATABASE|PGUSER|PGPASSWORD)$'
+
+   kubectl -n quizzicalbeats get secret quizzicalbeats-secrets -o json \
+     | jq -r '.data | keys[]' \
      | grep -E '^(PGHOST|PGDATABASE|PGUSER|PGPASSWORD)$'
    ```
 

--- a/musicround/helpers/database_config.py
+++ b/musicround/helpers/database_config.py
@@ -57,7 +57,20 @@ def managed_database_requirement_error(
 
 
 def database_uri_from_postgres_env(environ) -> str | None:
-    """Build a SQLAlchemy PostgreSQL URI from standard PG* environment variables."""
+    """Build a SQLAlchemy PostgreSQL URI from standard PG* environment variables.
+
+    Args:
+        environ: Mapping of environment variable names to values, typically
+            ``os.environ``.
+
+    Returns:
+        A PostgreSQL SQLAlchemy URI, or ``None`` when no required PG* variables
+        are configured.
+
+    Raises:
+        ValueError: If only part of the required PGHOST, PGDATABASE, PGUSER,
+            and PGPASSWORD configuration is present.
+    """
     values = {
         "PGHOST": environ.get("PGHOST"),
         "PGDATABASE": environ.get("PGDATABASE"),
@@ -104,8 +117,10 @@ def redact_database_uri(uri: str | None) -> str:
         return f"{parts.scheme}://[configured]"
 
     host = parts.hostname or "configured-host"
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
     port = f":{parts.port}" if parts.port else ""
-    username = f"{parts.username}:***@" if parts.username else ""
+    username = f"{quote(parts.username, safe='%')}:***@" if parts.username else ""
     netloc = f"{username}{host}{port}"
     path = parts.path or ""
     return urlunsplit((parts.scheme, netloc, path, "", ""))

--- a/musicround/helpers/database_config.py
+++ b/musicround/helpers/database_config.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from urllib.parse import quote, urlencode, urlsplit, urlunsplit
+from urllib.parse import quote, unquote, urlencode, urlsplit, urlunsplit
 
 
 def bool_from_config(value) -> bool:
@@ -120,7 +120,7 @@ def redact_database_uri(uri: str | None) -> str:
     if ":" in host and not host.startswith("["):
         host = f"[{host}]"
     port = f":{parts.port}" if parts.port else ""
-    username = f"{quote(parts.username, safe='%')}:***@" if parts.username else ""
+    username = f"{quote(unquote(parts.username), safe='')}:***@" if parts.username else ""
     netloc = f"{username}{host}{port}"
     path = parts.path or ""
     return urlunsplit((parts.scheme, netloc, path, "", ""))

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -189,6 +189,17 @@ def test_database_uri_redaction_hides_credentials():
     assert summary['database'] == 'quizzicalbeats'
 
 
+def test_database_uri_redaction_preserves_valid_escaped_username():
+    """Redacted URIs should stay parseable when usernames need escaping."""
+    uri = 'postgresql+psycopg2://qb%20user:super-secret@[2001:db8::1]:5432/quiz%20db'
+
+    redacted = redact_database_uri(uri)
+
+    assert redacted == 'postgresql+psycopg2://qb%20user:***@[2001:db8::1]:5432/quiz%20db'
+    assert 'qb user' not in redacted
+    assert 'super-secret' not in redacted
+
+
 def test_database_uri_from_postgres_env_quotes_secret_components():
     """Generated URIs must be valid and never include raw secret text."""
     environ = {

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -200,6 +200,17 @@ def test_database_uri_redaction_preserves_valid_escaped_username():
     assert 'super-secret' not in redacted
 
 
+def test_database_uri_redaction_requotes_literal_percent_username():
+    """Literal percent characters should stay percent-encoded after redaction."""
+    uri = 'postgresql+psycopg2://user%25name:super-secret@postgres.example:5432/qb'
+
+    redacted = redact_database_uri(uri)
+
+    assert redacted == 'postgresql+psycopg2://user%25name:***@postgres.example:5432/qb'
+    assert 'user%name' not in redacted
+    assert 'super-secret' not in redacted
+
+
 def test_database_uri_from_postgres_env_quotes_secret_components():
     """Generated URIs must be valid and never include raw secret text."""
     environ = {


### PR DESCRIPTION
## Summary
- keep redacted database URIs valid for escaped usernames and IPv6 hosts
- document SQLALCHEMY_DATABASE_URI precedence over PG* component variables
- verify secret-backed PG* keys without printing secret data

## Validation
- /tmp/QuizzicalBeats-pr80/.venv/bin/python -m pytest tests/test_app_factory.py -q
- /tmp/QuizzicalBeats-pr80/.venv/bin/python -m py_compile musicround/helpers/database_config.py
- git diff --check

Follow-up for post-merge review comments on #161.