### PR TITLE
Make analytics signals actionable

### DIFF
--- a/musicround/routes/core.py
+++ b/musicround/routes/core.py
@@ -383,19 +383,42 @@ def view_songs():
     per_page = _int_arg('per_page', default=25, minimum=1, maximum=200)
     query_text = (request.args.get('q') or '').strip()
     genre = (request.args.get('genre') or '').strip()
+    has_preview = (request.args.get('has_preview') or '').strip().lower()
     year = _int_arg('year')
     used_min = _int_arg('used_min', minimum=0)
+    used_max = _int_arg('used_max', minimum=0)
 
     query = Song.query
     if query_text:
         pattern = f'%{query_text}%'
         query = query.filter(or_(Song.title.ilike(pattern), Song.artist.ilike(pattern)))
-    if genre:
+    if genre == '__missing__':
+        query = query.filter(or_(Song.genre.is_(None), Song.genre == '', Song.genre.ilike('unknown')))
+    elif genre:
         query = query.filter(Song.genre.ilike(genre))
+    preview_filters = [
+        Song.preview_url.isnot(None),
+        Song.spotify_preview_url.isnot(None),
+        Song.deezer_preview_url.isnot(None),
+        Song.apple_preview_url.isnot(None),
+        Song.youtube_preview_url.isnot(None),
+    ]
+    if has_preview in {'true', '1', 'yes'}:
+        query = query.filter(or_(*preview_filters))
+    elif has_preview in {'false', '0', 'no'}:
+        query = query.filter(
+            Song.preview_url.is_(None),
+            Song.spotify_preview_url.is_(None),
+            Song.deezer_preview_url.is_(None),
+            Song.apple_preview_url.is_(None),
+            Song.youtube_preview_url.is_(None),
+        )
     if year is not None:
         query = query.filter(Song.year == year)
     if used_min is not None:
         query = query.filter(Song.used_count >= used_min)
+    if used_max is not None:
+        query = query.filter(or_(Song.used_count <= used_max, Song.used_count.is_(None)))
 
     query = query.order_by(Song.artist.asc(), Song.title.asc(), Song.id.asc())
     pagination = query.paginate(page=page, per_page=per_page, error_out=False)
@@ -413,8 +436,10 @@ def view_songs():
     query_args = {
         'q': query_text or None,
         'genre': genre or None,
+        'has_preview': has_preview or None,
         'year': year,
         'used_min': used_min,
+        'used_max': used_max,
         'per_page': per_page,
     }
     query_args = {key: value for key, value in query_args.items() if value not in (None, '')}
@@ -428,8 +453,10 @@ def view_songs():
         filters={
             'q': query_text,
             'genre': genre,
+            'has_preview': has_preview,
             'year': year,
             'used_min': used_min,
+            'used_max': used_max,
             'per_page': per_page,
         },
         total_songs=total_songs,

--- a/musicround/services/automation.py
+++ b/musicround/services/automation.py
@@ -2446,14 +2446,32 @@ def round_analytics_summary(months: int = 6, limit: int = 20) -> dict[str, Any]:
     )
     missing_preview_count = Song.query.filter(
         Song.preview_url.is_(None),
-        Song.deezer_preview_url.is_(None),
         Song.spotify_preview_url.is_(None),
+        Song.deezer_preview_url.is_(None),
+        Song.apple_preview_url.is_(None),
+        Song.youtube_preview_url.is_(None),
     ).count()
 
-    genre_rows = db.session.query(Song.genre, db.func.count(Song.id)).group_by(Song.genre).all()
+    genre_rows = db.session.query(Song.genre).all()
+    unknown_genre_count = 0
+    genre_counts_by_key: dict[str, int] = {}
+    genre_labels_by_key: dict[str, str] = {}
+    for (raw_genre,) in genre_rows:
+        genre_label = " ".join((raw_genre or "").strip().split())
+        if not genre_label or genre_label.casefold() == "unknown":
+            unknown_genre_count += 1
+            continue
+
+        genre_key = genre_label.casefold()
+        genre_labels_by_key.setdefault(genre_key, genre_label)
+        genre_counts_by_key[genre_key] = genre_counts_by_key.get(genre_key, 0) + 1
+
     genre_counts = {
-        genre or "Unknown": count
-        for genre, count in sorted(genre_rows, key=lambda item: (-(item[1] or 0), item[0] or ""))
+        genre_labels_by_key[genre_key]: count
+        for genre_key, count in sorted(
+            genre_counts_by_key.items(),
+            key=lambda item: (-item[1], genre_labels_by_key[item[0]].casefold()),
+        )
     }
 
     return {
@@ -2463,6 +2481,7 @@ def round_analytics_summary(months: int = 6, limit: int = 20) -> dict[str, Any]:
         "round_count": Round.query.count(),
         "recent_round_count": recent_rounds,
         "missing_preview_count": missing_preview_count,
+        "unknown_genre_count": unknown_genre_count,
         "genre_counts": genre_counts,
         "most_used_songs": [_song_summary(song) for song in most_used],
         "unused_candidates": [_song_summary(song) for song in stale_candidates],

--- a/musicround/templates/round_analytics.html
+++ b/musicround/templates/round_analytics.html
@@ -23,11 +23,20 @@
     </div>
 
     {% if summary %}
-    <div class="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
+    <div class="grid grid-cols-1 md:grid-cols-5 gap-4 mb-6">
         <div class="bg-white shadow-md rounded-lg p-5"><div class="text-sm text-gray-500">Songs</div><div class="text-3xl font-bold text-navy-800">{{ summary.song_count }}</div></div>
         <div class="bg-white shadow-md rounded-lg p-5"><div class="text-sm text-gray-500">Rounds</div><div class="text-3xl font-bold text-navy-800">{{ summary.round_count }}</div></div>
         <div class="bg-white shadow-md rounded-lg p-5"><div class="text-sm text-gray-500">Recent Rounds</div><div class="text-3xl font-bold text-navy-800">{{ summary.recent_round_count }}</div></div>
-        <div class="bg-white shadow-md rounded-lg p-5"><div class="text-sm text-gray-500">Missing Previews</div><div class="text-3xl font-bold text-red-700">{{ summary.missing_preview_count }}</div></div>
+        <a href="{{ url_for('core.view_songs', has_preview='false') }}" class="block bg-white shadow-md rounded-lg p-5 hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-red-300" aria-label="Review {{ summary.missing_preview_count }} songs with missing previews">
+            <div class="text-sm text-gray-500">Missing Previews</div>
+            <div class="text-3xl font-bold text-red-700">{{ summary.missing_preview_count }}</div>
+            <div class="mt-2 text-xs font-semibold text-red-700">Review songs</div>
+        </a>
+        <a href="{{ url_for('core.view_songs', genre='__missing__') }}" class="block bg-white shadow-md rounded-lg p-5 hover:bg-orange-50 focus:outline-none focus:ring-2 focus:ring-orange-300" aria-label="Review {{ summary.unknown_genre_count|default(0) }} songs with unknown genre metadata">
+            <div class="text-sm text-gray-500">Unknown Genres</div>
+            <div class="text-3xl font-bold text-orange-700">{{ summary.unknown_genre_count|default(0) }}</div>
+            <div class="mt-2 text-xs font-semibold text-orange-700">Clean metadata</div>
+        </a>
     </div>
 
     <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
@@ -35,32 +44,71 @@
             <h2 class="text-xl font-bold text-navy-800 font-montserrat mb-3">Most Used</h2>
             <div class="space-y-2">
                 {% for song in summary.most_used_songs %}
-                <div class="border-b border-gray-100 pb-2">
-                    <div class="font-semibold">{{ song.artist }} - {{ song.title }}</div>
-                    <div class="text-xs text-gray-500">Used {{ song.used_count or 0 }}x{% if song.last_used %} · {{ song.last_used }}{% endif %}</div>
+                <div class="border-b border-gray-100 pb-2 flex items-start justify-between gap-3">
+                    <div>
+                        <div class="font-semibold">{{ song.artist }} - {{ song.title }}</div>
+                        <div class="text-xs text-gray-500">Used {{ song.used_count or 0 }}x{% if song.last_used %} · {{ song.last_used }}{% endif %}</div>
+                    </div>
+                    <a href="{{ url_for('core.view_songs', q=song.artist ~ ' ' ~ song.title) }}" class="shrink-0 text-xs font-semibold text-teal-700 hover:text-teal-900 focus:outline-none focus:ring-2 focus:ring-teal-300 rounded px-2 py-1" aria-label="Inspect {{ song.title }} by {{ song.artist }} in the song library">Inspect</a>
                 </div>
+                {% else %}
+                <div class="text-sm text-gray-500">No usage data yet. Generate or approve rounds to build fatigue signals.</div>
                 {% endfor %}
+            </div>
+            <div class="mt-4">
+                <a href="{{ url_for('rounds.round_planning', theme='avoid overused songs') }}" class="inline-flex items-center text-sm font-semibold text-navy-800 hover:text-teal-700 focus:outline-none focus:ring-2 focus:ring-teal-300 rounded px-2 py-1">
+                    Plan around fatigue <i class="fas fa-arrow-right ml-2"></i>
+                </a>
             </div>
         </div>
         <div class="bg-white shadow-md rounded-lg p-6">
-            <h2 class="text-xl font-bold text-navy-800 font-montserrat mb-3">Unused Candidates</h2>
+            <div class="flex items-start justify-between gap-3 mb-3">
+                <h2 class="text-xl font-bold text-navy-800 font-montserrat">Unused Candidates</h2>
+                <a href="{{ url_for('core.view_songs', used_max=0) }}" class="text-xs font-semibold text-teal-700 hover:text-teal-900 focus:outline-none focus:ring-2 focus:ring-teal-300 rounded px-2 py-1">Open all</a>
+            </div>
             <div class="space-y-2">
                 {% for song in summary.unused_candidates %}
-                <div class="border-b border-gray-100 pb-2">
-                    <div class="font-semibold">{{ song.artist }} - {{ song.title }}</div>
-                    <div class="text-xs text-gray-500">{{ song.year or 'Unknown year' }}{% if song.genre %} · {{ song.genre }}{% endif %}</div>
+                <div class="border-b border-gray-100 pb-2 flex items-start justify-between gap-3">
+                    <div>
+                        <div class="font-semibold">{{ song.artist }} - {{ song.title }}</div>
+                        <div class="text-xs text-gray-500">{{ song.year or 'Unknown year' }}{% if song.genre %} · {{ song.genre }}{% endif %}</div>
+                    </div>
+                    <a href="{{ url_for('core.view_songs', q=song.artist ~ ' ' ~ song.title, used_max=0) }}" class="shrink-0 text-xs font-semibold text-teal-700 hover:text-teal-900 focus:outline-none focus:ring-2 focus:ring-teal-300 rounded px-2 py-1" aria-label="Inspect unused candidate {{ song.title }} by {{ song.artist }}">Inspect</a>
                 </div>
+                {% else %}
+                <div class="text-sm text-gray-500">No unused candidates match this limit. Raise the limit or import more songs.</div>
                 {% endfor %}
+            </div>
+            <div class="mt-4">
+                <a href="{{ url_for('rounds.round_planning', theme='unused candidate discovery') }}" class="inline-flex items-center text-sm font-semibold text-navy-800 hover:text-teal-700 focus:outline-none focus:ring-2 focus:ring-teal-300 rounded px-2 py-1">
+                    Create planning brief <i class="fas fa-arrow-right ml-2"></i>
+                </a>
             </div>
         </div>
         <div class="bg-white shadow-md rounded-lg p-6">
-            <h2 class="text-xl font-bold text-navy-800 font-montserrat mb-3">Genres</h2>
-            <div class="space-y-2">
+            <div class="flex items-start justify-between gap-3 mb-3">
+                <div>
+                    <h2 class="text-xl font-bold text-navy-800 font-montserrat">Genres</h2>
+                    {% if summary.unknown_genre_count|default(0) > 0 %}
+                    <p class="text-xs text-orange-700 mt-1">{{ summary.unknown_genre_count }} songs need metadata cleanup before genre balance is meaningful.</p>
+                    {% endif %}
+                </div>
+                {% if summary.unknown_genre_count|default(0) > 0 %}
+                <a href="{{ url_for('core.view_songs', genre='__missing__') }}" class="text-xs font-semibold text-orange-700 hover:text-orange-900 focus:outline-none focus:ring-2 focus:ring-orange-300 rounded px-2 py-1">Clean up</a>
+                {% endif %}
+            </div>
+            <div class="space-y-3">
                 {% for genre, count in summary.genre_counts.items() %}
                 <div>
-                    <div class="flex justify-between text-sm"><span>{{ genre }}</span><span>{{ count }}</span></div>
+                    <div class="flex justify-between gap-3 text-sm">
+                        <a href="{{ url_for('core.view_songs', genre=genre) }}" class="font-semibold text-navy-800 hover:text-teal-700 focus:outline-none focus:ring-2 focus:ring-teal-300 rounded" aria-label="Filter song library for {{ genre }} songs">{{ genre }}</a>
+                        <span>{{ count }}</span>
+                    </div>
                     <div class="h-2 bg-gray-100 rounded"><div class="h-2 bg-teal-500 rounded" style="width: {{ (count / summary.song_count * 100) if summary.song_count else 0 }}%"></div></div>
+                    <a href="{{ url_for('rounds.round_planning', theme='genre: ' ~ genre) }}" class="mt-1 inline-block text-xs font-semibold text-teal-700 hover:text-teal-900 focus:outline-none focus:ring-2 focus:ring-teal-300 rounded px-1" aria-label="Create planning brief for {{ genre }}">Plan this genre</a>
                 </div>
+                {% else %}
+                <div class="text-sm text-gray-500">No clean genre metadata yet. Start by cleaning unknown genres.</div>
                 {% endfor %}
             </div>
         </div>

--- a/musicround/templates/view_songs.html
+++ b/musicround/templates/view_songs.html
@@ -175,6 +175,21 @@
                     </div>
 
                     <div class="w-full md:w-1/6">
+                        <label for="previewFilter" class="block text-sm font-medium text-gray-700 mb-1">Preview</label>
+                        <select id="previewFilter" name="has_preview" class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-teal-500">
+                            <option value="" {% if not filters.has_preview %}selected{% endif %}>Any</option>
+                            <option value="true" {% if filters.has_preview in ['true', '1', 'yes'] %}selected{% endif %}>Has preview</option>
+                            <option value="false" {% if filters.has_preview in ['false', '0', 'no'] %}selected{% endif %}>Missing preview</option>
+                        </select>
+                    </div>
+
+                    <div class="w-full md:w-1/6">
+                        <label for="usedMaxFilter" class="block text-sm font-medium text-gray-700 mb-1">Used at most</label>
+                        <input type="number" id="usedMaxFilter" name="used_max" min="0" value="{{ filters.used_max if filters.used_max is not none else '' }}"
+                            class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-teal-500">
+                    </div>
+
+                    <div class="w-full md:w-1/6">
                         <label for="pageSizeSelect" class="block text-sm font-medium text-gray-700 mb-1">Records per page</label>
                         <select id="pageSizeSelect" name="per_page" class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-teal-500">
                             {% for size in [25, 50, 100, 200] %}
@@ -681,7 +696,7 @@
             }
             
             // Set up filter input handlers
-            $('#globalSearch, #genreFilter, #yearFilter').on('keydown', function(e) {
+            $('#globalSearch, #genreFilter, #yearFilter, #previewFilter, #usedMaxFilter').on('keydown', function(e) {
                 if (e.key === 'Enter') {
                     e.preventDefault();
                     $('#songLibraryFilters').trigger('submit');

--- a/tests/test_automation_service.py
+++ b/tests/test_automation_service.py
@@ -1605,12 +1605,15 @@ class TestAgentPlanningAutomation:
             _create_song(title="Used", artist="A", genre="Rock", used_count=4)
             _create_song(title="Unused", artist="B", genre="Pop", used_count=0)
             _create_song(title="No Preview", artist="C", genre="Rock")
+            _create_song(title="Unknown Genre", artist="D", genre="Unknown", preview_url="https://example.test/unknown.mp3")
 
             result = automation.round_analytics_summary(months=6, limit=5)
 
-            assert result["song_count"] == 3
+            assert result["song_count"] == 4
             assert result["missing_preview_count"] == 3
+            assert result["unknown_genre_count"] == 1
             assert result["genre_counts"]["Rock"] == 2
+            assert "Unknown" not in result["genre_counts"]
             assert result["most_used_songs"][0]["title"] == "Used"
             assert any(song["title"] == "Unused" for song in result["unused_candidates"])
 

--- a/tests/test_final_coverage.py
+++ b/tests/test_final_coverage.py
@@ -740,3 +740,31 @@ class TestCoreViewSongs:
         assert b'Server Match' in response.data
         assert b'Server Miss' not in response.data
         assert b'Filters are applied server-side' in response.data
+
+    def test_view_songs_supports_analytics_action_filters(self, app, client):
+        """Analytics links should land on actionable song-library filters."""
+        _login(app, client)
+        with app.app_context():
+            db.session.add(Song(title='Missing Preview', artist='Analytics', genre='Rock', used_count=0))
+            db.session.add(
+                Song(
+                    title='Has Preview',
+                    artist='Analytics',
+                    genre='Rock',
+                    used_count=3,
+                    preview_url='https://example.com/has-preview.mp3',
+                )
+            )
+            db.session.add(Song(title='Unknown Genre', artist='Analytics', genre='Unknown', used_count=0))
+            db.session.commit()
+
+        missing_preview = client.get('/view-songs?has_preview=false')
+        unused = client.get('/view-songs?used_max=0')
+        missing_genre = client.get('/view-songs?genre=__missing__')
+
+        assert b'Missing Preview' in missing_preview.data
+        assert b'Has Preview' not in missing_preview.data
+        assert b'Missing Preview' in unused.data
+        assert b'Has Preview' not in unused.data
+        assert b'Unknown Genre' in missing_genre.data
+        assert b'Has Preview' not in missing_genre.data

--- a/tests/test_rounds_routes.py
+++ b/tests/test_rounds_routes.py
@@ -252,6 +252,9 @@ class TestRoundsListRoute:
         assert response.status_code == 200
         assert b'Round Analytics' in response.data
         assert b'Missing Previews' in response.data
+        assert b'/view-songs?has_preview=false' in response.data
+        assert b'/view-songs?genre=__missing__' in response.data
+        assert b'Create planning brief' in response.data
 
     def test_round_planning_page_renders_brief(self, app, client):
         """Planning page should turn quizmaster context into a brief."""


### PR DESCRIPTION
## Summary

- Adds actionable drill-through filters from Round Analytics to the song library for missing previews, unknown genre metadata, unused songs, and individual songs.
- Adds visible song-library filters for preview availability and max usage count so analytics links land on editable/reviewable queues.
- Separates `Unknown` genre metadata debt from the meaningful genre distribution and normalizes genre labels before counting.
- Adds planning brief links from fatigue, unused-candidate, and genre signals.

Closes #170.

## Validation

- `git diff --check origin/main...HEAD`
- `SECRET_KEY=test-secret AUTOMATION_TOKEN=test-token .venv/bin/pytest tests/test_automation_service.py -k round_analytics_summary_reports_catalog_health -q`
- `SECRET_KEY=test-secret AUTOMATION_TOKEN=test-token .venv/bin/pytest tests/test_rounds_routes.py::TestRoundsListRoute::test_round_analytics_page_renders_summary tests/test_final_coverage.py::TestCoreViewSongs::test_view_songs_supports_analytics_action_filters tests/test_final_coverage.py::TestCoreViewSongs::test_view_songs_lazy_loads_preview_players -q`