### PR TITLE
Fix analytics genre drillthrough

### DIFF
--- a/musicround/routes/core.py
+++ b/musicround/routes/core.py
@@ -392,10 +392,17 @@ def view_songs():
     if query_text:
         pattern = f'%{query_text}%'
         query = query.filter(or_(Song.title.ilike(pattern), Song.artist.ilike(pattern)))
+    normalized_genre = func.lower(func.trim(Song.genre))
     if genre == '__missing__':
-        query = query.filter(or_(Song.genre.is_(None), Song.genre == '', Song.genre.ilike('unknown')))
+        query = query.filter(
+            or_(
+                Song.genre.is_(None),
+                normalized_genre == '',
+                normalized_genre == 'unknown',
+            )
+        )
     elif genre:
-        query = query.filter(Song.genre.ilike(genre))
+        query = query.filter(normalized_genre == genre.casefold())
     preview_filters = [
         Song.preview_url.isnot(None),
         Song.spotify_preview_url.isnot(None),

--- a/musicround/services/automation.py
+++ b/musicround/services/automation.py
@@ -2452,7 +2452,7 @@ def round_analytics_summary(months: int = 6, limit: int = 20) -> dict[str, Any]:
         Song.youtube_preview_url.is_(None),
     ).count()
 
-    genre_rows = db.session.query(Song.genre).all()
+    genre_rows = db.session.query(Song.genre).order_by(Song.id.asc()).yield_per(1000)
     unknown_genre_count = 0
     genre_counts_by_key: dict[str, int] = {}
     genre_labels_by_key: dict[str, str] = {}

--- a/tests/test_automation_service.py
+++ b/tests/test_automation_service.py
@@ -1606,13 +1606,15 @@ class TestAgentPlanningAutomation:
             _create_song(title="Unused", artist="B", genre="Pop", used_count=0)
             _create_song(title="No Preview", artist="C", genre="Rock")
             _create_song(title="Unknown Genre", artist="D", genre="Unknown", preview_url="https://example.test/unknown.mp3")
+            _create_song(title="Spaced Genre", artist="E", genre=" rock ", used_count=0)
+            _create_song(title="Blank Genre", artist="F", genre="   ", used_count=0)
 
             result = automation.round_analytics_summary(months=6, limit=5)
 
-            assert result["song_count"] == 4
-            assert result["missing_preview_count"] == 3
-            assert result["unknown_genre_count"] == 1
-            assert result["genre_counts"]["Rock"] == 2
+            assert result["song_count"] == 6
+            assert result["missing_preview_count"] == 5
+            assert result["unknown_genre_count"] == 2
+            assert result["genre_counts"]["Rock"] == 3
             assert "Unknown" not in result["genre_counts"]
             assert result["most_used_songs"][0]["title"] == "Used"
             assert any(song["title"] == "Unused" for song in result["unused_candidates"])

--- a/tests/test_final_coverage.py
+++ b/tests/test_final_coverage.py
@@ -756,15 +756,23 @@ class TestCoreViewSongs:
                 )
             )
             db.session.add(Song(title='Unknown Genre', artist='Analytics', genre='Unknown', used_count=0))
+            db.session.add(Song(title='Spaced Unknown Genre', artist='Analytics', genre=' Unknown ', used_count=0))
+            db.session.add(Song(title='Blank Genre', artist='Analytics', genre='   ', used_count=0))
+            db.session.add(Song(title='Spaced Rock', artist='Analytics', genre=' Rock ', used_count=0))
             db.session.commit()
 
         missing_preview = client.get('/view-songs?has_preview=false')
         unused = client.get('/view-songs?used_max=0')
         missing_genre = client.get('/view-songs?genre=__missing__')
+        rock_genre = client.get('/view-songs?genre=Rock')
 
         assert b'Missing Preview' in missing_preview.data
         assert b'Has Preview' not in missing_preview.data
         assert b'Missing Preview' in unused.data
         assert b'Has Preview' not in unused.data
         assert b'Unknown Genre' in missing_genre.data
+        assert b'Spaced Unknown Genre' in missing_genre.data
+        assert b'Blank Genre' in missing_genre.data
         assert b'Has Preview' not in missing_genre.data
+        assert b'Spaced Rock' in rock_genre.data
+        assert b'Unknown Genre' not in rock_genre.data


### PR DESCRIPTION
## Summary
- normalize song-library genre filters with trim/lower so analytics drill-through links match whitespace and unknown cleanup cases
- stream analytics genre rows with stable ordering instead of materializing all rows at once
- add regression coverage for normalized missing/genre filters and catalog health counts

## Tests
- python3 -m py_compile musicround/routes/core.py musicround/services/automation.py tests/test_final_coverage.py tests/test_automation_service.py
- git diff --check
- FLASK_ENV=testing SECRET_KEY=ci-test-secret-key AUTOMATION_TOKEN=ci-test-automation-token /tmp/qb-164-followup-py312/bin/python -m pytest tests/test_final_coverage.py tests/test_automation_service.py -q