### PR TITLE
Add managed database migration CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added planned quiz round records plus MCP tools to create, list, update, and link upcoming quiz dates before a round exists.
 - Added planned quiz dates to the browser round calendar with quizmaster visibility and linked-round actions.
 - Added PostgreSQL component-variable database configuration so Kubernetes/CNPG deployments can use `PGHOST`, `PGDATABASE`, `PGUSER`, and `PGPASSWORD` without storing one full database URI secret.
+- Added a dry-run-first SQLite-to-managed-database migration CLI with row-count validation, target safety checks, and credential-safe output.
 
 ### Fixed
 - Hid internal/noisy import tags from the music-round builder while keeping raw tags in storage, and mapped common public aliases such as `hip hop` to `Hip-Hop`.

--- a/docs/admin-guide/managed-database-migration.md
+++ b/docs/admin-guide/managed-database-migration.md
@@ -62,16 +62,41 @@ database to a managed SQL database without exposing credentials in logs or Git.
 ## Dry Run
 
 1. Restore the SQLite backup into a disposable workspace.
-2. Import into a disposable managed database using a tested migration tool such
-   as `pgloader` or an equivalent schema-aware export/import process.
-3. Start the app against the disposable managed URI and run:
+2. Point the app environment at the disposable managed database. Prefer the
+   component variables so the password can come from a Secret key:
+
+   ```bash
+   export PGHOST=quizzicalbeats-db-rw.quizzicalbeats.svc
+   export PGDATABASE=quizzicalbeats
+   export PGUSER=quizzicalbeats
+   export PGPASSWORD='from-secret-manager'
+   unset SQLALCHEMY_DATABASE_URI
+   ```
+
+3. Run the built-in dry run first. It prints only row counts and redacted
+   targets, never the source path or database password:
+
+   ```bash
+   python /app/run.py database migrate-sqlite --source /restore/song_data.db
+   ```
+
+4. Execute only after the dry run looks right. The target database must be
+   empty unless `--replace-target` is explicitly passed after taking a backup:
+
+   ```bash
+   python /app/run.py database migrate-sqlite \
+     --source /restore/song_data.db \
+     --execute
+   ```
+
+5. Start the app against the disposable managed URI and run:
 
    ```bash
    python /app/run.py database preflight
    python -m pytest tests/test_app_factory.py tests/test_automation_service.py
    ```
 
-4. Verify the core counts match the SQLite source: songs, rounds, users, tags,
+6. Verify the core counts match the SQLite source: songs, rounds, users, tags,
    and scheduled exports.
 
 ## Production Cutover
@@ -101,14 +126,32 @@ database to a managed SQL database without exposing credentials in logs or Git.
 
 2. Deploy the app with `DATABASE_REQUIRE_MANAGED=true` and without a ConfigMap
    `SQLALCHEMY_DATABASE_URI` SQLite fallback.
-3. Restart the web deployment after the secret has synced:
+3. Run the production dry run from a one-off pod or the web pod with the new
+   target database environment. Do not pass `--execute` until backup and
+   rollback are confirmed:
+
+   ```bash
+   kubectl -n quizzicalbeats exec deploy/quizzicalbeats -c web -- \
+     python /app/run.py database migrate-sqlite --source /data/song_data.db
+   ```
+
+4. Execute the copy during the maintenance window:
+
+   ```bash
+   kubectl -n quizzicalbeats exec deploy/quizzicalbeats -c web -- \
+     python /app/run.py database migrate-sqlite \
+       --source /data/song_data.db \
+       --execute
+   ```
+
+5. Restart the web deployment after the secret has synced:
 
    ```bash
    kubectl -n quizzicalbeats rollout restart deploy/quizzicalbeats
    kubectl -n quizzicalbeats rollout status deploy/quizzicalbeats
    ```
 
-4. Verify without printing credentials:
+6. Verify without printing credentials:
 
    ```bash
    kubectl -n quizzicalbeats exec deploy/quizzicalbeats -c web -- python /app/run.py database preflight
@@ -121,7 +164,7 @@ database to a managed SQL database without exposing credentials in logs or Git.
    PY
    ```
 
-5. Verify web, MCP, and scheduled-email execution share the same config:
+7. Verify web, MCP, and scheduled-email execution share the same config:
 
    ```bash
    kubectl -n quizzicalbeats exec deploy/quizzicalbeats -c web -- python /app/run.py database preflight

--- a/musicround/helpers/database_migration.py
+++ b/musicround/helpers/database_migration.py
@@ -1,0 +1,190 @@
+"""Credential-safe helpers for moving the legacy SQLite DB to managed SQL."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any
+
+from sqlalchemy import create_engine, inspect, select, text
+from sqlalchemy.engine import Engine
+from sqlalchemy.exc import SQLAlchemyError
+
+from musicround import db
+from musicround.helpers.database_config import database_backend, redact_database_uri
+
+
+class DatabaseMigrationError(RuntimeError):
+    """Raised when a migration precondition fails."""
+
+
+@dataclass(frozen=True)
+class TableCopyResult:
+    table: str
+    source_rows: int
+    target_rows_before: int
+    target_rows_after: int | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "table": self.table,
+            "source_rows": self.source_rows,
+            "target_rows_before": self.target_rows_before,
+            "target_rows_after": self.target_rows_after,
+        }
+
+
+def migrate_sqlite_to_configured_database(
+    source_path: str,
+    target_engine: Engine,
+    *,
+    execute: bool = False,
+    replace_target: bool = False,
+    allow_sqlite_target: bool = False,
+) -> dict[str, Any]:
+    """Copy rows from a SQLite file into the already configured target engine.
+
+    The default mode is a dry run. Execution is intentionally opt-in because
+    this helper is meant for production cutover work.
+    """
+    source_path = os.path.abspath(source_path)
+    if not os.path.exists(source_path):
+        raise DatabaseMigrationError("Source SQLite database file does not exist.")
+    if not os.path.isfile(source_path):
+        raise DatabaseMigrationError("Source SQLite database path is not a file.")
+
+    target_uri = str(target_engine.url)
+    if database_backend(target_uri) == "sqlite" and not allow_sqlite_target:
+        raise DatabaseMigrationError(
+            "Refusing to migrate into a SQLite target. Configure managed SQL or "
+            "pass --allow-sqlite-target for local tests only."
+        )
+
+    source_engine = create_engine(f"sqlite:///{source_path}")
+    db.create_all()
+
+    try:
+        with source_engine.connect() as source, target_engine.begin() as target:
+            source_inspector = inspect(source)
+            results = []
+            for table in db.metadata.sorted_tables:
+                source_rows = _count_table(source, table.name, source_inspector)
+                target_rows_before = _count_table(target, table.name)
+                results.append(
+                    TableCopyResult(
+                        table=table.name,
+                        source_rows=source_rows,
+                        target_rows_before=target_rows_before,
+                    )
+                )
+
+            target_nonempty = any(result.target_rows_before for result in results)
+            if target_nonempty and execute and not replace_target:
+                raise DatabaseMigrationError(
+                    "Target database already contains rows. Re-run with "
+                    "--replace-target after taking a backup, or use a fresh "
+                    "managed database."
+                )
+
+            copied_results = results
+            if execute:
+                if replace_target:
+                    _delete_target_rows(target)
+                copied_results = _copy_tables(source, target, source_inspector)
+                _reset_postgres_sequences(target_engine, target)
+
+            return {
+                "mode": "execute" if execute else "dry-run",
+                "source": "sqlite:///[source-file]",
+                "target": redact_database_uri(target_uri),
+                "target_nonempty": target_nonempty,
+                "tables": [result.to_dict() for result in copied_results],
+                "total_source_rows": sum(result.source_rows for result in results),
+                "total_target_rows_before": sum(
+                    result.target_rows_before for result in results
+                ),
+                "total_target_rows_after": (
+                    sum(result.target_rows_after or 0 for result in copied_results)
+                    if execute
+                    else None
+                ),
+            }
+    except SQLAlchemyError as exc:
+        raise DatabaseMigrationError("Database migration failed.") from exc
+    finally:
+        source_engine.dispose()
+
+
+def _count_table(connection, table_name: str, inspector=None) -> int:
+    if inspector is not None and not inspector.has_table(table_name):
+        return 0
+    result = connection.execute(text(f"SELECT COUNT(*) FROM {_quote_identifier(table_name)}"))
+    return int(result.scalar() or 0)
+
+
+def _copy_tables(source, target, source_inspector) -> list[TableCopyResult]:
+    results: list[TableCopyResult] = []
+    for table in db.metadata.sorted_tables:
+        if not source_inspector.has_table(table.name):
+            source_rows = 0
+        else:
+            source_columns = {column["name"] for column in source_inspector.get_columns(table.name)}
+            selected_columns = [
+                column for column in table.columns if column.name in source_columns
+            ]
+            rows = [
+                dict(row._mapping)
+                for row in source.execute(select(*selected_columns)).fetchall()
+            ]
+            source_rows = len(rows)
+            if rows:
+                target.execute(table.insert(), rows)
+        target_rows_after = _count_table(target, table.name)
+        results.append(
+            TableCopyResult(
+                table=table.name,
+                source_rows=source_rows,
+                target_rows_before=0,
+                target_rows_after=target_rows_after,
+            )
+        )
+    return results
+
+
+def _delete_target_rows(target) -> None:
+    for table in reversed(db.metadata.sorted_tables):
+        target.execute(table.delete())
+
+
+def _reset_postgres_sequences(target_engine: Engine, target) -> None:
+    if database_backend(str(target_engine.url)) != "postgresql":
+        return
+
+    preparer = target_engine.dialect.identifier_preparer
+    for table in db.metadata.sorted_tables:
+        primary_keys = list(table.primary_key.columns)
+        if len(primary_keys) != 1:
+            continue
+        primary_key = primary_keys[0]
+        try:
+            python_type = primary_key.type.python_type
+        except NotImplementedError:
+            continue
+        if python_type is not int:
+            continue
+        quoted_table = preparer.quote(table.name)
+        quoted_column = preparer.quote(primary_key.name)
+        target.execute(
+            text(
+                "SELECT setval("
+                "pg_get_serial_sequence(:table_name, :column_name), "
+                f"COALESCE((SELECT MAX({quoted_column}) FROM {quoted_table}), 0) + 1, "
+                "false)"
+            ),
+            {"table_name": table.name, "column_name": primary_key.name},
+        )
+
+
+def _quote_identifier(identifier: str) -> str:
+    escaped = identifier.replace('"', '""')
+    return f'"{escaped}"'

--- a/run.py
+++ b/run.py
@@ -39,6 +39,30 @@ def main():
         action='store_true',
         help='Report diagnostics without failing on SQLite; useful before cutover work starts',
     )
+    migrate_parser = database_subparsers.add_parser(
+        'migrate-sqlite',
+        help='Dry-run or execute a SQLite-to-configured-database row copy',
+    )
+    migrate_parser.add_argument(
+        '--source',
+        required=True,
+        help='Path to the source SQLite database file, for example /data/song_data.db',
+    )
+    migrate_parser.add_argument(
+        '--execute',
+        action='store_true',
+        help='Actually copy data. Omit this for the default dry run.',
+    )
+    migrate_parser.add_argument(
+        '--replace-target',
+        action='store_true',
+        help='Delete existing target rows before copying. Requires --execute.',
+    )
+    migrate_parser.add_argument(
+        '--allow-sqlite-target',
+        action='store_true',
+        help='Allow a SQLite target for local tests only. Production should use managed SQL.',
+    )
 
     health_parser = subparsers.add_parser('health', help='Health diagnostics')
     health_subparsers = health_parser.add_subparsers(dest='health_action', help='Health action to perform')
@@ -70,6 +94,36 @@ def main():
                     print(f"Retention policy failed: {result['message']}")
                     return 1
     elif args.command == 'database':
+        if args.database_action == 'migrate-sqlite':
+            if args.replace_target and not args.execute:
+                print(
+                    "Database migration error: --replace-target requires --execute.",
+                    file=sys.stderr,
+                )
+                return 78
+            with contextlib.redirect_stdout(sys.stderr):
+                app = create_app()
+            with app.app_context():
+                from musicround import db
+                from musicround.helpers.database_migration import (
+                    DatabaseMigrationError,
+                    migrate_sqlite_to_configured_database,
+                )
+
+                try:
+                    result = migrate_sqlite_to_configured_database(
+                        args.source,
+                        db.engine,
+                        execute=args.execute,
+                        replace_target=args.replace_target,
+                        allow_sqlite_target=args.allow_sqlite_target,
+                    )
+                except DatabaseMigrationError as exc:
+                    print(f"Database migration error: {exc}", file=sys.stderr)
+                    return 78
+                print(json.dumps(result, indent=2, sort_keys=True))
+                return 0
+
         from flask import Flask
         from musicround import _configure_database_uri
         from musicround.config import Config
@@ -81,6 +135,8 @@ def main():
 
         app = Flask(__name__)
         app.config.from_object(Config)
+        if "SQLALCHEMY_DATABASE_URI" not in os.environ:
+            app.config["SQLALCHEMY_DATABASE_URI"] = None
         if args.database_action == 'preflight':
             app.config['DATABASE_REQUIRE_MANAGED'] = not args.allow_sqlite
         try:

--- a/tests/test_run_cli.py
+++ b/tests/test_run_cli.py
@@ -1,7 +1,10 @@
 """Tests for the management CLI."""
 
 import json
+import sqlite3
 import sys
+
+from sqlalchemy import create_engine
 
 
 def test_health_check_command_outputs_public_safe_json(app, monkeypatch, capsys):
@@ -160,3 +163,139 @@ def test_database_preflight_reports_missing_pg_keys_safely(monkeypatch, capsys):
     assert "PGUSER" in captured.err
     assert "postgres.example" not in captured.err
     assert "Traceback" not in captured.err
+
+
+def test_database_migrate_sqlite_refuses_sqlite_target_by_default(
+    monkeypatch,
+    capsys,
+    tmp_path,
+):
+    """The migration command should not copy into SQLite unless it is a local test."""
+    import run
+
+    source = tmp_path / "source.db"
+    target = tmp_path / "target.db"
+    _create_source_sqlite(source, songs=1)
+
+    monkeypatch.setenv("SECRET_KEY", "test-secret-key-for-testing-only")
+    monkeypatch.setenv("AUTOMATION_TOKEN", "test-automation-token-for-testing")
+    monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", f"sqlite:///{target}")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["run.py", "database", "migrate-sqlite", "--source", str(source)],
+    )
+
+    exit_code = run.main()
+    captured = capsys.readouterr()
+
+    assert exit_code == 78
+    assert "Refusing to migrate into a SQLite target" in captured.err
+    assert str(source) not in captured.out
+    assert str(target) not in captured.out
+
+
+def test_database_migrate_sqlite_dry_run_reports_safe_counts(
+    monkeypatch,
+    capsys,
+    tmp_path,
+):
+    """Dry-run migration output should be useful and credential-safe."""
+    import run
+
+    source = tmp_path / "source.db"
+    target = tmp_path / "target.db"
+    _create_source_sqlite(source, songs=1)
+
+    monkeypatch.setenv("SECRET_KEY", "test-secret-key-for-testing-only")
+    monkeypatch.setenv("AUTOMATION_TOKEN", "test-automation-token-for-testing")
+    monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", f"sqlite:///{target}")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run.py",
+            "database",
+            "migrate-sqlite",
+            "--source",
+            str(source),
+            "--allow-sqlite-target",
+        ],
+    )
+
+    exit_code = run.main()
+    output = capsys.readouterr().out
+    payload = json.loads(output)
+
+    assert exit_code == 0
+    assert payload["mode"] == "dry-run"
+    assert payload["target"] == "sqlite:///[local-file]"
+    assert payload["source"] == "sqlite:///[source-file]"
+    assert payload["total_source_rows"] == 1
+    assert payload["total_target_rows_after"] is None
+    assert _table_payload(payload, "song")["source_rows"] == 1
+    assert str(source) not in output
+    assert str(target) not in output
+
+
+def test_database_migrate_sqlite_execute_copies_rows(
+    monkeypatch,
+    capsys,
+    tmp_path,
+):
+    """Explicit execution should copy rows into an empty configured target."""
+    import run
+
+    source = tmp_path / "source.db"
+    target = tmp_path / "target.db"
+    _create_source_sqlite(source, songs=1)
+
+    monkeypatch.setenv("SECRET_KEY", "test-secret-key-for-testing-only")
+    monkeypatch.setenv("AUTOMATION_TOKEN", "test-automation-token-for-testing")
+    monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", f"sqlite:///{target}")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run.py",
+            "database",
+            "migrate-sqlite",
+            "--source",
+            str(source),
+            "--allow-sqlite-target",
+            "--execute",
+        ],
+    )
+
+    exit_code = run.main()
+    output = capsys.readouterr().out
+    payload = json.loads(output)
+
+    assert exit_code == 0
+    assert payload["mode"] == "execute"
+    assert payload["total_target_rows_after"] == 1
+    assert _table_payload(payload, "song")["target_rows_after"] == 1
+    with sqlite3.connect(target) as connection:
+        assert connection.execute("SELECT title FROM song").fetchone()[0] == "Test Song"
+
+
+def _create_source_sqlite(path, *, songs: int) -> None:
+    from musicround import db
+    import musicround.models  # noqa: F401
+
+    engine = create_engine(f"sqlite:///{path}")
+    db.metadata.create_all(bind=engine)
+    if songs:
+        with engine.begin() as connection:
+            for index in range(songs):
+                connection.execute(
+                    db.metadata.tables["song"].insert().values(
+                        title=f"Test Song" if index == 0 else f"Test Song {index + 1}",
+                        artist="Test Artist",
+                    )
+                )
+    engine.dispose()
+
+
+def _table_payload(payload, table_name):
+    return next(table for table in payload["tables"] if table["table"] == table_name)


### PR DESCRIPTION
## Summary
- add `run.py database migrate-sqlite` as a dry-run-first migration command for the SQLite to managed SQL cutover
- protect execution behind explicit `--execute`, refuse SQLite targets by default, and block non-empty targets unless `--replace-target` is explicit
- return credential-safe JSON with row counts and redacted database targets
- document the updated dry-run and production cutover steps in the managed database runbook

## Why
Production still reports the legacy `/data/song_data.db` SQLite backend. The existing preflight work made the misconfiguration visible, but #126 still needed a repeatable, locally testable copy path before touching the live database configuration.

## Validation
- `SECRET_KEY=test-secret-key-for-testing-only AUTOMATION_TOKEN=test-automation-token-for-testing .venv/bin/pytest tests/test_run_cli.py tests/test_app_factory.py -q`
- `.venv/bin/python -m py_compile run.py musicround/helpers/database_migration.py tests/test_run_cli.py`
- `git diff --check`

Refs #126
