### PR TITLE
fix: address MP3 regenerate review follow-ups

### DIFF
--- a/musicround/routes/rounds.py
+++ b/musicround/routes/rounds.py
@@ -581,7 +581,7 @@ def round_quality(round_id):
             ),
         )
     except ValueError:
-        return _automation_error_response(AutomationError('Preview duration values must be numeric.'), 400)
+        return _automation_error_response(AutomationError('Quality parameter values must be numeric.'), 400)
     except AutomationError as exc:
         return _automation_error_response(exc, 400)
     return jsonify({'success': True, **result})
@@ -732,8 +732,7 @@ def round_mp3(round_id):
     current_app.logger.info(f"Checking MP3 generation status for round {round_id}")
     force_regenerate = _bool_form_value('force', False)
 
-    # Check if the MP3 has already been generated and if the file exists
-    # We'll generate a new file if either the flag is False or the file doesn't exist
+    # Reuse the existing MP3 unless the caller explicitly requested regeneration.
     if not force_regenerate and round.mp3_generated and os.path.exists(mp3_file_path):
         current_app.logger.info(f"MP3 file already exists and is up to date at: {mp3_file_path}")
         download_url = url_for('rounds.download_mp3', round_id=round_id)
@@ -742,7 +741,8 @@ def round_mp3(round_id):
         if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
             return jsonify({
                 'success': True, 
-                'message': 'MP3 file already exists', 
+                'message': 'MP3 file already exists',
+                'mp3_status': 'exists',
                 'download_url': download_url
             })
         else:
@@ -864,6 +864,7 @@ def round_mp3(round_id):
                 return jsonify({
                     'success': True,
                     'message': 'MP3 file successfully regenerated' if force_regenerate else 'MP3 file successfully generated',
+                    'mp3_status': 'regenerated' if force_regenerate else 'generated',
                     'download_url': download_url
                 })
             else:

--- a/musicround/routes/rounds.py
+++ b/musicround/routes/rounds.py
@@ -37,6 +37,9 @@ ROUND_MP3_PREVIEW_PROCESSING_ERROR = "Song preview audio could not be processed.
 ROUND_MP3_EXPORT_ERROR = "MP3 generation failed. Check the server logs."
 ROUND_PDF_GENERATION_ERROR = "PDF generation failed. Check the server logs."
 ROUND_QUALITY_SESSION_REPORT_MAX_CHARS = 2000
+ROUND_MP3_STATUS_EXISTS = 'exists'
+ROUND_MP3_STATUS_GENERATED = 'generated'
+ROUND_MP3_STATUS_REGENERATED = 'regenerated'
 
 
 def _int_arg(name, default=None, minimum=None, maximum=None):
@@ -566,22 +569,63 @@ def update_round_review(round_id):
 def round_quality(round_id):
     """Return package quality and repair guidance for a round."""
     _get_visible_round_or_404(round_id)
+    invalid_parameters = []
+
+    def parse_int_query_arg(name, default, minimum=None, maximum=None):
+        raw_value = request.args.get(name)
+        if raw_value in (None, ''):
+            return default
+        try:
+            value = int(raw_value)
+        except (TypeError, ValueError):
+            invalid_parameters.append({'name': name, 'value': raw_value})
+            return default
+        if minimum is not None:
+            value = max(minimum, value)
+        if maximum is not None:
+            value = min(maximum, value)
+        return value
+
+    def parse_float_query_arg(name, default):
+        raw_value = request.args.get(name)
+        if raw_value in (None, ''):
+            return default
+        try:
+            return float(raw_value)
+        except (TypeError, ValueError):
+            invalid_parameters.append({'name': name, 'value': raw_value})
+            return default
+
+    expected_song_count = parse_int_query_arg(
+        'expected_song_count',
+        default=8,
+        minimum=1,
+        maximum=25,
+    )
+    min_preview_seconds = parse_float_query_arg('min_preview_seconds', 20.0)
+    max_preview_seconds = parse_float_query_arg('max_preview_seconds', 35.0)
+    duration_tolerance_seconds = parse_float_query_arg(
+        'duration_tolerance_seconds',
+        automation.DEFAULT_MP3_DURATION_TOLERANCE_SECONDS,
+    )
+    if invalid_parameters:
+        return _automation_error_response(
+            AutomationError(
+                'Quality parameter values must be numeric.',
+                details={'invalid_parameters': invalid_parameters},
+            ),
+            400,
+        )
+
     try:
         result = automation.round_repair_report(
             round_id=round_id,
             user_id=current_user.id,
-            expected_song_count=_int_arg('expected_song_count', default=8, minimum=1, maximum=25),
-            min_preview_seconds=float(request.args.get('min_preview_seconds', 20.0)),
-            max_preview_seconds=float(request.args.get('max_preview_seconds', 35.0)),
-            duration_tolerance_seconds=float(
-                request.args.get(
-                    'duration_tolerance_seconds',
-                    automation.DEFAULT_MP3_DURATION_TOLERANCE_SECONDS,
-                )
-            ),
+            expected_song_count=expected_song_count,
+            min_preview_seconds=min_preview_seconds,
+            max_preview_seconds=max_preview_seconds,
+            duration_tolerance_seconds=duration_tolerance_seconds,
         )
-    except ValueError:
-        return _automation_error_response(AutomationError('Quality parameter values must be numeric.'), 400)
     except AutomationError as exc:
         return _automation_error_response(exc, 400)
     return jsonify({'success': True, **result})
@@ -742,7 +786,7 @@ def round_mp3(round_id):
             return jsonify({
                 'success': True, 
                 'message': 'MP3 file already exists',
-                'mp3_status': 'exists',
+                'mp3_status': ROUND_MP3_STATUS_EXISTS,
                 'download_url': download_url
             })
         else:
@@ -864,7 +908,7 @@ def round_mp3(round_id):
                 return jsonify({
                     'success': True,
                     'message': 'MP3 file successfully regenerated' if force_regenerate else 'MP3 file successfully generated',
-                    'mp3_status': 'regenerated' if force_regenerate else 'generated',
+                    'mp3_status': ROUND_MP3_STATUS_REGENERATED if force_regenerate else ROUND_MP3_STATUS_GENERATED,
                     'download_url': download_url
                 })
             else:

--- a/musicround/templates/round_detail.html
+++ b/musicround/templates/round_detail.html
@@ -1051,7 +1051,7 @@
                 mp3Loading.classList.add('hidden');
                 
                 if (data.success) {
-                    if (data.message === 'MP3 file already exists') {
+                    if (data.mp3_status === 'exists') {
                         mp3StatusTitle.textContent = 'MP3 Already Exists';
                         mp3StatusMessage.textContent = 'An MP3 is already available. Download it or regenerate it.';
                         regenerateMp3Btn.classList.remove('hidden');

--- a/tests/test_rounds_routes.py
+++ b/tests/test_rounds_routes.py
@@ -533,12 +533,24 @@ class TestRoundDetailRoute:
         song_id = _create_song(app, title='Quality Parameter Song')
         round_id = _create_round(app, [song_id], name='Quality Parameter Round')
 
-        response = client.get(f'/rounds/{round_id}/quality?duration_tolerance_seconds=wide')
+        response = client.get(
+            f'/rounds/{round_id}/quality'
+            '?expected_song_count=many'
+            '&min_preview_seconds=short'
+            '&duration_tolerance_seconds=wide'
+        )
 
         assert response.status_code == 400
         assert response.get_json() == {
             'success': False,
             'error': 'Quality parameter values must be numeric.',
+            'details': {
+                'invalid_parameters': [
+                    {'name': 'expected_song_count', 'value': 'many'},
+                    {'name': 'min_preview_seconds', 'value': 'short'},
+                    {'name': 'duration_tolerance_seconds', 'value': 'wide'},
+                ],
+            },
         }
 
     def test_replacement_endpoints_proxy_automation(self, app, client):

--- a/tests/test_rounds_routes.py
+++ b/tests/test_rounds_routes.py
@@ -527,6 +527,20 @@ class TestRoundDetailRoute:
         assert data['success'] is True
         assert data['report']['summary'] == 'Needs replacement'
 
+    def test_round_quality_endpoint_reports_numeric_parameter_errors(self, app, client):
+        """Quality endpoint should describe all numeric parameter parse failures."""
+        _login(app, client)
+        song_id = _create_song(app, title='Quality Parameter Song')
+        round_id = _create_round(app, [song_id], name='Quality Parameter Round')
+
+        response = client.get(f'/rounds/{round_id}/quality?duration_tolerance_seconds=wide')
+
+        assert response.status_code == 400
+        assert response.get_json() == {
+            'success': False,
+            'error': 'Quality parameter values must be numeric.',
+        }
+
     def test_replacement_endpoints_proxy_automation(self, app, client):
         """Replacement routes should make repair candidates actionable."""
         _login(app, client)
@@ -815,6 +829,7 @@ class TestLegacyEmptyRoundRoutes:
         assert response.status_code == 200
         assert response.get_json()['success'] is True
         assert response.get_json()['message'] == 'MP3 file already exists'
+        assert response.get_json()['mp3_status'] == 'exists'
         mock_from_mp3.assert_not_called()
 
     def test_round_mp3_force_regenerates_existing_file(self, app, client):
@@ -849,6 +864,7 @@ class TestLegacyEmptyRoundRoutes:
         assert response.status_code == 200
         assert response.get_json()['success'] is True
         assert response.get_json()['message'] == 'MP3 file successfully regenerated'
+        assert response.get_json()['mp3_status'] == 'regenerated'
         assert mock_from_mp3.called
         with open(mp3_path, 'rb') as handle:
             assert handle.read() == b'NEW'

--- a/tests/test_rounds_routes.py
+++ b/tests/test_rounds_routes.py
@@ -844,6 +844,35 @@ class TestLegacyEmptyRoundRoutes:
         assert response.get_json()['mp3_status'] == 'exists'
         mock_from_mp3.assert_not_called()
 
+    def test_round_mp3_first_generation_reports_generated_status(self, app, client):
+        """First-time MP3 generation should report the generated machine status."""
+        _login(app, client)
+        song_id = _create_song(app, title='Generated MP3 Song')
+        round_id = _create_round(app, [song_id], name='Generated MP3 Round')
+        mp3_path = os.path.join(app.config['ROUND_MP3_DIR'], f'round_{round_id}.mp3')
+
+        def fake_export(segment, path, format='mp3'):
+            with open(path, 'wb') as handle:
+                handle.write(b'NEW')
+            return None
+
+        with patch(
+            'musicround.routes.rounds.AudioSegment.from_mp3',
+            return_value=AudioSegment.silent(duration=100),
+        ) as mock_from_mp3, patch('pydub.audio_segment.AudioSegment.export', fake_export):
+            response = client.post(
+                f'/rounds/round/{round_id}/mp3',
+                headers={'X-Requested-With': 'XMLHttpRequest'},
+            )
+
+        assert response.status_code == 200
+        assert response.get_json()['success'] is True
+        assert response.get_json()['message'] == 'MP3 file successfully generated'
+        assert response.get_json()['mp3_status'] == 'generated'
+        assert mock_from_mp3.called
+        with open(mp3_path, 'rb') as handle:
+            assert handle.read() == b'NEW'
+
     def test_round_mp3_force_regenerates_existing_file(self, app, client):
         """force=true should bypass the existing-file shortcut and render again."""
         _login(app, client)


### PR DESCRIPTION
## Summary
- add explicit mp3_status values for MP3 reuse/regenerate responses so the UI does not branch on copy text
- broaden quality endpoint parse errors to cover all numeric parameters
- update the stale MP3 reuse comment and add route regression coverage

## Validation
- python3 -m py_compile musicround/routes/rounds.py tests/test_rounds_routes.py
- git diff --check
- FLASK_ENV=testing SECRET_KEY=ci-test-secret-key AUTOMATION_TOKEN=ci-test-automation-token /tmp/qb-164-followup-py312/bin/python -m pytest tests/test_rounds_routes.py -q (54 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the error message shown when quality settings contain invalid numeric values.
  * MP3 generation now returns clearer status updates when a file already exists, is newly generated, or is regenerated.

* **User Experience**
  * The round details page now uses the updated MP3 status to show the correct actions when an MP3 is already available.

* **Tests**
  * Added coverage for invalid quality parameter handling and MP3 status responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->