### PR TITLE
Relax MP3 gate and add regenerate flow

### DIFF
--- a/musicround/mcp_server.py
+++ b/musicround/mcp_server.py
@@ -762,7 +762,7 @@ def inspect_round_package(
     expected_song_count: int = 8,
     min_preview_seconds: float = 20.0,
     max_preview_seconds: float = 35.0,
-    duration_tolerance_seconds: float = 6.0,
+    duration_tolerance_seconds: float = automation.DEFAULT_MP3_DURATION_TOLERANCE_SECONDS,
 ) -> dict[str, Any]:
     """Check previews, generated MP3 length, MP3 quality, and PDF integrity before sending."""
     return _with_app_context(
@@ -783,7 +783,7 @@ def round_repair_report(
     expected_song_count: int = 8,
     min_preview_seconds: float = 20.0,
     max_preview_seconds: float = 35.0,
-    duration_tolerance_seconds: float = 6.0,
+    duration_tolerance_seconds: float = automation.DEFAULT_MP3_DURATION_TOLERANCE_SECONDS,
 ) -> dict[str, Any]:
     """Return package quality plus a human-readable repair report."""
     return _with_app_context(

--- a/musicround/routes/rounds.py
+++ b/musicround/routes/rounds.py
@@ -559,6 +559,12 @@ def round_quality(round_id):
             expected_song_count=_int_arg('expected_song_count', default=8, minimum=1, maximum=25),
             min_preview_seconds=float(request.args.get('min_preview_seconds', 20.0)),
             max_preview_seconds=float(request.args.get('max_preview_seconds', 35.0)),
+            duration_tolerance_seconds=float(
+                request.args.get(
+                    'duration_tolerance_seconds',
+                    automation.DEFAULT_MP3_DURATION_TOLERANCE_SECONDS,
+                )
+            ),
         )
     except ValueError:
         return _automation_error_response(AutomationError('Preview duration values must be numeric.'), 400)
@@ -710,10 +716,11 @@ def round_mp3(round_id):
     # Define the path for the MP3 file
     mp3_file_path = os.path.join(rounds_dir, f'round_{round_id}.mp3')
     current_app.logger.info(f"Checking MP3 generation status for round {round_id}")
+    force_regenerate = _bool_form_value('force', False)
 
     # Check if the MP3 has already been generated and if the file exists
     # We'll generate a new file if either the flag is False or the file doesn't exist
-    if round.mp3_generated and os.path.exists(mp3_file_path):
+    if not force_regenerate and round.mp3_generated and os.path.exists(mp3_file_path):
         current_app.logger.info(f"MP3 file already exists and is up to date at: {mp3_file_path}")
         download_url = url_for('rounds.download_mp3', round_id=round_id)
         
@@ -842,12 +849,12 @@ def round_mp3(round_id):
                 download_url = url_for('rounds.download_mp3', round_id=round_id)
                 return jsonify({
                     'success': True,
-                    'message': 'MP3 file successfully generated',
+                    'message': 'MP3 file successfully regenerated' if force_regenerate else 'MP3 file successfully generated',
                     'download_url': download_url
                 })
             else:
                 # Traditional form submission, send file
-                flash('MP3 generated successfully', 'success')
+                flash('MP3 regenerated successfully' if force_regenerate else 'MP3 generated successfully', 'success')
                 return send_file(mp3_file_path, as_attachment=True)
             
         except Exception as e:

--- a/musicround/services/automation.py
+++ b/musicround/services/automation.py
@@ -59,6 +59,7 @@ AUTOMATION_PDF_INSPECTION_ERROR = "PDF inspection failed."
 AUTOMATION_MP3_INSPECTION_ERROR = "MP3 inspection failed."
 AUTOMATION_MP3_GENERATION_ERROR = "MP3 generation failed. Check the server logs."
 AUTOMATION_SCHEDULED_EMAIL_ERROR = "Scheduled round email failed. Check the server logs."
+DEFAULT_MP3_DURATION_TOLERANCE_SECONDS = 45.0
 
 
 def _round_song_ids(round_obj: Round) -> list[int]:
@@ -1696,7 +1697,7 @@ def inspect_round_package(
     expected_song_count: int = 8,
     min_preview_seconds: float = 20.0,
     max_preview_seconds: float = 35.0,
-    duration_tolerance_seconds: float = 6.0,
+    duration_tolerance_seconds: float = DEFAULT_MP3_DURATION_TOLERANCE_SECONDS,
 ) -> dict[str, Any]:
     """Validate a generated round bundle before it is allowed to leave by email."""
     round_obj = db.session.get(Round, round_id)
@@ -2011,7 +2012,7 @@ def round_repair_report(
     expected_song_count: int = 8,
     min_preview_seconds: float = 20.0,
     max_preview_seconds: float = 35.0,
-    duration_tolerance_seconds: float = 6.0,
+    duration_tolerance_seconds: float = DEFAULT_MP3_DURATION_TOLERANCE_SECONDS,
 ) -> dict[str, Any]:
     """Return the package quality payload plus a human-readable repair report."""
     quality = inspect_round_package(

--- a/musicround/templates/round_detail.html
+++ b/musicround/templates/round_detail.html
@@ -216,8 +216,8 @@
                 <i class="fas fa-file-audio fa-3x"></i>
             </div>
             <h3 class="text-xl font-semibold mb-4 text-navy-800 text-center font-montserrat">Generate MP3</h3>
-            <p class="text-gray-600 mb-4 text-center text-sm">Create an audio file with all songs to play during your quiz.</p>
-            <button id="generate-mp3-btn" class="bg-orange-500 hover:bg-orange-600 text-white py-2 px-4 rounded transition-colors w-full font-semibold">
+            <p class="text-gray-600 mb-4 text-center text-sm">Create or refresh the audio file with all songs to play during your quiz.</p>
+            <button id="generate-mp3-btn" title="Shift-click to regenerate the MP3" class="bg-orange-500 hover:bg-orange-600 text-white py-2 px-4 rounded transition-colors w-full font-semibold">
                 <i class="fas fa-music mr-2"></i> Generate MP3
             </button>
         </div>
@@ -438,6 +438,9 @@
                     <i class="fas fa-download mr-2"></i> Download MP3
                 </a>
             </div>
+            <button id="regenerate-mp3-btn" class="hidden mt-4 bg-orange-500 hover:bg-orange-600 text-white py-2 px-4 rounded transition-colors font-semibold">
+                <i class="fas fa-sync-alt mr-2"></i> Regenerate MP3
+            </button>
             <button id="close-mp3-modal" class="mt-4 bg-gray-300 hover:bg-gray-400 text-gray-800 py-2 px-4 rounded transition-colors">Close</button>
         </div>
     </div>
@@ -576,6 +579,7 @@
         const mp3Loading = document.getElementById('mp3-loading');
         const mp3DownloadBtn = document.getElementById('mp3-download-btn');
         const mp3DownloadBtnContainer = document.getElementById('mp3-download-btn-container');
+        const regenerateMp3Btn = document.getElementById('regenerate-mp3-btn');
         const closeMP3Modal = document.getElementById('close-mp3-modal');
         
         // PDF modal elements
@@ -1017,14 +1021,19 @@
             loadReplacementsBtn.addEventListener('click', loadReplacements);
         }
 
-        // MP3 generation with AJAX
-        generateMp3Btn.addEventListener('click', function() {
+        function generateMp3(forceRegenerate = false) {
             // Show the mp3 status modal
             mp3StatusModal.classList.remove('hidden');
             mp3Loading.classList.remove('hidden');
             mp3DownloadBtnContainer.classList.add('hidden');
-            mp3StatusTitle.textContent = 'Generating MP3...';
+            regenerateMp3Btn.classList.add('hidden');
+            mp3StatusTitle.textContent = forceRegenerate ? 'Regenerating MP3...' : 'Generating MP3...';
             mp3StatusMessage.textContent = 'Please wait, this may take a few minutes.';
+
+            const body = new URLSearchParams({ csrf_token: '{{ csrf_token() }}' });
+            if (forceRegenerate) {
+                body.set('force', 'true');
+            }
             
             // Send the AJAX request
             fetch('{{ url_for("rounds.round_mp3", round_id=round.id) }}', {
@@ -1033,18 +1042,24 @@
                     'X-Requested-With': 'XMLHttpRequest',
                     'Content-Type': 'application/x-www-form-urlencoded',
                 },
-                body: 'csrf_token={{ csrf_token() }}'
+                body: body.toString()
             })
             .then(response => response.json())
             .then(data => {
                 mp3Loading.classList.add('hidden');
                 
                 if (data.success) {
-                    mp3StatusTitle.textContent = 'MP3 Generated Successfully';
-                    mp3StatusMessage.textContent = 'Your MP3 file is ready for download.';
+                    if (data.message === 'MP3 file already exists') {
+                        mp3StatusTitle.textContent = 'MP3 Already Exists';
+                        mp3StatusMessage.textContent = 'An MP3 is already available. Download it or regenerate it.';
+                        regenerateMp3Btn.classList.remove('hidden');
+                    } else {
+                        mp3StatusTitle.textContent = forceRegenerate ? 'MP3 Regenerated Successfully' : 'MP3 Generated Successfully';
+                        mp3StatusMessage.textContent = 'Your MP3 file is ready for download.';
+                    }
                     mp3DownloadBtn.href = data.download_url;
                     mp3DownloadBtnContainer.classList.remove('hidden');
-                    showToast('MP3 generated successfully', 'success');
+                    showToast(data.message || 'MP3 generated successfully', 'success');
                 } else {
                     mp3StatusTitle.textContent = 'Error Generating MP3';
                     mp3StatusMessage.textContent = data.error || 'An unknown error occurred.';
@@ -1058,6 +1073,15 @@
                 showToast('Error generating MP3', 'error');
                 console.error('Error:', error);
             });
+        }
+
+        // MP3 generation with AJAX
+        generateMp3Btn.addEventListener('click', function(event) {
+            generateMp3(event.shiftKey);
+        });
+
+        regenerateMp3Btn.addEventListener('click', function() {
+            generateMp3(true);
         });
         
         // Close MP3 modal

--- a/tests/test_automation_service.py
+++ b/tests/test_automation_service.py
@@ -868,7 +868,49 @@ class TestAssetInspection:
             assert result["status"] == "needs_substitution"
             assert any(issue["code"] == "preview_too_short" for issue in result["issues"])
 
-    def test_inspect_round_package_warns_for_mp3_duration_mismatch(self, app):
+    def test_inspect_round_package_tolerates_minor_mp3_duration_variance(self, app):
+        with app.app_context():
+            user = _create_user()
+            song = _create_song(title="Long Enough", artist="Artist", deezer_id="123")
+            round_id = automation.create_round(
+                name="Minor Variance",
+                round_type="manual",
+                song_ids=[song.id],
+            )["round"]["id"]
+
+            with (
+                patch(
+                    "musicround.services.automation._download_preview_audio",
+                    return_value=("https://example.test/preview.mp3", AudioSegment.silent(duration=30000), None),
+                ),
+                patch(
+                    "musicround.services.automation._round_audio_components",
+                    return_value=(
+                        {"custom_audio_ms": {"intro": 1000, "replay": 1000, "outro": 1000}, "number_audio_ms": [1000]},
+                        [],
+                    ),
+                ),
+                patch(
+                    "musicround.services.automation.inspect_pdf_quality",
+                    return_value={"warnings": [], "ok": True},
+                ),
+                patch(
+                    "musicround.services.automation.inspect_mp3_quality",
+                    return_value={"warnings": [], "ok": True, "duration_seconds": 50},
+                ),
+            ):
+                result = automation.inspect_round_package(
+                    round_id, user_id=user.id, expected_song_count=1
+                )
+
+            assert result["expected_duration_seconds"] == 65
+            assert result["status"] == "ok"
+            assert not any(
+                issue["code"] == "round_mp3_duration_mismatch"
+                for issue in result["issues"]
+            )
+
+    def test_inspect_round_package_warns_for_large_mp3_duration_mismatch(self, app):
         with app.app_context():
             user = _create_user()
             song = _create_song(title="Long Enough", artist="Artist", deezer_id="123")
@@ -896,7 +938,7 @@ class TestAssetInspection:
                 ),
                 patch(
                     "musicround.services.automation.inspect_mp3_quality",
-                    return_value={"warnings": [], "ok": True, "duration_seconds": 40},
+                    return_value={"warnings": [], "ok": True, "duration_seconds": 5},
                 ),
             ):
                 result = automation.inspect_round_package(

--- a/tests/test_rounds_routes.py
+++ b/tests/test_rounds_routes.py
@@ -1,5 +1,6 @@
 """Tests for rounds blueprint routes."""
 import json
+import os
 from datetime import datetime
 from unittest.mock import patch, mock_open
 from flask import jsonify
@@ -767,6 +768,67 @@ class TestLegacyEmptyRoundRoutes:
         body = response.get_data(as_text=True)
         assert 'secret' not in body
         assert '/srv/private.mp3' not in body
+
+    def test_round_mp3_existing_file_does_not_regenerate_by_default(self, app, client):
+        """Existing generated MP3s should be reused unless force=true is posted."""
+        _login(app, client)
+        song_id = _create_song(app, title='Existing MP3 Song')
+        round_id = _create_round(app, [song_id], name='Existing MP3 Round')
+        mp3_path = os.path.join(app.config['ROUND_MP3_DIR'], f'round_{round_id}.mp3')
+        with open(mp3_path, 'wb') as handle:
+            handle.write(b'ID3')
+
+        with app.app_context():
+            round_obj = db.session.get(Round, round_id)
+            round_obj.mp3_generated = True
+            db.session.commit()
+
+        with patch('musicround.routes.rounds.AudioSegment.from_mp3') as mock_from_mp3:
+            response = client.post(
+                f'/rounds/round/{round_id}/mp3',
+                headers={'X-Requested-With': 'XMLHttpRequest'},
+            )
+
+        assert response.status_code == 200
+        assert response.get_json()['success'] is True
+        assert response.get_json()['message'] == 'MP3 file already exists'
+        mock_from_mp3.assert_not_called()
+
+    def test_round_mp3_force_regenerates_existing_file(self, app, client):
+        """force=true should bypass the existing-file shortcut and render again."""
+        _login(app, client)
+        song_id = _create_song(app, title='Force MP3 Song')
+        round_id = _create_round(app, [song_id], name='Force MP3 Round')
+        mp3_path = os.path.join(app.config['ROUND_MP3_DIR'], f'round_{round_id}.mp3')
+        with open(mp3_path, 'wb') as handle:
+            handle.write(b'OLD')
+
+        with app.app_context():
+            round_obj = db.session.get(Round, round_id)
+            round_obj.mp3_generated = True
+            db.session.commit()
+
+        def fake_export(segment, path, format='mp3'):
+            with open(path, 'wb') as handle:
+                handle.write(b'NEW')
+            return None
+
+        with patch(
+            'musicround.routes.rounds.AudioSegment.from_mp3',
+            return_value=AudioSegment.silent(duration=100),
+        ) as mock_from_mp3, patch('pydub.audio_segment.AudioSegment.export', fake_export):
+            response = client.post(
+                f'/rounds/round/{round_id}/mp3',
+                data={'force': 'true'},
+                headers={'X-Requested-With': 'XMLHttpRequest'},
+            )
+
+        assert response.status_code == 200
+        assert response.get_json()['success'] is True
+        assert response.get_json()['message'] == 'MP3 file successfully regenerated'
+        assert mock_from_mp3.called
+        with open(mp3_path, 'rb') as handle:
+            assert handle.read() == b'NEW'
 
     def test_round_pdf_hides_generation_exception_details(self, app, client):
         """PDF generation failures should return a stable safe message."""


### PR DESCRIPTION
## What changed
- Relaxed the generated MP3 duration gate from a 6 second default tolerance to 45 seconds.
- Kept large duration gaps blocking so missing-song-sized renders still fail quality inspection.
- Added a force-regenerate path for existing MP3 files via `force=true`.
- Updated the round detail UI: normal click reuses an existing MP3 and offers regeneration, Shift-click regenerates immediately.

## Why
The previous duration gate was too strict for real generated MP3 variance. A valid 8-song round with a ~15 second difference could be marked `render_failed`, even though the important failure case is closer to a missing preview/song-length gap.

## Validation
- `git diff --check`
- `SECRET_KEY=test-secret AUTOMATION_TOKEN=test-token .venv/bin/pytest tests/test_automation_service.py::TestAssetInspection tests/test_rounds_routes.py::TestLegacyEmptyRoundRoutes tests/test_rounds_routes.py::TestRoundMp3Hints tests/test_rounds_routes.py::TestRoundEmailRoute -q`
