### PR TITLE
Tighten genre whitespace normalization

### DIFF
--- a/musicround/routes/core.py
+++ b/musicround/routes/core.py
@@ -383,7 +383,7 @@ def view_songs():
     per_page = _int_arg('per_page', default=25, minimum=1, maximum=200)
     query_text = (request.args.get('q') or '').strip()
     genre = (request.args.get('genre') or '').strip()
-    normalized_genre_filter = " ".join(genre.split()).lower()
+    normalized_genre_filter = " ".join(genre.split()).casefold()
     has_preview = (request.args.get('has_preview') or '').strip().lower()
     year = _int_arg('year')
     used_min = _int_arg('used_min', minimum=0)
@@ -396,7 +396,7 @@ def view_songs():
     normalized_genre = Song.genre
     for whitespace in ("\t", "\n", "\r"):
         normalized_genre = func.replace(normalized_genre, whitespace, " ")
-    for _ in range(6):
+    for _ in range(7):
         normalized_genre = func.replace(normalized_genre, "  ", " ")
     normalized_genre = func.lower(func.trim(normalized_genre))
     if genre == '__missing__':

--- a/tests/test_final_coverage.py
+++ b/tests/test_final_coverage.py
@@ -766,7 +766,7 @@ class TestCoreViewSongs:
         unused = client.get('/view-songs?used_max=0')
         missing_genre = client.get('/view-songs?genre=__missing__')
         rock_genre = client.get('/view-songs?genre=Rock')
-        hip_hop_genre = client.get('/view-songs?genre=Hip+Hop')
+        hip_hop_genre = client.get('/view-songs?genre=Hip+++Hop')
 
         assert b'Missing Preview' in missing_preview.data
         assert b'Has Preview' not in missing_preview.data


### PR DESCRIPTION
## Summary
- use casefold for request-side genre normalization
- collapse max-length stored genre whitespace with a seventh SQL replace pass
- cover repeated spaces in the genre query parameter

## Validation
- python3 -m py_compile musicround/routes/core.py tests/test_final_coverage.py
- git diff --check
- FLASK_ENV=testing SECRET_KEY=ci-test-secret-key AUTOMATION_TOKEN=ci-test-automation-token /tmp/qb-164-followup-py312/bin/python -m pytest tests/test_final_coverage.py -q