### PR TITLE
Normalize multi-word genre filters

### DIFF
--- a/musicround/routes/core.py
+++ b/musicround/routes/core.py
@@ -383,6 +383,7 @@ def view_songs():
     per_page = _int_arg('per_page', default=25, minimum=1, maximum=200)
     query_text = (request.args.get('q') or '').strip()
     genre = (request.args.get('genre') or '').strip()
+    normalized_genre_filter = " ".join(genre.split()).lower()
     has_preview = (request.args.get('has_preview') or '').strip().lower()
     year = _int_arg('year')
     used_min = _int_arg('used_min', minimum=0)
@@ -392,7 +393,12 @@ def view_songs():
     if query_text:
         pattern = f'%{query_text}%'
         query = query.filter(or_(Song.title.ilike(pattern), Song.artist.ilike(pattern)))
-    normalized_genre = func.lower(func.trim(Song.genre))
+    normalized_genre = Song.genre
+    for whitespace in ("\t", "\n", "\r"):
+        normalized_genre = func.replace(normalized_genre, whitespace, " ")
+    for _ in range(6):
+        normalized_genre = func.replace(normalized_genre, "  ", " ")
+    normalized_genre = func.lower(func.trim(normalized_genre))
     if genre == '__missing__':
         query = query.filter(
             or_(
@@ -401,8 +407,8 @@ def view_songs():
                 normalized_genre == 'unknown',
             )
         )
-    elif genre:
-        query = query.filter(normalized_genre == genre.casefold())
+    elif normalized_genre_filter:
+        query = query.filter(normalized_genre == normalized_genre_filter)
     preview_filters = [
         Song.preview_url.isnot(None),
         Song.spotify_preview_url.isnot(None),

--- a/tests/test_final_coverage.py
+++ b/tests/test_final_coverage.py
@@ -759,12 +759,14 @@ class TestCoreViewSongs:
             db.session.add(Song(title='Spaced Unknown Genre', artist='Analytics', genre=' Unknown ', used_count=0))
             db.session.add(Song(title='Blank Genre', artist='Analytics', genre='   ', used_count=0))
             db.session.add(Song(title='Spaced Rock', artist='Analytics', genre=' Rock ', used_count=0))
+            db.session.add(Song(title='Spaced Hip Hop', artist='Analytics', genre=' Hip   Hop ', used_count=0))
             db.session.commit()
 
         missing_preview = client.get('/view-songs?has_preview=false')
         unused = client.get('/view-songs?used_max=0')
         missing_genre = client.get('/view-songs?genre=__missing__')
         rock_genre = client.get('/view-songs?genre=Rock')
+        hip_hop_genre = client.get('/view-songs?genre=Hip+Hop')
 
         assert b'Missing Preview' in missing_preview.data
         assert b'Has Preview' not in missing_preview.data
@@ -776,3 +778,5 @@ class TestCoreViewSongs:
         assert b'Has Preview' not in missing_genre.data
         assert b'Spaced Rock' in rock_genre.data
         assert b'Unknown Genre' not in rock_genre.data
+        assert b'Spaced Hip Hop' in hip_hop_genre.data
+        assert b'Spaced Rock' not in hip_hop_genre.data


### PR DESCRIPTION
## Summary
- normalize /view-songs genre query parameters with the same whitespace collapsing used by analytics labels
- collapse stored genre whitespace in SQL before lower/trim comparisons
- add regression coverage for multi-word genres with repeated internal whitespace

## Tests
- python3 -m py_compile musicround/routes/core.py tests/test_final_coverage.py
- git diff --check
- FLASK_ENV=testing SECRET_KEY=ci-test-secret-key AUTOMATION_TOKEN=ci-test-automation-token /tmp/qb-164-followup-py312/bin/python -m pytest tests/test_final_coverage.py -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved genre filtering on the songs page so searches handle extra spaces, tabs, and mixed capitalization more reliably.
  * Better matches now appear when a genre is entered with inconsistent whitespace, while unrelated genres are still excluded.
* **Tests**
  * Expanded coverage for genre filtering to verify matches with whitespace-variant genre values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->