### PR TITLE
Add managed database preflight

### DIFF
--- a/docs/admin-guide/managed-database-migration.md
+++ b/docs/admin-guide/managed-database-migration.md
@@ -27,6 +27,21 @@ database to a managed SQL database without exposing credentials in logs or Git.
    kubectl -n quizzicalbeats exec deploy/quizzicalbeats -c web -- python /app/run.py database status
    ```
 
+   Before the managed database cutover, run the stricter preflight. It fails
+   with exit code `78` while legacy SQLite is still active or the PG*
+   configuration is incomplete:
+
+   ```bash
+   kubectl -n quizzicalbeats exec deploy/quizzicalbeats -c web -- python /app/run.py database preflight
+   ```
+
+   During early migration work, use `--allow-sqlite` only to collect the same
+   diagnostics without blocking on the current SQLite state:
+
+   ```bash
+   kubectl -n quizzicalbeats exec deploy/quizzicalbeats -c web -- python /app/run.py database preflight --allow-sqlite
+   ```
+
 2. Create a final SQLite backup before migration:
 
    ```bash
@@ -52,7 +67,7 @@ database to a managed SQL database without exposing credentials in logs or Git.
 3. Start the app against the disposable managed URI and run:
 
    ```bash
-   python /app/run.py database status
+   python /app/run.py database preflight
    python -m pytest tests/test_app_factory.py tests/test_automation_service.py
    ```
 
@@ -96,7 +111,7 @@ database to a managed SQL database without exposing credentials in logs or Git.
 4. Verify without printing credentials:
 
    ```bash
-   kubectl -n quizzicalbeats exec deploy/quizzicalbeats -c web -- python /app/run.py database status
+   kubectl -n quizzicalbeats exec deploy/quizzicalbeats -c web -- python /app/run.py database preflight
    kubectl -n quizzicalbeats exec deploy/quizzicalbeats -c web -- python - <<'PY'
    from musicround import create_app, db
    from musicround.models import Song, Round, User
@@ -109,8 +124,8 @@ database to a managed SQL database without exposing credentials in logs or Git.
 5. Verify web, MCP, and scheduled-email execution share the same config:
 
    ```bash
-   kubectl -n quizzicalbeats exec deploy/quizzicalbeats -c web -- python /app/run.py database status
-   kubectl -n quizzicalbeats exec deploy/quizzicalbeats-mcp -c mcp -- python /app/run.py database status
+   kubectl -n quizzicalbeats exec deploy/quizzicalbeats -c web -- python /app/run.py database preflight
+   kubectl -n quizzicalbeats exec deploy/quizzicalbeats-mcp -c mcp -- python /app/run.py database preflight
    kubectl -n quizzicalbeats create job --from=cronjob/quizzicalbeats-scheduled-email qb-db-cutover-smoke
    ```
 

--- a/musicround/helpers/database_config.py
+++ b/musicround/helpers/database_config.py
@@ -105,6 +105,22 @@ def database_uri_from_postgres_env(environ) -> str | None:
     return urlunsplit((scheme, netloc, f"/{database}", query, ""))
 
 
+def postgres_env_readiness(environ) -> dict[str, list[str] | bool]:
+    """Return credential-safe readiness details for PG* database variables."""
+    required_keys = ["PGHOST", "PGDATABASE", "PGUSER", "PGPASSWORD"]
+    optional_keys = ["PGPORT", "PGSSLMODE", "SQLALCHEMY_POSTGRES_SCHEME"]
+    present_required = [name for name in required_keys if environ.get(name)]
+    missing_required = [name for name in required_keys if not environ.get(name)]
+    present_optional = [name for name in optional_keys if environ.get(name)]
+    return {
+        "configured": bool(present_required),
+        "complete": not missing_required,
+        "present_required": present_required,
+        "missing_required": missing_required,
+        "present_optional": present_optional,
+    }
+
+
 def redact_database_uri(uri: str | None) -> str:
     """Redact credentials from a database URI without hiding the backend."""
     if not uri:

--- a/run.py
+++ b/run.py
@@ -30,6 +30,15 @@ def main():
     database_parser = subparsers.add_parser('database', help='Database diagnostics')
     database_subparsers = database_parser.add_subparsers(dest='database_action', help='Database action to perform')
     database_subparsers.add_parser('status', help='Print the configured database backend without credentials')
+    preflight_parser = database_subparsers.add_parser(
+        'preflight',
+        help='Validate managed database readiness without printing credentials',
+    )
+    preflight_parser.add_argument(
+        '--allow-sqlite',
+        action='store_true',
+        help='Report diagnostics without failing on SQLite; useful before cutover work starts',
+    )
 
     health_parser = subparsers.add_parser('health', help='Health diagnostics')
     health_subparsers = health_parser.add_subparsers(dest='health_action', help='Health action to perform')
@@ -64,26 +73,59 @@ def main():
         from flask import Flask
         from musicround import _configure_database_uri
         from musicround.config import Config
-        from musicround.helpers.database_config import database_summary, is_legacy_data_sqlite_uri
+        from musicround.helpers.database_config import (
+            database_summary,
+            is_legacy_data_sqlite_uri,
+            postgres_env_readiness,
+        )
 
         app = Flask(__name__)
         app.config.from_object(Config)
+        if args.database_action == 'preflight' and not args.allow_sqlite:
+            app.config['DATABASE_REQUIRE_MANAGED'] = True
         try:
             _configure_database_uri(app)
         except RuntimeError as exc:
             print(f"Database configuration error: {exc}", file=sys.stderr)
+            readiness = postgres_env_readiness(os.environ)
+            if readiness["configured"] and not readiness["complete"]:
+                print(
+                    "PostgreSQL environment is incomplete; missing keys: "
+                    + ", ".join(readiness["missing_required"]),
+                    file=sys.stderr,
+                )
             return 78
         db_uri = app.config.get('SQLALCHEMY_DATABASE_URI')
         summary = database_summary(db_uri)
         print(f"Database backend: {summary['backend']}")
         print(f"Database target: {summary['redacted_uri']}")
         print(f"Managed database required: {bool(app.config.get('DATABASE_REQUIRE_MANAGED'))}")
+        readiness = postgres_env_readiness(os.environ)
+        if readiness["configured"]:
+            print(
+                "PostgreSQL env present: "
+                + ", ".join(readiness["present_required"] + readiness["present_optional"])
+            )
+            if readiness["missing_required"]:
+                print(
+                    "PostgreSQL env missing: "
+                    + ", ".join(readiness["missing_required"])
+                )
         if is_legacy_data_sqlite_uri(db_uri):
             print(
                 "Warning: legacy /data SQLite database is configured; "
                 "configure a managed SQL URI or complete PG* credentials via "
                 "secrets for production."
             )
+            if args.database_action == 'preflight' and not args.allow_sqlite:
+                print(
+                    "Preflight failed: managed database cutover is not ready "
+                    "while legacy SQLite is configured.",
+                    file=sys.stderr,
+                )
+                return 78
+        if args.database_action == 'preflight':
+            print("Database preflight passed.")
         return 0
     elif args.command == 'health':
         with contextlib.redirect_stdout(sys.stderr):

--- a/run.py
+++ b/run.py
@@ -81,19 +81,12 @@ def main():
 
         app = Flask(__name__)
         app.config.from_object(Config)
-        if args.database_action == 'preflight' and not args.allow_sqlite:
-            app.config['DATABASE_REQUIRE_MANAGED'] = True
+        if args.database_action == 'preflight':
+            app.config['DATABASE_REQUIRE_MANAGED'] = not args.allow_sqlite
         try:
             _configure_database_uri(app)
         except RuntimeError as exc:
             print(f"Database configuration error: {exc}", file=sys.stderr)
-            readiness = postgres_env_readiness(os.environ)
-            if readiness["configured"] and not readiness["complete"]:
-                print(
-                    "PostgreSQL environment is incomplete; missing keys: "
-                    + ", ".join(readiness["missing_required"]),
-                    file=sys.stderr,
-                )
             return 78
         db_uri = app.config.get('SQLALCHEMY_DATABASE_URI')
         summary = database_summary(db_uri)

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -20,6 +20,7 @@ from musicround.helpers.database_config import (
     database_summary,
     is_legacy_data_sqlite_uri,
     managed_database_requirement_error,
+    postgres_env_readiness,
     redact_database_uri,
 )
 from musicround.models import User, db
@@ -95,6 +96,22 @@ def test_configure_database_uri_rejects_partial_postgres_env(monkeypatch):
     import pytest
     with pytest.raises(RuntimeError, match='PostgreSQL environment is incomplete'):
         _configure_database_uri(app)
+
+
+def test_postgres_env_readiness_reports_only_key_names():
+    """PG readiness diagnostics should not expose configured values."""
+    readiness = postgres_env_readiness({
+        'PGHOST': 'postgres.example',
+        'PGDATABASE': 'quizzicalbeats',
+        'PGSSLMODE': 'require',
+    })
+
+    assert readiness['configured'] is True
+    assert readiness['complete'] is False
+    assert readiness['present_required'] == ['PGHOST', 'PGDATABASE']
+    assert readiness['missing_required'] == ['PGUSER', 'PGPASSWORD']
+    assert readiness['present_optional'] == ['PGSSLMODE']
+    assert 'postgres.example' not in repr(readiness)
 
 
 def test_configure_database_uri_uses_sqlite_fallback(monkeypatch):

--- a/tests/test_run_cli.py
+++ b/tests/test_run_cli.py
@@ -87,10 +87,13 @@ def test_database_preflight_blocks_legacy_sqlite_by_default(monkeypatch, capsys)
 def test_database_preflight_can_report_sqlite_without_blocking(monkeypatch, capsys):
     """Operators can inspect early migration state before the managed cutover."""
     import run
+    from musicround.config import Config
 
     monkeypatch.setenv("SECRET_KEY", "test-secret-key-for-testing-only")
     monkeypatch.setenv("AUTOMATION_TOKEN", "test-automation-token-for-testing")
     monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", "sqlite:////data/song_data.db")
+    monkeypatch.setenv("DATABASE_REQUIRE_MANAGED", "true")
+    monkeypatch.setattr(Config, "DATABASE_REQUIRE_MANAGED", True)
     monkeypatch.setattr(
         sys,
         "argv",
@@ -102,6 +105,7 @@ def test_database_preflight_can_report_sqlite_without_blocking(monkeypatch, caps
 
     assert exit_code == 0
     assert "Database backend: sqlite" in output
+    assert "Managed database required: False" in output
     assert "legacy /data SQLite database is configured" in output
     assert "Database preflight passed." in output
 

--- a/tests/test_run_cli.py
+++ b/tests/test_run_cli.py
@@ -62,3 +62,97 @@ def test_database_status_returns_safe_error_when_managed_guard_fails(monkeypatch
     assert "points at SQLite" in captured.err
     assert "Traceback" not in captured.err
     assert "/data/song_data.db" not in captured.err
+
+
+def test_database_preflight_blocks_legacy_sqlite_by_default(monkeypatch, capsys):
+    """The managed DB cutover preflight should fail before SQLite reaches prod."""
+    import run
+
+    monkeypatch.setenv("SECRET_KEY", "test-secret-key-for-testing-only")
+    monkeypatch.setenv("AUTOMATION_TOKEN", "test-automation-token-for-testing")
+    monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", "sqlite:////data/song_data.db")
+    monkeypatch.delenv("DATABASE_REQUIRE_MANAGED", raising=False)
+    monkeypatch.setattr(sys, "argv", ["run.py", "database", "preflight"])
+
+    exit_code = run.main()
+    captured = capsys.readouterr()
+
+    assert exit_code == 78
+    assert "Database configuration error:" in captured.err
+    assert "points at SQLite" in captured.err
+    assert "Traceback" not in captured.err
+    assert "/data/song_data.db" not in captured.err
+
+
+def test_database_preflight_can_report_sqlite_without_blocking(monkeypatch, capsys):
+    """Operators can inspect early migration state before the managed cutover."""
+    import run
+
+    monkeypatch.setenv("SECRET_KEY", "test-secret-key-for-testing-only")
+    monkeypatch.setenv("AUTOMATION_TOKEN", "test-automation-token-for-testing")
+    monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", "sqlite:////data/song_data.db")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["run.py", "database", "preflight", "--allow-sqlite"],
+    )
+
+    exit_code = run.main()
+    output = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert "Database backend: sqlite" in output
+    assert "legacy /data SQLite database is configured" in output
+    assert "Database preflight passed." in output
+
+
+def test_database_preflight_accepts_complete_pg_env(monkeypatch, capsys):
+    """A complete PG* setup should pass without exposing credentials."""
+    import run
+
+    monkeypatch.setenv("SECRET_KEY", "test-secret-key-for-testing-only")
+    monkeypatch.setenv("AUTOMATION_TOKEN", "test-automation-token-for-testing")
+    monkeypatch.delenv("SQLALCHEMY_DATABASE_URI", raising=False)
+    monkeypatch.setenv("PGHOST", "postgres.example")
+    monkeypatch.setenv("PGDATABASE", "quizzicalbeats")
+    monkeypatch.setenv("PGUSER", "qb_user")
+    monkeypatch.setenv("PGPASSWORD", "super-secret-password")
+    monkeypatch.setenv("PGSSLMODE", "require")
+    monkeypatch.setattr(sys, "argv", ["run.py", "database", "preflight"])
+
+    exit_code = run.main()
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "Database backend: postgresql" in captured.out
+    assert (
+        "PostgreSQL env present: PGHOST, PGDATABASE, PGUSER, PGPASSWORD, "
+        "PGSSLMODE"
+    ) in captured.out
+    assert "Database preflight passed." in captured.out
+    assert "super-secret-password" not in captured.out
+    assert "super-secret-password" not in captured.err
+
+
+def test_database_preflight_reports_missing_pg_keys_safely(monkeypatch, capsys):
+    """Incomplete PG* setup should fail with key names, not secret values."""
+    import run
+
+    monkeypatch.setenv("SECRET_KEY", "test-secret-key-for-testing-only")
+    monkeypatch.setenv("AUTOMATION_TOKEN", "test-automation-token-for-testing")
+    monkeypatch.delenv("SQLALCHEMY_DATABASE_URI", raising=False)
+    monkeypatch.setenv("PGHOST", "postgres.example")
+    monkeypatch.setenv("PGDATABASE", "quizzicalbeats")
+    monkeypatch.delenv("PGUSER", raising=False)
+    monkeypatch.delenv("PGPASSWORD", raising=False)
+    monkeypatch.setattr(sys, "argv", ["run.py", "database", "preflight"])
+
+    exit_code = run.main()
+    captured = capsys.readouterr()
+
+    assert exit_code == 78
+    assert "PostgreSQL environment is incomplete" in captured.err
+    assert "PGPASSWORD" in captured.err
+    assert "PGUSER" in captured.err
+    assert "postgres.example" not in captured.err
+    assert "Traceback" not in captured.err


### PR DESCRIPTION
## Summary
- add `run.py database preflight` as a credential-safe managed database cutover gate
- report PG* readiness by key name only and block legacy SQLite with exit code 78 by default
- update the managed database migration runbook to use the stricter preflight command

## Why
Production still reports the legacy `/data` SQLite backend. This adds a repeatable local/pod-level gate for issue #126 so migration readiness can be validated before deployment or scheduled jobs proceed, without exposing database secrets.

## Validation
- `SECRET_KEY=test-secret-key-for-testing-only AUTOMATION_TOKEN=test-automation-token-for-testing .venv/bin/pytest tests/test_run_cli.py tests/test_app_factory.py -q`
- `env -u SQLALCHEMY_DATABASE_URI SECRET_KEY=test-secret-key-for-testing-only AUTOMATION_TOKEN=test-automation-token-for-testing PGHOST=postgres.example PGDATABASE=quizzicalbeats PGUSER=qb_user PGPASSWORD=super-secret-password PGSSLMODE=require .venv/bin/python run.py database preflight`
- `SECRET_KEY=test-secret-key-for-testing-only AUTOMATION_TOKEN=test-automation-token-for-testing SQLALCHEMY_DATABASE_URI=sqlite:////data/song_data.db .venv/bin/python run.py database preflight; test $? -eq 78`
- `git diff --check origin/main..HEAD`

Refs #126.