### PR TITLE
[codex] enforce round email quality gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Made the rounds list flag non-eight-song rounds, unresolved song IDs, and failed email deliveries before quiz rounds reach inbox workflows.
 - Preserved Spotify playlist import order when the importer returns database song IDs directly.
 - Kept round package preview failures aligned to stored round positions even when unresolved song IDs create gaps.
+- Blocked browser email delivery on the same round-package quality gate used by MCP and scheduled email exports.
+- Persisted scheduled-email quality failures as repairable, credential-safe round export messages.
+- Showed round email quality feedback and failed delivery messages on the round detail page.
 - Added playlist import position maps to MCP round-creation success and repair payloads.
 - Fixed Spotify playlist imports so already-cataloged tracks count as resolved positions and successful imports always return their result payload.
 - Added credential-safe health and CLI warnings when production still points at the legacy `/data/song_data.db` SQLite file.

--- a/docs/user-guide/exporting-rounds.md
+++ b/docs/user-guide/exporting-rounds.md
@@ -18,6 +18,18 @@ To export a round to your local device:
 2. Select the round you want to view
 3. Click the "Download MP3" or "Download PDF" button to save the respective file
 
+## Email Delivery
+
+Round email delivery is protected by the package quality gate. Before an email
+is sent, Quizzical Beats checks that the round has the expected number of songs,
+that preview clips are playable and within the configured length range, and that
+the generated MP3/PDF artifacts pass inspection.
+
+If the package gate fails, the email is not sent. The round detail page shows the
+repair feedback, including missing or too-short previews and replacement actions.
+Scheduled emails use the same gate and keep a failed export message on the round
+so the issue can be repaired before resending.
+
 ## Dropbox Export
 
 Quizzical Beats integrates with Dropbox to easily store your rounds in the cloud:

--- a/musicround/routes/rounds.py
+++ b/musicround/routes/rounds.py
@@ -265,6 +265,39 @@ def _round_generation_failure_response(round_id, log_message, user_message, stat
     return redirect(url_for('rounds.round_detail', round_id=round_id))
 
 
+def _round_quality_failure_response(round_id, quality, recipient=None, subject=None, body_text=None):
+    """Persist and return repairable package-gate failures before email delivery."""
+    report = quality.get('report') or {}
+    error_msg = report.get('headline') or 'Round quality gate failed. Repair the round before sending.'
+    db.session.add(
+        RoundExport(
+            round_id=round_id,
+            user_id=current_user.id,
+            export_type='email',
+            destination=recipient,
+            include_mp3s=True,
+            status='failed',
+            subject=subject,
+            body_text=body_text,
+            error_message=error_msg,
+            processed_at=datetime.utcnow(),
+        )
+    )
+    db.session.commit()
+    if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
+        return jsonify({
+            'success': False,
+            'error': error_msg,
+            'status': quality.get('status'),
+            'hints': quality.get('hints', []),
+            'quality': quality,
+            'report': report,
+        }), 422
+    flash(error_msg, 'error')
+    session['round_quality_report'] = report.get('markdown')
+    return redirect(url_for('rounds.round_detail', round_id=round_id))
+
+
 def _selected_track_hint_audio(round_id):
     """Load selected per-track hint audio keyed by one-based song position."""
     hints = {}
@@ -1182,11 +1215,34 @@ def send_email(round_id):
         else:
             session['email_error'] = error_msg
             return redirect(url_for('rounds.round_detail', round_id=round_id))
-    
+
     # Get the round name for the subject
     round_title = f'Pub Quiz Round #{round_id}'
     if rnd and rnd.name:
         round_title = rnd.name
+
+    try:
+        quality = automation.inspect_round_package(round_id=round_id, user_id=current_user.id)
+    except AutomationError as exc:
+        current_app.logger.error(
+            "Round package inspection failed before email for round %s: %s",
+            round_id,
+            exc,
+            exc_info=True,
+        )
+        error_msg = "Round quality gate could not run. Please try again later or contact an administrator."
+        if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
+            return jsonify({'success': False, 'error': error_msg}), 500
+        flash(error_msg, 'error')
+        return redirect(url_for('rounds.round_detail', round_id=round_id))
+    if not quality.get('ok'):
+        return _round_quality_failure_response(
+            round_id,
+            quality,
+            recipient=mail_recipient,
+            subject=round_title,
+            body_text='Attached please find the MP3 and PDF files for the quiz round.',
+        )
 
     try:
         with open(mp3_file_path, 'rb') as mp3_file:

--- a/musicround/routes/rounds.py
+++ b/musicround/routes/rounds.py
@@ -439,6 +439,7 @@ def round_detail(round_id):
         ordered_songs = rnd.song_list
         
         email_error = session.pop('email_error', None)  # Retrieve and remove the error message from the session
+        round_quality_report = session.pop('round_quality_report', None)
         
         # For oauth.spotify, we need to ensure we have a valid token if needed for this view
         user_info = None
@@ -471,6 +472,7 @@ def round_detail(round_id):
             songs=ordered_songs,
             user_info=user_info,
             email_error=email_error,
+            round_quality_report=round_quality_report,
             audio_scripts=audio_scripts,
             scheduled_exports=scheduled_exports,
         )

--- a/musicround/services/automation.py
+++ b/musicround/services/automation.py
@@ -3051,6 +3051,25 @@ def _round_export_summary(export: RoundExport) -> dict[str, Any]:
     }
 
 
+def _scheduled_email_error_message(exc: Exception) -> str:
+    """Return a persisted, credential-safe scheduled email failure summary."""
+    details = getattr(exc, "details", None)
+    if isinstance(details, dict):
+        report = details.get("report")
+        if isinstance(report, dict) and report.get("headline"):
+            return str(report["headline"])
+        quality = details.get("quality")
+        if isinstance(quality, dict):
+            quality_report = quality.get("report")
+            if isinstance(quality_report, dict) and quality_report.get("headline"):
+                return str(quality_report["headline"])
+            if quality.get("status"):
+                return f"Round quality gate failed: {quality['status']}."
+        if details.get("status"):
+            return f"Scheduled round email failed: {details['status']}."
+    return AUTOMATION_SCHEDULED_EMAIL_ERROR
+
+
 def schedule_round_email(
     round_id: int,
     scheduled_for: str | datetime,
@@ -3190,19 +3209,20 @@ def process_due_scheduled_round_emails(
         except Exception as exc:
             export.status = "failed"
             export.processed_at = datetime.utcnow()
+            safe_error_message = _scheduled_email_error_message(exc)
             current_app.logger.error(
                 "Scheduled round email export %s failed: %s",
                 export.id,
                 exc,
                 exc_info=True,
             )
-            export.error_message = AUTOMATION_SCHEDULED_EMAIL_ERROR
+            export.error_message = safe_error_message
             db.session.commit()
             details = getattr(exc, "details", None)
             results.append(
                 {
                     "export": _round_export_summary(export),
-                    "error": AUTOMATION_SCHEDULED_EMAIL_ERROR,
+                    "error": safe_error_message,
                     "details": details,
                 }
             )

--- a/musicround/templates/round_detail.html
+++ b/musicround/templates/round_detail.html
@@ -91,7 +91,11 @@
                 </button>
             </div>
             <div id="quality-result" class="border border-gray-200 rounded-md p-4 bg-gray-50 text-sm text-gray-700">
+                {% if round_quality_report %}
+                <div class="border border-orange-200 rounded-md p-3 bg-orange-50 text-orange-900 whitespace-pre-wrap">{{ round_quality_report }}</div>
+                {% else %}
                 <p>Run the package check to see preview, MP3, PDF, and duration readiness.</p>
+                {% endif %}
             </div>
             <div id="repair-suggestions" class="hidden mt-4 border border-orange-200 rounded-md p-4 bg-orange-50">
                 <h3 class="font-semibold text-orange-800 mb-3">Replacement Candidates</h3>
@@ -136,6 +140,9 @@
                     <div class="text-xs border border-gray-200 rounded p-2">
                         <div class="font-semibold">{{ export.status|capitalize }}{% if export.scheduled_for %} for {{ export.scheduled_for.strftime('%Y-%m-%d %H:%M') }}{% endif %}</div>
                         <div class="text-gray-500">{{ export.destination or 'No destination' }}</div>
+                        {% if export.error_message %}
+                        <div class="text-red-700 mt-1">{{ export.error_message }}</div>
+                        {% endif %}
                     </div>
                     {% endfor %}
                 </div>

--- a/tests/test_automation_service.py
+++ b/tests/test_automation_service.py
@@ -1255,6 +1255,68 @@ class TestAssetInspection:
             assert export.status == "failed"
             assert export.error_message == automation.AUTOMATION_SCHEDULED_EMAIL_ERROR
 
+    def test_process_due_scheduled_round_email_persists_quality_feedback(self, app):
+        with app.app_context():
+            _configure_mail(app)
+            user = _create_user()
+            song = _create_song(title="Due Quality Failure", artist="Artist")
+            round_id = automation.create_round(
+                name="Due Quality Failure Round",
+                round_type="manual",
+                song_ids=[song.id],
+            )["round"]["id"]
+            with (
+                patch(
+                    "musicround.services.automation.generate_round_assets",
+                    return_value={"pdf": {"path": "/tmp/round.pdf"}, "mp3": {"path": "/tmp/round.mp3"}},
+                ),
+                patch(
+                    "musicround.services.automation.inspect_round_package",
+                    return_value={"ok": True, "status": "ok"},
+                ),
+            ):
+                scheduled = automation.schedule_round_email(
+                    round_id,
+                    scheduled_for="2026-07-09T19:00:00+02:00",
+                    user_id=user.id,
+                )
+
+            quality_details = {
+                "success": False,
+                "status": "needs_substitution",
+                "quality": {
+                    "status": "needs_substitution",
+                    "report": {
+                        "headline": "Due Quality Failure Round is blocked: needs_substitution.",
+                    },
+                },
+                "report": {
+                    "headline": "Due Quality Failure Round is blocked: needs_substitution.",
+                },
+            }
+            with patch(
+                "musicround.services.automation.email_round",
+                side_effect=automation.AutomationError(
+                    "Round quality gate failed: preview missing token=secret",
+                    details=quality_details,
+                ),
+            ):
+                result = automation.process_due_scheduled_round_emails(
+                    now="2026-07-09T19:01:00+02:00"
+                )
+
+            body = str(result)
+            assert result["processed_count"] == 1
+            assert result["results"][0]["error"] == (
+                "Due Quality Failure Round is blocked: needs_substitution."
+            )
+            assert "token=secret" not in body
+            export = RoundExport.query.get(scheduled["export"]["id"])
+            assert export.status == "failed"
+            assert export.error_message == (
+                "Due Quality Failure Round is blocked: needs_substitution."
+            )
+
 
 class TestTTSAutomation:
     """Tests for TTS snippet assignment."""

--- a/tests/test_rounds_routes.py
+++ b/tests/test_rounds_routes.py
@@ -50,6 +50,15 @@ def _create_round(app, songs_ids, name='Test Round'):
         return round_.id
 
 
+def _passing_round_quality():
+    return {
+        'ok': True,
+        'status': 'ok',
+        'hints': [],
+        'report': {'headline': 'Round is ready to send.', 'markdown': '# Ready'},
+    }
+
+
 def _user_id(app, username):
     with app.app_context():
         return User.query.filter_by(username=username).one().id
@@ -966,6 +975,10 @@ class TestRoundEmailRoute:
                 patch('musicround.routes.rounds.os.path.exists', return_value=True), \
                 patch('builtins.open', mock_open(read_data=b'ID3 test mp3')), \
                 patch(
+                    'musicround.routes.rounds.automation.inspect_round_package',
+                    return_value=_passing_round_quality(),
+                ), \
+                patch(
                     'musicround.routes.rounds.send_quiz_email',
                     return_value=(True, 'sent'),
                 ) as mock_send:
@@ -1057,6 +1070,10 @@ class TestRoundEmailRoute:
                     side_effect=regenerate_mp3,
                 ) as mock_round_mp3, \
                 patch(
+                    'musicround.routes.rounds.automation.inspect_round_package',
+                    return_value=_passing_round_quality(),
+                ), \
+                patch(
                     'musicround.routes.rounds.send_quiz_email',
                     return_value=(True, 'sent'),
                 ) as mock_send:
@@ -1084,6 +1101,10 @@ class TestRoundEmailRoute:
                 patch('musicround.routes.rounds.os.path.exists', return_value=True), \
                 patch('builtins.open', mock_open(read_data=b'ID3 test mp3')), \
                 patch(
+                    'musicround.routes.rounds.automation.inspect_round_package',
+                    return_value=_passing_round_quality(),
+                ), \
+                patch(
                     'musicround.routes.rounds.send_quiz_email',
                     return_value=(False, 'Missing parameters: MAIL_PASSWORD'),
                 ):
@@ -1096,3 +1117,54 @@ class TestRoundEmailRoute:
         assert response.get_json()['error'] == (
             'Unable to send the email. Please try again later or contact an administrator.'
         )
+
+    def test_mail_route_blocks_failed_package_quality_before_sending(self, app, client):
+        """UI email delivery must not bypass the package quality gate."""
+        _login(app, client)
+        user_id = _user_id(app, 'roundsuser')
+        song_id = _create_song(app, title='Short Preview Song')
+        round_id = _create_round(app, [song_id], name='Blocked Quality Round')
+        with app.app_context():
+            round_ = Round.query.get(round_id)
+            round_.mp3_generated = True
+            db.session.commit()
+
+        quality = {
+            'ok': False,
+            'status': 'needs_substitution',
+            'hints': ['Short Preview Song preview is 10.0s; expected at least 20.0s.'],
+            'report': {
+                'headline': 'Blocked Quality Round is blocked: needs_substitution.',
+                'markdown': '# Blocked Quality Round is blocked',
+                'failed_positions': [{'position': 1}],
+            },
+        }
+
+        with patch('musicround.routes.rounds.generate_pdf', return_value=b'%PDF'), \
+                patch('musicround.routes.rounds.os.path.exists', return_value=True), \
+                patch('builtins.open', mock_open(read_data=b'ID3 test mp3')) as opened, \
+                patch(
+                    'musicround.routes.rounds.automation.inspect_round_package',
+                    return_value=quality,
+                ) as mock_quality, \
+                patch('musicround.routes.rounds.send_quiz_email') as mock_send:
+            response = client.post(
+                f'/rounds/{round_id}/mail',
+                headers={'X-Requested-With': 'XMLHttpRequest'},
+            )
+
+        assert response.status_code == 422
+        payload = response.get_json()
+        assert payload['success'] is False
+        assert payload['status'] == 'needs_substitution'
+        assert payload['quality'] == quality
+        assert payload['report'] == quality['report']
+        assert 'Short Preview Song preview' in payload['hints'][0]
+        mock_quality.assert_called_once_with(round_id=round_id, user_id=user_id)
+        mock_send.assert_not_called()
+        opened.assert_not_called()
+        with app.app_context():
+            export = RoundExport.query.filter_by(round_id=round_id, export_type='email').one()
+            assert export.status == 'failed'
+            assert export.destination == 'rounds@example.com'
+            assert export.error_message == quality['report']['headline']

--- a/tests/test_rounds_routes.py
+++ b/tests/test_rounds_routes.py
@@ -368,6 +368,26 @@ class TestRoundDetailRoute:
         assert b'Reviewed' in response.data
         assert b'Welcome to the review round' in response.data
 
+    def test_round_detail_shows_failed_email_export_message(self, app, client):
+        """Round detail should show persisted delivery/quality failure feedback."""
+        _login(app, client)
+        song_id = _create_song(app, title='Failed Export Detail Song')
+        round_id = _create_round(app, [song_id], name='Failed Export Detail Round')
+        with app.app_context():
+            db.session.add(RoundExport(
+                round_id=round_id,
+                export_type='email',
+                destination='rounds@example.com',
+                status='failed',
+                error_message='Failed Export Detail Round is blocked: needs_substitution.',
+            ))
+            db.session.commit()
+
+        response = client.get(f'/rounds/{round_id}')
+
+        assert response.status_code == 200
+        assert b'Failed Export Detail Round is blocked: needs_substitution.' in response.data
+
     def test_round_detail_hides_private_round_owned_by_other_user(self, app, client):
         """Private owned rounds should not be visible to other quizmasters."""
         _login(app, client, username='viewer_one', email='viewer_one@example.com')
@@ -1168,3 +1188,39 @@ class TestRoundEmailRoute:
             assert export.status == 'failed'
             assert export.destination == 'rounds@example.com'
             assert export.error_message == quality['report']['headline']
+
+    def test_mail_route_redirect_shows_quality_report(self, app, client):
+        """Non-AJAX email failures should carry repair feedback to round detail."""
+        _login(app, client)
+        user_id = _user_id(app, 'roundsuser')
+        song_id = _create_song(app, title='Redirect Quality Song')
+        round_id = _create_round(app, [song_id], name='Redirect Quality Round')
+        with app.app_context():
+            round_ = Round.query.get(round_id)
+            round_.mp3_generated = True
+            db.session.commit()
+
+        quality = {
+            'ok': False,
+            'status': 'needs_substitution',
+            'hints': ['Redirect Quality Song has no preview.'],
+            'report': {
+                'headline': 'Redirect Quality Round is blocked: needs_substitution.',
+                'markdown': '# Redirect Quality Round is blocked\n\nReplace position 1.',
+            },
+        }
+
+        with patch('musicround.routes.rounds.generate_pdf', return_value=b'%PDF'), \
+                patch('musicround.routes.rounds.os.path.exists', return_value=True), \
+                patch(
+                    'musicround.routes.rounds.automation.inspect_round_package',
+                    return_value=quality,
+                ) as mock_quality, \
+                patch('musicround.routes.rounds.send_quiz_email') as mock_send:
+            response = client.post(f'/rounds/{round_id}/mail', follow_redirects=True)
+
+        assert response.status_code == 200
+        assert b'Redirect Quality Round is blocked' in response.data
+        assert b'Replace position 1.' in response.data
+        mock_quality.assert_called_once_with(round_id=round_id, user_id=user_id)
+        mock_send.assert_not_called()


### PR DESCRIPTION
## Summary
- gate browser email delivery on the same round-package quality checks used by MCP and scheduled email
- persist scheduled-email quality failures as repairable, credential-safe export messages
- show failed delivery and quality repair feedback on the round detail page
- document the email quality gate in the changelog and user export guide

## Why
Broken music rounds must not reach the inbox. The automation path already had a robust package gate, but the browser email path still had a direct send flow and scheduled failures could remain too generic to repair from the round detail page.

## Validation
- `git diff --check`
- `SECRET_KEY=test-secret AUTOMATION_TOKEN=test-token .venv/bin/pytest tests/test_rounds_routes.py::TestRoundDetailRoute tests/test_rounds_routes.py::TestRoundEmailRoute tests/test_automation_service.py::TestAssetInspection -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a package quality check before round emails are sent, with feedback shown on the round detail page when delivery is blocked.
  * Scheduled email failures now surface clearer, user-friendly error messages and can be repaired and retried.

* **Bug Fixes**
  * Failed email deliveries are now saved with visible status details, including export history and failure messages.
  * Round detail pages now display the latest quality report instead of only a generic instruction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->