### PR TITLE
fix: address round email review follow-ups

### DIFF
--- a/musicround/routes/rounds.py
+++ b/musicround/routes/rounds.py
@@ -271,9 +271,11 @@ def _session_quality_report(report):
     markdown = (report or {}).get('markdown') or ''
     if len(markdown) <= ROUND_QUALITY_SESSION_REPORT_MAX_CHARS:
         return markdown
+    suffix = "\n\n[Report truncated; rerun Inspect Round for full details.]"
+    body_max = max(0, ROUND_QUALITY_SESSION_REPORT_MAX_CHARS - len(suffix))
     return (
-        markdown[:ROUND_QUALITY_SESSION_REPORT_MAX_CHARS].rstrip()
-        + "\n\n[Report truncated; rerun Inspect Round for full details.]"
+        markdown[:body_max].rstrip()
+        + suffix
     )
 
 

--- a/musicround/routes/rounds.py
+++ b/musicround/routes/rounds.py
@@ -36,6 +36,7 @@ ROUND_MP3_PREVIEW_DOWNLOAD_ERROR = "Song preview audio could not be downloaded. 
 ROUND_MP3_PREVIEW_PROCESSING_ERROR = "Song preview audio could not be processed. Check the server logs."
 ROUND_MP3_EXPORT_ERROR = "MP3 generation failed. Check the server logs."
 ROUND_PDF_GENERATION_ERROR = "PDF generation failed. Check the server logs."
+ROUND_QUALITY_SESSION_REPORT_MAX_CHARS = 2000
 
 
 def _int_arg(name, default=None, minimum=None, maximum=None):
@@ -265,6 +266,17 @@ def _round_generation_failure_response(round_id, log_message, user_message, stat
     return redirect(url_for('rounds.round_detail', round_id=round_id))
 
 
+def _session_quality_report(report):
+    """Keep repair feedback small enough for Flask's cookie-backed session."""
+    markdown = (report or {}).get('markdown') or ''
+    if len(markdown) <= ROUND_QUALITY_SESSION_REPORT_MAX_CHARS:
+        return markdown
+    return (
+        markdown[:ROUND_QUALITY_SESSION_REPORT_MAX_CHARS].rstrip()
+        + "\n\n[Report truncated; rerun Inspect Round for full details.]"
+    )
+
+
 def _round_quality_failure_response(round_id, quality, recipient=None, subject=None, body_text=None):
     """Persist and return repairable package-gate failures before email delivery."""
     report = quality.get('report') or {}
@@ -294,7 +306,7 @@ def _round_quality_failure_response(round_id, quality, recipient=None, subject=N
             'report': report,
         }), 422
     flash(error_msg, 'error')
-    session['round_quality_report'] = report.get('markdown')
+    session['round_quality_report'] = _session_quality_report(report)
     return redirect(url_for('rounds.round_detail', round_id=round_id))
 
 
@@ -1225,7 +1237,7 @@ def send_email(round_id):
 
     try:
         quality = automation.inspect_round_package(round_id=round_id, user_id=current_user.id)
-    except AutomationError as exc:
+    except Exception as exc:
         current_app.logger.error(
             "Round package inspection failed before email for round %s: %s",
             round_id,

--- a/musicround/templates/round_detail.html
+++ b/musicround/templates/round_detail.html
@@ -140,8 +140,10 @@
                     <div class="text-xs border border-gray-200 rounded p-2">
                         <div class="font-semibold">{{ export.status|capitalize }}{% if export.scheduled_for %} for {{ export.scheduled_for.strftime('%Y-%m-%d %H:%M') }}{% endif %}</div>
                         <div class="text-gray-500">{{ export.destination or 'No destination' }}</div>
-                        {% if export.error_message %}
+                        {% if export.error_message and export.status == 'failed' %}
                         <div class="text-red-700 mt-1">{{ export.error_message }}</div>
+                        {% elif export.error_message %}
+                        <div class="text-gray-500 mt-1">{{ export.error_message }}</div>
                         {% endif %}
                     </div>
                     {% endfor %}

--- a/tests/test_rounds_routes.py
+++ b/tests/test_rounds_routes.py
@@ -5,6 +5,7 @@ from unittest.mock import patch, mock_open
 from flask import jsonify
 from pydub import AudioSegment
 from musicround.models import db, PlannedQuizRound, User, Song, Round, RoundAudioScript, RoundExport, RoundShare
+from musicround.routes.rounds import ROUND_QUALITY_SESSION_REPORT_MAX_CHARS, _session_quality_report
 
 
 def _login(app, client, username='roundsuser', email='rounds@example.com'):
@@ -1281,6 +1282,7 @@ class TestRoundEmailRoute:
         assert b'Large Redirect Quality Round is blocked' in response.data
         assert b'Report truncated' in response.data
         assert large_tail.encode() not in response.data
+        assert len(_session_quality_report(quality['report'])) <= ROUND_QUALITY_SESSION_REPORT_MAX_CHARS
         mock_send.assert_not_called()
 
     def test_mail_route_handles_unexpected_quality_gate_exception(self, app, client):

--- a/tests/test_rounds_routes.py
+++ b/tests/test_rounds_routes.py
@@ -387,6 +387,28 @@ class TestRoundDetailRoute:
 
         assert response.status_code == 200
         assert b'Failed Export Detail Round is blocked: needs_substitution.' in response.data
+        assert b'text-red-700 mt-1' in response.data
+
+    def test_round_detail_styles_success_email_export_message_as_neutral(self, app, client):
+        """Successful delivery messages should not be shown as red errors."""
+        _login(app, client)
+        song_id = _create_song(app, title='Success Export Detail Song')
+        round_id = _create_round(app, [song_id], name='Success Export Detail Round')
+        with app.app_context():
+            db.session.add(RoundExport(
+                round_id=round_id,
+                export_type='email',
+                destination='rounds@example.com',
+                status='success',
+                error_message='Email delivered to rounds@example.com.',
+            ))
+            db.session.commit()
+
+        response = client.get(f'/rounds/{round_id}')
+
+        assert response.status_code == 200
+        assert b'Email delivered to rounds@example.com.' in response.data
+        assert b'text-gray-500 mt-1' in response.data
 
     def test_round_detail_hides_private_round_owned_by_other_user(self, app, client):
         """Private owned rounds should not be visible to other quizmasters."""
@@ -1223,4 +1245,69 @@ class TestRoundEmailRoute:
         assert b'Redirect Quality Round is blocked' in response.data
         assert b'Replace position 1.' in response.data
         mock_quality.assert_called_once_with(round_id=round_id, user_id=user_id)
+        mock_send.assert_not_called()
+
+    def test_mail_route_redirect_truncates_quality_report_session_payload(self, app, client):
+        """Large repair reports should not exceed Flask session cookie limits."""
+        _login(app, client)
+        song_id = _create_song(app, title='Large Redirect Quality Song')
+        round_id = _create_round(app, [song_id], name='Large Redirect Quality Round')
+        with app.app_context():
+            round_ = Round.query.get(round_id)
+            round_.mp3_generated = True
+            db.session.commit()
+
+        large_tail = 'TAIL_SHOULD_NOT_RENDER'
+        quality = {
+            'ok': False,
+            'status': 'needs_substitution',
+            'hints': ['Large Redirect Quality Song has no preview.'],
+            'report': {
+                'headline': 'Large Redirect Quality Round is blocked: needs_substitution.',
+                'markdown': '# Large Redirect Quality Round is blocked\n\n' + ('x' * 5000) + large_tail,
+            },
+        }
+
+        with patch('musicround.routes.rounds.generate_pdf', return_value=b'%PDF'), \
+                patch('musicround.routes.rounds.os.path.exists', return_value=True), \
+                patch(
+                    'musicround.routes.rounds.automation.inspect_round_package',
+                    return_value=quality,
+                ), \
+                patch('musicround.routes.rounds.send_quiz_email') as mock_send:
+            response = client.post(f'/rounds/{round_id}/mail', follow_redirects=True)
+
+        assert response.status_code == 200
+        assert b'Large Redirect Quality Round is blocked' in response.data
+        assert b'Report truncated' in response.data
+        assert large_tail.encode() not in response.data
+        mock_send.assert_not_called()
+
+    def test_mail_route_handles_unexpected_quality_gate_exception(self, app, client):
+        """Unexpected inspection failures should return a controlled safe response."""
+        _login(app, client)
+        song_id = _create_song(app, title='Unexpected Quality Error Song')
+        round_id = _create_round(app, [song_id], name='Unexpected Quality Error Round')
+        with app.app_context():
+            round_ = Round.query.get(round_id)
+            round_.mp3_generated = True
+            db.session.commit()
+
+        with patch('musicround.routes.rounds.generate_pdf', return_value=b'%PDF'), \
+                patch('musicround.routes.rounds.os.path.exists', return_value=True), \
+                patch(
+                    'musicround.routes.rounds.automation.inspect_round_package',
+                    side_effect=RuntimeError('database exploded'),
+                ), \
+                patch('musicround.routes.rounds.send_quiz_email') as mock_send:
+            response = client.post(
+                f'/rounds/{round_id}/mail',
+                headers={'X-Requested-With': 'XMLHttpRequest'},
+            )
+
+        assert response.status_code == 500
+        assert response.get_json() == {
+            'success': False,
+            'error': 'Round quality gate could not run. Please try again later or contact an administrator.',
+        }
         mock_send.assert_not_called()


### PR DESCRIPTION
## Summary
- cap round quality reports stored in the Flask session so redirect feedback stays below cookie limits
- return a controlled email response when quality inspection raises an unexpected exception
- render successful export messages neutrally while keeping failed exports red

## Validation
- python3 -m py_compile musicround/routes/rounds.py tests/test_rounds_routes.py
- git diff --check
- attempted targeted pytest in a temporary venv; local Python 3.14 lacks audioop and no pyaudioop package is available, so GitHub CI is the executable test gate