### PR TITLE
Improve QB accessibility controls

### DIFF
--- a/musicround/templates/base.html
+++ b/musicround/templates/base.html
@@ -82,6 +82,18 @@
                 @apply rounded border-gray-300 text-teal-600 focus:ring-teal-500;
             }
         }
+
+        @layer components {
+            .nav-dropdown-menu {
+                display: none;
+            }
+
+            .nav-dropdown:hover .nav-dropdown-menu,
+            .nav-dropdown:focus-within .nav-dropdown-menu,
+            .nav-dropdown.is-open .nav-dropdown-menu {
+                display: flex;
+            }
+        }
     </style>
     {% block head %}{% endblock %}
 </head>
@@ -94,17 +106,17 @@
                         <img src="{{ url_for('static', filename='img/dark/logo.png') }}" alt="Quizzical Beats" class="h-8 mr-2">
                         <span class="hidden sm:inline">Quizzical Beats</span>
                     </a>
-                    <button id="menu-toggle" class="md:hidden focus:outline-none">
+                    <button id="menu-toggle" type="button" class="md:hidden focus:outline-none focus:ring-2 focus:ring-teal-300 rounded p-2" aria-controls="navbar-menu" aria-expanded="false" aria-label="Toggle navigation menu">
                         <i class="fas fa-bars"></i>
                     </button>
                     <div id="navbar-menu" class="hidden md:flex flex-grow items-center">
                         <ul class="flex flex-col md:flex-row space-y-2 md:space-y-0 md:ml-8 md:space-x-6 mt-4 md:mt-0">
                             {% if current_user.is_authenticated %}
-                                <li class="group relative">
-                                    <button class="peer flex items-center text-white hover:text-teal-500">
+                                <li class="nav-dropdown group relative">
+                                    <button type="button" class="nav-dropdown-trigger peer flex items-center text-white hover:text-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-300 rounded px-1 py-1" aria-haspopup="true" aria-expanded="false">
                                         <i class="fab fa-spotify mr-2"></i>Import Spotify <i class="fas fa-chevron-down ml-1"></i>
                                     </button>
-                                    <ul class="hidden peer-hover:flex hover:flex flex-col absolute bg-white text-gray-800 shadow-md py-2 rounded-md w-48 z-10">
+                                    <ul class="nav-dropdown-menu flex-col absolute bg-white text-gray-800 shadow-md py-2 rounded-md w-48 z-10" aria-label="Import Spotify options">
                                         <li><a class="block px-4 py-2 hover:bg-navy-50" href="{{ url_for('import_songs.import_song') }}">Song</a></li>
                                         <li><a class="block px-4 py-2 hover:bg-navy-50" href="{{ url_for('import_songs.import_playlist') }}">Playlist</a></li>
                                         <li><a class="block px-4 py-2 hover:bg-navy-50" href="{{ url_for('import_songs.import_album') }}">Album</a></li>
@@ -118,11 +130,11 @@
                                         </li>
                                     </ul>
                                 </li>
-                                <li class="group relative">
-                                    <button class="peer flex items-center text-white hover:text-teal-500">
+                                <li class="nav-dropdown group relative">
+                                    <button type="button" class="nav-dropdown-trigger peer flex items-center text-white hover:text-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-300 rounded px-1 py-1" aria-haspopup="true" aria-expanded="false">
                                         <i class="fab fa-deezer mr-2"></i>Import Deezer <i class="fas fa-chevron-down ml-1"></i>
                                     </button>
-                                    <ul class="hidden peer-hover:flex hover:flex flex-col absolute bg-white text-gray-800 shadow-md py-2 rounded-md w-48 z-10">
+                                    <ul class="nav-dropdown-menu flex-col absolute bg-white text-gray-800 shadow-md py-2 rounded-md w-48 z-10" aria-label="Import Deezer options">
                                         <li><a class="block px-4 py-2 hover:bg-navy-50" href="{{ url_for('deezer.import_deezer_track') }}">Song</a></li>
                                         <li><a class="block px-4 py-2 hover:bg-navy-50" href="{{ url_for('deezer.import_deezer_playlist') }}">Playlist</a></li>
                                         <li><a class="block px-4 py-2 hover:bg-navy-50" href="{{ url_for('deezer.import_deezer_album') }}">Album</a></li>
@@ -145,22 +157,22 @@
                                 <li>
                                     <a class="text-white hover:text-teal-500" href="{{ url_for('rounds.rounds_list') }}">View Rounds</a>
                                 </li>
-                                <li class="group relative">
-                                    <button class="peer flex items-center text-white hover:text-teal-500">
+                                <li class="nav-dropdown group relative">
+                                    <button type="button" class="nav-dropdown-trigger peer flex items-center text-white hover:text-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-300 rounded px-1 py-1" aria-haspopup="true" aria-expanded="false">
                                         Round Ops <i class="fas fa-chevron-down ml-1"></i>
                                     </button>
-                                    <ul class="hidden peer-hover:flex hover:flex flex-col absolute bg-white text-gray-800 shadow-md py-2 rounded-md w-48 z-10">
+                                    <ul class="nav-dropdown-menu flex-col absolute bg-white text-gray-800 shadow-md py-2 rounded-md w-48 z-10" aria-label="Round operations options">
                                         <li><a class="block px-4 py-2 hover:bg-navy-50" href="{{ url_for('rounds.rounds_calendar') }}">Calendar</a></li>
                                         <li><a class="block px-4 py-2 hover:bg-navy-50" href="{{ url_for('rounds.rounds_analytics') }}">Analytics</a></li>
                                         <li><a class="block px-4 py-2 hover:bg-navy-50" href="{{ url_for('rounds.round_planning') }}">Planning Brief</a></li>
                                     </ul>
                                 </li>
                                 {% if current_user.is_admin %}
-                                <li class="group relative">
-                                    <button class="peer flex items-center text-white hover:text-teal-500">
+                                <li class="nav-dropdown group relative">
+                                    <button type="button" class="nav-dropdown-trigger peer flex items-center text-white hover:text-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-300 rounded px-1 py-1" aria-haspopup="true" aria-expanded="false">
                                         <i class="fas fa-shield-alt mr-2"></i>Admin <i class="fas fa-chevron-down ml-1"></i>
                                     </button>
-                                    <ul class="hidden peer-hover:flex hover:flex flex-col absolute bg-white text-gray-800 shadow-md py-2 rounded-md w-48 z-10">
+                                    <ul class="nav-dropdown-menu flex-col absolute bg-white text-gray-800 shadow-md py-2 rounded-md w-48 z-10" aria-label="Admin options">
                                         <li><a class="block px-4 py-2 hover:bg-navy-50" href="{{ url_for('admin.index') }}">
                                             <span class="flex items-center">
                                                 <i class="fas fa-database mr-2"></i> Data Manager
@@ -244,9 +256,96 @@
 
     <!-- Mobile menu script -->
     <script>
-        document.getElementById('menu-toggle').addEventListener('click', function() {
+        const menuToggle = document.getElementById('menu-toggle');
+
+        menuToggle.addEventListener('click', function() {
             const menu = document.getElementById('navbar-menu');
             menu.classList.toggle('hidden');
+            menuToggle.setAttribute('aria-expanded', String(!menu.classList.contains('hidden')));
+        });
+
+        const dropdowns = Array.from(document.querySelectorAll('.nav-dropdown'));
+        const closeDropdown = (dropdown) => {
+            dropdown.classList.remove('is-open');
+            dropdown.querySelector('.nav-dropdown-trigger')?.setAttribute('aria-expanded', 'false');
+        };
+        const openDropdown = (dropdown) => {
+            dropdowns.forEach((candidate) => {
+                if (candidate !== dropdown) {
+                    closeDropdown(candidate);
+                }
+            });
+            dropdown.classList.add('is-open');
+            dropdown.querySelector('.nav-dropdown-trigger')?.setAttribute('aria-expanded', 'true');
+        };
+
+        dropdowns.forEach((dropdown) => {
+            const trigger = dropdown.querySelector('.nav-dropdown-trigger');
+            const menuLinks = Array.from(dropdown.querySelectorAll('.nav-dropdown-menu a'));
+            if (!trigger || menuLinks.length === 0) {
+                return;
+            }
+
+            dropdown.addEventListener('mouseenter', () => {
+                trigger.setAttribute('aria-expanded', 'true');
+            });
+            dropdown.addEventListener('mouseleave', () => {
+                if (!dropdown.classList.contains('is-open') && !dropdown.contains(document.activeElement)) {
+                    trigger.setAttribute('aria-expanded', 'false');
+                }
+            });
+            dropdown.addEventListener('focusout', () => {
+                window.setTimeout(() => {
+                    if (!dropdown.contains(document.activeElement)) {
+                        closeDropdown(dropdown);
+                    }
+                }, 0);
+            });
+
+            trigger.addEventListener('click', () => {
+                if (dropdown.classList.contains('is-open')) {
+                    closeDropdown(dropdown);
+                } else {
+                    openDropdown(dropdown);
+                }
+            });
+
+            trigger.addEventListener('keydown', (event) => {
+                if (['Enter', ' ', 'ArrowDown'].includes(event.key)) {
+                    event.preventDefault();
+                    openDropdown(dropdown);
+                    menuLinks[0].focus();
+                }
+                if (event.key === 'Escape') {
+                    closeDropdown(dropdown);
+                    trigger.focus();
+                }
+            });
+
+            menuLinks.forEach((link, index) => {
+                link.addEventListener('keydown', (event) => {
+                    if (event.key === 'Escape') {
+                        closeDropdown(dropdown);
+                        trigger.focus();
+                    }
+                    if (event.key === 'ArrowDown') {
+                        event.preventDefault();
+                        menuLinks[(index + 1) % menuLinks.length].focus();
+                    }
+                    if (event.key === 'ArrowUp') {
+                        event.preventDefault();
+                        menuLinks[(index - 1 + menuLinks.length) % menuLinks.length].focus();
+                    }
+                });
+            });
+        });
+
+        document.addEventListener('click', (event) => {
+            dropdowns.forEach((dropdown) => {
+                if (!dropdown.contains(event.target)) {
+                    closeDropdown(dropdown);
+                }
+            });
         });
     </script>
 

--- a/musicround/templates/base.html
+++ b/musicround/templates/base.html
@@ -89,7 +89,6 @@
             }
 
             .nav-dropdown:hover .nav-dropdown-menu,
-            .nav-dropdown:focus-within .nav-dropdown-menu,
             .nav-dropdown.is-open .nav-dropdown-menu {
                 display: flex;
             }

--- a/musicround/templates/build_music_round.html
+++ b/musicround/templates/build_music_round.html
@@ -71,7 +71,8 @@
                 <div class="p-6">
                     <h5 class="text-xl font-semibold text-navy-800 font-montserrat mb-3">By Tag</h5>
                     <p class="text-gray-600 mb-3 h-20">Create a music quiz with songs that share a specific tag from your collection.</p>
-                    <select name="tag_name" class="shadow border rounded w-full py-2 px-3 text-gray-700 mb-3 leading-tight focus:outline-none focus:shadow-outline">
+                    <label for="tag_name" class="sr-only">Select a tag for this music round</label>
+                    <select id="tag_name" name="tag_name" class="shadow border rounded w-full py-2 px-3 text-gray-700 mb-3 leading-tight focus:outline-none focus:shadow-outline">
                         <option value="">Select a Tag</option>
                         {% for tag in tags %}
                             <option value="{{ tag }}">{{ tag }}</option>
@@ -109,4 +110,3 @@
     </div>
 </div>
 {% endblock %}
-

--- a/musicround/templates/round_detail.html
+++ b/musicround/templates/round_detail.html
@@ -185,10 +185,21 @@
                             <td class="px-4 py-3">{{ song.year }}</td>
                             <td class="px-4 py-3">{{ song.genre }}</td>
                             <td class="px-4 py-3">
-                                <audio controls class="w-full max-w-[200px]" src="{{ song.preview_url }}">Your browser does not support the audio element.</audio>
+                                {% if song.preview_url %}
+                                <button type="button"
+                                        class="round-preview-load-btn inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md border border-transparent px-3 py-2 text-teal-600 transition-all hover:border-teal-200 hover:bg-teal-50 hover:text-teal-800"
+                                        data-preview-url="{{ song.preview_url|e }}"
+                                        title="Load preview for {{ song.title|e }} by {{ song.artist|e }}"
+                                        aria-label="Load preview for {{ song.title|e }} by {{ song.artist|e }}">
+                                    <i class="fas fa-play"></i>
+                                    <span class="ml-2 hidden sm:inline">Preview</span>
+                                </button>
+                                {% else %}
+                                <span class="text-gray-400">No preview</span>
+                                {% endif %}
                             </td>
                             <td class="px-4 py-3">
-                                <button type="button" class="remove-song text-red-500 hover:text-red-700" data-id="{{ song.id }}">
+                                <button type="button" class="remove-song inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md text-red-500 hover:bg-red-50 hover:text-red-700" data-id="{{ song.id }}" aria-label="Remove {{ song.title|e }} by {{ song.artist|e }} from this round" title="Remove {{ song.title|e }} by {{ song.artist|e }}">
                                     <i class="fas fa-trash"></i>
                                 </button>
                             </td>
@@ -694,6 +705,58 @@
                 }[character];
             });
         }
+
+        function renderRoundPreviewCell(previewUrl, title, artist) {
+            if (!previewUrl) {
+                return '<span class="text-gray-400">No preview</span>';
+            }
+
+            const label = `Load preview for ${title || 'song'}${artist ? ` by ${artist}` : ''}`;
+            return `
+                <button type="button"
+                        class="round-preview-load-btn inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md border border-transparent px-3 py-2 text-teal-600 transition-all hover:border-teal-200 hover:bg-teal-50 hover:text-teal-800"
+                        data-preview-url="${escapeHtml(previewUrl)}"
+                        title="${escapeHtml(label)}"
+                        aria-label="${escapeHtml(label)}">
+                    <i class="fas fa-play"></i>
+                    <span class="ml-2 hidden sm:inline">Preview</span>
+                </button>
+            `;
+        }
+
+        document.addEventListener('click', function(event) {
+            const previewButton = event.target.closest('.round-preview-load-btn');
+            if (!previewButton) {
+                return;
+            }
+
+            event.preventDefault();
+            const previewUrl = previewButton.dataset.previewUrl;
+            if (!previewUrl) {
+                return;
+            }
+
+            const audio = document.createElement('audio');
+            audio.controls = true;
+            audio.preload = 'none';
+            audio.className = 'preview-audio w-full min-w-[180px] max-w-[260px]';
+            audio.src = previewUrl;
+            audio.textContent = 'Your browser does not support audio.';
+            previewButton.replaceWith(audio);
+            audio.load();
+            audio.play().catch(function() {});
+        });
+
+        document.addEventListener('play', function(event) {
+            if (event.target.tagName !== 'AUDIO') {
+                return;
+            }
+            document.querySelectorAll('audio').forEach(function(player) {
+                if (player !== event.target) {
+                    player.pause();
+                }
+            });
+        }, true);
         
         // Close toast button event
         toastCloseBtn.addEventListener('click', hideToast);
@@ -853,11 +916,9 @@
                 <td class="px-4 py-3">${songData.artist}</td>
                 <td class="px-4 py-3">${songData.year}</td>
                 <td class="px-4 py-3">${songData.genre}</td>
+                <td class="px-4 py-3">${renderRoundPreviewCell(songData.preview, songData.title, songData.artist)}</td>
                 <td class="px-4 py-3">
-                    <audio controls class="w-full max-w-[200px]" src="${songData.preview}">Your browser does not support the audio element.</audio>
-                </td>
-                <td class="px-4 py-3">
-                    <button type="button" class="remove-song text-red-500 hover:text-red-700" data-id="${songData.id}">
+                    <button type="button" class="remove-song inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md text-red-500 hover:bg-red-50 hover:text-red-700" data-id="${songData.id}" aria-label="Remove ${escapeHtml(songData.title)} by ${escapeHtml(songData.artist)} from this round" title="Remove ${escapeHtml(songData.title)} by ${escapeHtml(songData.artist)}">
                         <i class="fas fa-trash"></i>
                     </button>
                 </td>

--- a/musicround/templates/users/audio_settings.html
+++ b/musicround/templates/users/audio_settings.html
@@ -57,7 +57,8 @@
                         
                         <div class="flex items-center space-x-4">
                             <div class="flex-grow">
-                                <input type="file" name="audio_file" accept=".mp3" class="w-full px-4 py-2 border rounded-md focus:ring-orange-500 focus:border-orange-500">
+                                <label for="intro_audio_file" class="sr-only">Upload intro MP3</label>
+                                <input id="intro_audio_file" type="file" name="audio_file" accept=".mp3" class="w-full px-4 py-2 border rounded-md focus:ring-orange-500 focus:border-orange-500">
                             </div>
                             <button type="submit" class="bg-orange-500 hover:bg-orange-600 text-white py-2 px-4 rounded transition-colors">
                                 Upload
@@ -71,8 +72,8 @@
                     {% if has_tts_services %}
                         <form method="GET" class="mb-4 flex items-end space-x-2">
                             <input type="hidden" name="mp3_type" value="intro">
-                            <label class="block text-sm font-medium text-gray-700 mb-1">TTS Service</label>
-                            <select name="tts_service" class="px-4 py-2 border rounded-md focus:ring-orange-500 focus:border-orange-500 w-full">
+                            <label for="intro_tts_service" class="block text-sm font-medium text-gray-700 mb-1">TTS Service</label>
+                            <select id="intro_tts_service" name="tts_service" class="px-4 py-2 border rounded-md focus:ring-orange-500 focus:border-orange-500 w-full">
                                 {% for svc in tts_services %}
                                     <option value="{{ svc.id }}" {% if selected_service and svc.id == selected_service.id %}selected{% endif %}>{{ svc.name }}</option>
                                 {% endfor %}
@@ -86,8 +87,8 @@
                             <input type="hidden" name="tts_service" value="{{ selected_service.id }}">
                             <p class="mt-1 text-sm text-gray-500">{{ selected_service.description if selected_service else '' }}</p>
                             <div class="mb-4">
-                                <label class="block text-sm font-medium text-gray-700 mb-1">Voice</label>
-                                <select name="tts_voice" class="px-4 py-2 border rounded-md focus:ring-orange-500 focus:border-orange-500 w-full">
+                                <label for="intro_tts_voice" class="block text-sm font-medium text-gray-700 mb-1">Voice</label>
+                                <select id="intro_tts_voice" name="tts_voice" class="px-4 py-2 border rounded-md focus:ring-orange-500 focus:border-orange-500 w-full">
                                     {% for voice in selected_service.voices %}
                                         <option value="{{ voice.id }}">{{ voice.name }} ({{ voice.gender }}, {{ voice.language }})</option>
                                     {% endfor %}
@@ -95,8 +96,8 @@
                             </div>
                             {% if selected_service.id == 'openai' and selected_service.models %}
                                 <div class="mb-4">
-                                    <label class="block text-sm font-medium text-gray-700 mb-1">Model Quality</label>
-                                    <select name="openai_model" class="px-4 py-2 border rounded-md focus:ring-orange-500 focus:border-orange-500 w-full">
+                                    <label for="intro_openai_model" class="block text-sm font-medium text-gray-700 mb-1">Model Quality</label>
+                                    <select id="intro_openai_model" name="openai_model" class="px-4 py-2 border rounded-md focus:ring-orange-500 focus:border-orange-500 w-full">
                                         {% for model in selected_service.models %}
                                             <option value="{{ model.id }}">{{ model.name }}</option>
                                         {% endfor %}
@@ -105,8 +106,8 @@
                             {% endif %}
                             {% if selected_service.id == 'elevenlabs' and selected_service.models %}
                                 <div class="mb-4">
-                                    <label class="block text-sm font-medium text-gray-700 mb-1">Model</label>
-                                    <select name="elevenlabs_model" class="px-4 py-2 border rounded-md focus:ring-orange-500 focus:border-orange-500 w-full">
+                                    <label for="intro_elevenlabs_model" class="block text-sm font-medium text-gray-700 mb-1">Model</label>
+                                    <select id="intro_elevenlabs_model" name="elevenlabs_model" class="px-4 py-2 border rounded-md focus:ring-orange-500 focus:border-orange-500 w-full">
                                         {% for model in selected_service.models %}
                                             <option value="{{ model.id }}">{{ model.name }}</option>
                                         {% endfor %}
@@ -117,16 +118,16 @@
                                 <div class="mb-4 bg-gray-50 p-4 rounded-md">
                                     <h5 class="font-medium text-gray-700 mb-2">Voice Settings</h5>
                                     <div class="mb-3">
-                                        <label class="block text-sm font-medium text-gray-700 mb-1">Stability <span class="text-xs text-gray-500">(0.0 - 1.0)</span></label>
-                                        <input type="range" name="stability" min="0" max="1" step="0.05" value="0.5" class="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer">
+                                        <label for="intro_stability" class="block text-sm font-medium text-gray-700 mb-1">Stability <span class="text-xs text-gray-500">(0.0 - 1.0)</span></label>
+                                        <input id="intro_stability" type="range" name="stability" min="0" max="1" step="0.05" value="0.5" class="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer">
                                         <div class="flex justify-between text-xs text-gray-500 mt-1">
                                             <span>More variable</span>
                                             <span>More stable</span>
                                         </div>
                                     </div>
                                     <div class="mb-3">
-                                        <label class="block text-sm font-medium text-gray-700 mb-1">Similarity Boost <span class="text-xs text-gray-500">(0.0 - 1.0)</span></label>
-                                        <input type="range" name="similarity_boost" min="0" max="1" step="0.05" value="0.75" class="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer">
+                                        <label for="intro_similarity_boost" class="block text-sm font-medium text-gray-700 mb-1">Similarity Boost <span class="text-xs text-gray-500">(0.0 - 1.0)</span></label>
+                                        <input id="intro_similarity_boost" type="range" name="similarity_boost" min="0" max="1" step="0.05" value="0.75" class="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer">
                                         <div class="flex justify-between text-xs text-gray-500 mt-1">
                                             <span>More unique</span>
                                             <span>More similar</span>
@@ -135,8 +136,8 @@
                                 </div>
                             {% endif %}
                             <div class="mb-4">
-                                <label class="block text-sm font-medium text-gray-700 mb-1">Text to Convert</label>
-                                <textarea name="tts_text" rows="3" class="w-full px-4 py-2 border rounded-md focus:ring-orange-500 focus:border-orange-500" 
+                                <label for="intro_tts_text" class="block text-sm font-medium text-gray-700 mb-1">Text to Convert</label>
+                                <textarea id="intro_tts_text" name="tts_text" rows="3" class="w-full px-4 py-2 border rounded-md focus:ring-orange-500 focus:border-orange-500"
                                     placeholder="Enter text for intro announcement...">{{ default_texts.intro }}</textarea>
                             </div>
                             <div class="flex justify-end">
@@ -203,7 +204,8 @@
                         
                         <div class="flex items-center space-x-4">
                             <div class="flex-grow">
-                                <input type="file" name="audio_file" accept=".mp3" class="w-full px-4 py-2 border rounded-md focus:ring-orange-500 focus:border-orange-500">
+                                <label for="outro_audio_file" class="sr-only">Upload outro MP3</label>
+                                <input id="outro_audio_file" type="file" name="audio_file" accept=".mp3" class="w-full px-4 py-2 border rounded-md focus:ring-orange-500 focus:border-orange-500">
                             </div>
                             <button type="submit" class="bg-orange-500 hover:bg-orange-600 text-white py-2 px-4 rounded transition-colors">
                                 Upload
@@ -217,8 +219,8 @@
                     {% if has_tts_services %}
                         <form method="GET" class="mb-4 flex items-end space-x-2">
                             <input type="hidden" name="mp3_type" value="outro">
-                            <label class="block text-sm font-medium text-gray-700 mb-1">TTS Service</label>
-                            <select name="tts_service" class="px-4 py-2 border rounded-md focus:ring-orange-500 focus:border-orange-500 w-full">
+                            <label for="outro_tts_service" class="block text-sm font-medium text-gray-700 mb-1">TTS Service</label>
+                            <select id="outro_tts_service" name="tts_service" class="px-4 py-2 border rounded-md focus:ring-orange-500 focus:border-orange-500 w-full">
                                 {% for svc in tts_services %}
                                     <option value="{{ svc.id }}" {% if selected_service and svc.id == selected_service.id %}selected{% endif %}>{{ svc.name }}</option>
                                 {% endfor %}
@@ -232,8 +234,8 @@
                             <input type="hidden" name="tts_service" value="{{ selected_service.id }}">
                             <p class="mt-1 text-sm text-gray-500">{{ selected_service.description if selected_service else '' }}</p>
                             <div class="mb-4">
-                                <label class="block text-sm font-medium text-gray-700 mb-1">Voice</label>
-                                <select name="tts_voice" class="px-4 py-2 border rounded-md focus:ring-orange-500 focus:border-orange-500 w-full">
+                                <label for="outro_tts_voice" class="block text-sm font-medium text-gray-700 mb-1">Voice</label>
+                                <select id="outro_tts_voice" name="tts_voice" class="px-4 py-2 border rounded-md focus:ring-orange-500 focus:border-orange-500 w-full">
                                     {% for voice in selected_service.voices %}
                                         <option value="{{ voice.id }}">{{ voice.name }} ({{ voice.gender }}, {{ voice.language }})</option>
                                     {% endfor %}
@@ -241,8 +243,8 @@
                             </div>
                             {% if selected_service.id == 'openai' and selected_service.models %}
                                 <div class="mb-4">
-                                    <label class="block text-sm font-medium text-gray-700 mb-1">Model Quality</label>
-                                    <select name="openai_model" class="px-4 py-2 border rounded-md focus:ring-orange-500 focus:border-orange-500 w-full">
+                                    <label for="outro_openai_model" class="block text-sm font-medium text-gray-700 mb-1">Model Quality</label>
+                                    <select id="outro_openai_model" name="openai_model" class="px-4 py-2 border rounded-md focus:ring-orange-500 focus:border-orange-500 w-full">
                                         {% for model in selected_service.models %}
                                             <option value="{{ model.id }}">{{ model.name }}</option>
                                         {% endfor %}
@@ -251,8 +253,8 @@
                             {% endif %}
                             {% if selected_service.id == 'elevenlabs' and selected_service.models %}
                                 <div class="mb-4">
-                                    <label class="block text-sm font-medium text-gray-700 mb-1">Model</label>
-                                    <select name="elevenlabs_model" class="px-4 py-2 border rounded-md focus:ring-orange-500 focus:border-orange-500 w-full">
+                                    <label for="outro_elevenlabs_model" class="block text-sm font-medium text-gray-700 mb-1">Model</label>
+                                    <select id="outro_elevenlabs_model" name="elevenlabs_model" class="px-4 py-2 border rounded-md focus:ring-orange-500 focus:border-orange-500 w-full">
                                         {% for model in selected_service.models %}
                                             <option value="{{ model.id }}">{{ model.name }}</option>
                                         {% endfor %}
@@ -263,16 +265,16 @@
                                 <div class="mb-4 bg-gray-50 p-4 rounded-md">
                                     <h5 class="font-medium text-gray-700 mb-2">Voice Settings</h5>
                                     <div class="mb-3">
-                                        <label class="block text-sm font-medium text-gray-700 mb-1">Stability <span class="text-xs text-gray-500">(0.0 - 1.0)</span></label>
-                                        <input type="range" name="stability" min="0" max="1" step="0.05" value="0.5" class="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer">
+                                        <label for="outro_stability" class="block text-sm font-medium text-gray-700 mb-1">Stability <span class="text-xs text-gray-500">(0.0 - 1.0)</span></label>
+                                        <input id="outro_stability" type="range" name="stability" min="0" max="1" step="0.05" value="0.5" class="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer">
                                         <div class="flex justify-between text-xs text-gray-500 mt-1">
                                             <span>More variable</span>
                                             <span>More stable</span>
                                         </div>
                                     </div>
                                     <div class="mb-3">
-                                        <label class="block text-sm font-medium text-gray-700 mb-1">Similarity Boost <span class="text-xs text-gray-500">(0.0 - 1.0)</span></label>
-                                        <input type="range" name="similarity_boost" min="0" max="1" step="0.05" value="0.75" class="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer">
+                                        <label for="outro_similarity_boost" class="block text-sm font-medium text-gray-700 mb-1">Similarity Boost <span class="text-xs text-gray-500">(0.0 - 1.0)</span></label>
+                                        <input id="outro_similarity_boost" type="range" name="similarity_boost" min="0" max="1" step="0.05" value="0.75" class="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer">
                                         <div class="flex justify-between text-xs text-gray-500 mt-1">
                                             <span>More unique</span>
                                             <span>More similar</span>
@@ -281,8 +283,8 @@
                                 </div>
                             {% endif %}
                             <div class="mb-4">
-                                <label class="block text-sm font-medium text-gray-700 mb-1">Text to Convert</label>
-                                <textarea name="tts_text" rows="3" class="w-full px-4 py-2 border rounded-md focus:ring-orange-500 focus:border-orange-500" 
+                                <label for="outro_tts_text" class="block text-sm font-medium text-gray-700 mb-1">Text to Convert</label>
+                                <textarea id="outro_tts_text" name="tts_text" rows="3" class="w-full px-4 py-2 border rounded-md focus:ring-orange-500 focus:border-orange-500"
                                     placeholder="Enter text for outro announcement...">{{ default_texts.outro }}</textarea>
                             </div>
                             <div class="flex justify-end">
@@ -344,7 +346,8 @@
                         <input type="hidden" name="mp3_type" value="replay">
                         <div class="flex items-center space-x-4">
                             <div class="flex-grow">
-                                <input type="file" name="audio_file" accept=".mp3" class="w-full px-4 py-2 border rounded-md focus:ring-orange-500 focus:border-orange-500">
+                                <label for="replay_audio_file" class="sr-only">Upload replay MP3</label>
+                                <input id="replay_audio_file" type="file" name="audio_file" accept=".mp3" class="w-full px-4 py-2 border rounded-md focus:ring-orange-500 focus:border-orange-500">
                             </div>
                             <button type="submit" class="bg-orange-500 hover:bg-orange-600 text-white py-2 px-4 rounded transition-colors">
                                 Upload
@@ -357,8 +360,8 @@
                     {% if has_tts_services %}
                         <form method="GET" class="mb-4 flex items-end space-x-2">
                             <input type="hidden" name="mp3_type" value="replay">
-                            <label class="block text-sm font-medium text-gray-700 mb-1">TTS Service</label>
-                            <select name="tts_service" class="px-4 py-2 border rounded-md focus:ring-orange-500 focus:border-orange-500 w-full">
+                            <label for="replay_tts_service" class="block text-sm font-medium text-gray-700 mb-1">TTS Service</label>
+                            <select id="replay_tts_service" name="tts_service" class="px-4 py-2 border rounded-md focus:ring-orange-500 focus:border-orange-500 w-full">
                                 {% for svc in tts_services %}
                                     <option value="{{ svc.id }}" {% if selected_service and svc.id == selected_service.id %}selected{% endif %}>{{ svc.name }}</option>
                                 {% endfor %}
@@ -372,8 +375,8 @@
                             <input type="hidden" name="tts_service" value="{{ selected_service.id }}">
                             <p class="mt-1 text-sm text-gray-500">{{ selected_service.description if selected_service else '' }}</p>
                             <div class="mb-4">
-                                <label class="block text-sm font-medium text-gray-700 mb-1">Voice</label>
-                                <select name="tts_voice" class="px-4 py-2 border rounded-md focus:ring-orange-500 focus:border-orange-500 w-full">
+                                <label for="replay_tts_voice" class="block text-sm font-medium text-gray-700 mb-1">Voice</label>
+                                <select id="replay_tts_voice" name="tts_voice" class="px-4 py-2 border rounded-md focus:ring-orange-500 focus:border-orange-500 w-full">
                                     {% for voice in selected_service.voices %}
                                         <option value="{{ voice.id }}">{{ voice.name }} ({{ voice.gender }}, {{ voice.language }})</option>
                                     {% endfor %}
@@ -381,8 +384,8 @@
                             </div>
                             {% if selected_service.id == 'openai' and selected_service.models %}
                                 <div class="mb-4">
-                                    <label class="block text-sm font-medium text-gray-700 mb-1">Model Quality</label>
-                                    <select name="openai_model" class="px-4 py-2 border rounded-md focus:ring-orange-500 focus:border-orange-500 w-full">
+                                    <label for="replay_openai_model" class="block text-sm font-medium text-gray-700 mb-1">Model Quality</label>
+                                    <select id="replay_openai_model" name="openai_model" class="px-4 py-2 border rounded-md focus:ring-orange-500 focus:border-orange-500 w-full">
                                         {% for model in selected_service.models %}
                                             <option value="{{ model.id }}">{{ model.name }}</option>
                                         {% endfor %}
@@ -391,8 +394,8 @@
                             {% endif %}
                             {% if selected_service.id == 'elevenlabs' and selected_service.models %}
                                 <div class="mb-4">
-                                    <label class="block text-sm font-medium text-gray-700 mb-1">Model</label>
-                                    <select name="elevenlabs_model" class="px-4 py-2 border rounded-md focus:ring-orange-500 focus:border-orange-500 w-full">
+                                    <label for="replay_elevenlabs_model" class="block text-sm font-medium text-gray-700 mb-1">Model</label>
+                                    <select id="replay_elevenlabs_model" name="elevenlabs_model" class="px-4 py-2 border rounded-md focus:ring-orange-500 focus:border-orange-500 w-full">
                                         {% for model in selected_service.models %}
                                             <option value="{{ model.id }}">{{ model.name }}</option>
                                         {% endfor %}
@@ -403,16 +406,16 @@
                                 <div class="mb-4 bg-gray-50 p-4 rounded-md">
                                     <h5 class="font-medium text-gray-700 mb-2">Voice Settings</h5>
                                     <div class="mb-3">
-                                        <label class="block text-sm font-medium text-gray-700 mb-1">Stability <span class="text-xs text-gray-500">(0.0 - 1.0)</span></label>
-                                        <input type="range" name="stability" min="0" max="1" step="0.05" value="0.5" class="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer">
+                                        <label for="replay_stability" class="block text-sm font-medium text-gray-700 mb-1">Stability <span class="text-xs text-gray-500">(0.0 - 1.0)</span></label>
+                                        <input id="replay_stability" type="range" name="stability" min="0" max="1" step="0.05" value="0.5" class="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer">
                                         <div class="flex justify-between text-xs text-gray-500 mt-1">
                                             <span>More variable</span>
                                             <span>More stable</span>
                                         </div>
                                     </div>
                                     <div class="mb-3">
-                                        <label class="block text-sm font-medium text-gray-700 mb-1">Similarity Boost <span class="text-xs text-gray-500">(0.0 - 1.0)</span></label>
-                                        <input type="range" name="similarity_boost" min="0" max="1" step="0.05" value="0.75" class="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer">
+                                        <label for="replay_similarity_boost" class="block text-sm font-medium text-gray-700 mb-1">Similarity Boost <span class="text-xs text-gray-500">(0.0 - 1.0)</span></label>
+                                        <input id="replay_similarity_boost" type="range" name="similarity_boost" min="0" max="1" step="0.05" value="0.75" class="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer">
                                         <div class="flex justify-between text-xs text-gray-500 mt-1">
                                             <span>More unique</span>
                                             <span>More similar</span>
@@ -421,8 +424,8 @@
                                 </div>
                             {% endif %}
                             <div class="mb-4">
-                                <label class="block text-sm font-medium text-gray-700 mb-1">Text to Convert</label>
-                                <textarea name="tts_text" rows="3" class="w-full px-4 py-2 border rounded-md focus:ring-orange-500 focus:border-orange-500"
+                                <label for="replay_tts_text" class="block text-sm font-medium text-gray-700 mb-1">Text to Convert</label>
+                                <textarea id="replay_tts_text" name="tts_text" rows="3" class="w-full px-4 py-2 border rounded-md focus:ring-orange-500 focus:border-orange-500"
                                     placeholder="Enter text for replay announcement...">{{ default_texts.replay }}</textarea>
                             </div>
                             <div class="flex justify-end">

--- a/musicround/templates/view_songs.html
+++ b/musicround/templates/view_songs.html
@@ -245,10 +245,10 @@
                                     {% set preview_url = song.preview_url or song.spotify_preview_url or song.deezer_preview_url or song.apple_preview_url or song.youtube_preview_url %}
                                     {% if preview_url %}
                                     <button type="button"
-                                            class="preview-load-btn text-teal-600 hover:text-teal-800 px-2 py-1 rounded-md border border-transparent hover:border-teal-200 hover:bg-teal-50 transition-all"
+                                            class="preview-load-btn inline-flex min-h-[44px] min-w-[44px] items-center justify-center text-teal-600 hover:text-teal-800 px-2 py-1 rounded-md border border-transparent hover:border-teal-200 hover:bg-teal-50 transition-all"
                                             data-preview-url="{{ preview_url|e }}"
-                                            title="Load preview"
-                                            aria-label="Load preview">
+                                            title="Load preview for {{ song.title|e }} by {{ song.artist|e }}"
+                                            aria-label="Load preview for {{ song.title|e }} by {{ song.artist|e }}">
                                         <i class="fas fa-play"></i>
                                     </button>
                                     {% else %}
@@ -258,15 +258,17 @@
                                 <td class="px-4 py-3">
                                     <div class="flex space-x-2">
                                         <button type="button" 
-                                                class="edit-song-btn text-teal-600 hover:text-teal-800 px-2 py-1 rounded-md border border-transparent hover:border-teal-200 hover:bg-teal-50 transition-all" 
-                                                title="Edit song">
+                                                class="edit-song-btn inline-flex min-h-[44px] min-w-[44px] items-center justify-center text-teal-600 hover:text-teal-800 px-2 py-1 rounded-md border border-transparent hover:border-teal-200 hover:bg-teal-50 transition-all"
+                                                title="Edit {{ song.title|e }} by {{ song.artist|e }}"
+                                                aria-label="Edit {{ song.title|e }} by {{ song.artist|e }}">
                                             <i class="fas fa-edit"></i>
                                         </button>
                                         <button type="button" 
-                                                class="delete-song-btn text-red-600 hover:text-red-800 px-2 py-1 rounded-md border border-transparent hover:border-red-200 hover:bg-red-50 transition-all"
+                                                class="delete-song-btn inline-flex min-h-[44px] min-w-[44px] items-center justify-center text-red-600 hover:text-red-800 px-2 py-1 rounded-md border border-transparent hover:border-red-200 hover:bg-red-50 transition-all"
                                                 data-song-id="{{ song.id }}"
                                                 data-song-title="{{ song.title }}"
-                                                title="Delete song">
+                                                title="Delete {{ song.title|e }} by {{ song.artist|e }}"
+                                                aria-label="Delete {{ song.title|e }} by {{ song.artist|e }}">
                                             <i class="fas fa-trash-alt"></i>
                                         </button>
                                     </div>
@@ -707,17 +709,19 @@
                 return $('<div>').text(value || '').html();
             }
 
-            function renderPreviewCell(previewUrl) {
+            function renderPreviewCell(previewUrl, title, artist) {
                 if (!previewUrl) {
                     return '<span class="text-gray-400">No preview</span>';
                 }
                 const escapedUrl = escapeHtml(previewUrl);
+                const label = `Load preview for ${title || 'song'}${artist ? ` by ${artist}` : ''}`;
+                const escapedLabel = escapeHtml(label);
                 return `
                     <button type="button"
-                            class="preview-load-btn text-teal-600 hover:text-teal-800 px-2 py-1 rounded-md border border-transparent hover:border-teal-200 hover:bg-teal-50 transition-all"
+                            class="preview-load-btn inline-flex min-h-[44px] min-w-[44px] items-center justify-center text-teal-600 hover:text-teal-800 px-2 py-1 rounded-md border border-transparent hover:border-teal-200 hover:bg-teal-50 transition-all"
                             data-preview-url="${escapedUrl}"
-                            title="Load preview"
-                            aria-label="Load preview">
+                            title="${escapedLabel}"
+                            aria-label="${escapedLabel}">
                         <i class="fas fa-play"></i>
                     </button>
                 `;
@@ -1277,10 +1281,16 @@
                     
                     // Update audio preview without eagerly creating table audio players.
                     const audioCell = row.find('td:nth-child(7)');
-                    audioCell.html(renderPreviewCell(data.preview_url));
+                    audioCell.html(renderPreviewCell(data.preview_url, data.title, data.artist));
                     
-                    // Update delete button song title attribute
+                    // Update action button labels for assistive tech.
                     row.find('.delete-song-btn').data('song-title', data.title);
+                    row.find('.delete-song-btn')
+                        .attr('title', `Delete ${data.title || 'song'} by ${data.artist || 'unknown artist'}`)
+                        .attr('aria-label', `Delete ${data.title || 'song'} by ${data.artist || 'unknown artist'}`);
+                    row.find('.edit-song-btn')
+                        .attr('title', `Edit ${data.title || 'song'} by ${data.artist || 'unknown artist'}`)
+                        .attr('aria-label', `Edit ${data.title || 'song'} by ${data.artist || 'unknown artist'}`);
                     
                     // Update the row in our arrays
                     for (let i = 0; i < allRows.length; i++) {

--- a/tests/test_final_coverage.py
+++ b/tests/test_final_coverage.py
@@ -695,6 +695,9 @@ class TestCoreViewSongs:
         assert response.status_code == 200
         assert b'preview-load-btn' in response.data
         assert b'data-preview-url="https://example.com/preview.mp3"' in response.data
+        assert b'aria-label="Load preview for Preview Test by Preview Artist"' in response.data
+        assert b'aria-label="Edit Preview Test by Preview Artist"' in response.data
+        assert b'aria-label="Delete Preview Test by Preview Artist"' in response.data
         assert b'<audio controls class="preview-audio w-full max-w-[180px]" src=' not in response.data
 
     def test_view_songs_paginates_server_side(self, app, client):

--- a/tests/test_rounds_routes.py
+++ b/tests/test_rounds_routes.py
@@ -348,6 +348,29 @@ class TestRoundDetailRoute:
         response = client.get(f'/rounds/{round_id}')
         assert response.status_code == 200
 
+    def test_round_detail_lazy_loads_named_preview_controls(self, app, client):
+        """Round detail should keep previews lazy and label the play control."""
+        _login(app, client)
+        with app.app_context():
+            song = Song(
+                title='Round Preview',
+                artist='Round Artist',
+                genre='Pop',
+                preview_url='https://example.com/round-preview.mp3',
+            )
+            db.session.add(song)
+            db.session.commit()
+            song_id = song.id
+        round_id = _create_round(app, [song_id], name='Preview Round')
+
+        response = client.get(f'/rounds/{round_id}')
+
+        assert response.status_code == 200
+        assert b'round-preview-load-btn' in response.data
+        assert b'data-preview-url="https://example.com/round-preview.mp3"' in response.data
+        assert b'aria-label="Load preview for Round Preview by Round Artist"' in response.data
+        assert b'<audio controls class="w-full max-w-[200px]"' not in response.data
+
     def test_round_detail_shows_review_and_audio_scripts(self, app, client):
         """Round detail should surface review state and script drafts."""
         _login(app, client)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -245,6 +245,7 @@ class TestAuthenticatedRoutes:
         assert b'aria-haspopup="true"' in response.data
         assert b'aria-expanded="false"' in response.data
         assert b'aria-label="Toggle navigation menu"' in response.data
+        assert b'.nav-dropdown:focus-within .nav-dropdown-menu' not in response.data
 
     def test_search_accessible_when_logged_in(self, app, client):
         """Test that search page is accessible when logged in."""

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -235,11 +235,52 @@ class TestAuthenticatedRoutes:
         response = client.get('/view-songs')
         assert response.status_code == 200
 
+    def test_navigation_dropdowns_are_keyboard_accessible(self, app, client):
+        """Header dropdowns should expose state and keyboard hooks."""
+        self._login(app, client)
+        response = client.get('/')
+
+        assert response.status_code == 200
+        assert b'class="nav-dropdown-trigger' in response.data
+        assert b'aria-haspopup="true"' in response.data
+        assert b'aria-expanded="false"' in response.data
+        assert b'aria-label="Toggle navigation menu"' in response.data
+
     def test_search_accessible_when_logged_in(self, app, client):
         """Test that search page is accessible when logged in."""
         self._login(app, client)
         response = client.get('/search')
         assert response.status_code == 200
+
+    def test_build_music_round_tag_select_has_label(self, app, client):
+        """The tag round select should have an explicit accessible label."""
+        self._login(app, client)
+        response = client.get('/build-music-round')
+
+        assert response.status_code == 200
+        assert b'for="tag_name"' in response.data
+        assert b'id="tag_name"' in response.data
+
+    def test_audio_settings_controls_have_explicit_labels(self, app, client):
+        """Audio settings should render unique input ids and matching labels."""
+        self._login(app, client)
+        app.config['OPENAI_API_KEY'] = 'test-openai-key'
+
+        response = client.get('/users/audio-settings?tts_service=openai')
+
+        assert response.status_code == 200
+        assert b'for="intro_audio_file"' in response.data
+        assert b'id="intro_audio_file"' in response.data
+        assert b'for="outro_audio_file"' in response.data
+        assert b'id="outro_audio_file"' in response.data
+        assert b'for="replay_audio_file"' in response.data
+        assert b'id="replay_audio_file"' in response.data
+        assert b'for="intro_tts_service"' in response.data
+        assert b'id="intro_tts_service"' in response.data
+        assert b'for="outro_tts_voice"' in response.data
+        assert b'id="outro_tts_voice"' in response.data
+        assert b'for="replay_tts_text"' in response.data
+        assert b'id="replay_tts_text"' in response.data
 
     def test_index_accessible_when_logged_in(self, app, client):
         """Test that homepage is accessible when logged in."""


### PR DESCRIPTION
## Summary

- Makes the header dropdowns keyboard-accessible with explicit menu state, focus rings, Escape/arrow handling, and mobile menu labels.
- Adds explicit labels and stable IDs to tag round generation and custom audio upload/TTS controls.
- Gives song library and round detail preview/actions descriptive labels and larger stable targets.
- Lazy-loads round detail preview audio instead of rendering narrow native players immediately.

Closes #166.
Closes #167.
Closes #168.
Closes #169.

## Validation

- `git diff --check`
- `SECRET_KEY=test-secret AUTOMATION_TOKEN=test-token .venv/bin/pytest tests/test_routes.py::TestAuthenticatedRoutes::test_navigation_dropdowns_are_keyboard_accessible tests/test_routes.py::TestAuthenticatedRoutes::test_build_music_round_tag_select_has_label tests/test_routes.py::TestAuthenticatedRoutes::test_audio_settings_controls_have_explicit_labels tests/test_final_coverage.py::TestCoreViewSongs tests/test_rounds_routes.py::TestRoundDetailRoute -q`