### PR TITLE
Fix managed database migration CLI review follow-ups

### DIFF
--- a/musicround/helpers/database_migration.py
+++ b/musicround/helpers/database_migration.py
@@ -13,6 +13,8 @@ from sqlalchemy.exc import SQLAlchemyError
 from musicround import db
 from musicround.helpers.database_config import database_backend, redact_database_uri
 
+COPY_BATCH_SIZE = 500
+
 
 class DatabaseMigrationError(RuntimeError):
     """Raised when a migration precondition fails."""
@@ -60,16 +62,17 @@ def migrate_sqlite_to_configured_database(
             "pass --allow-sqlite-target for local tests only."
         )
 
-    source_engine = create_engine(f"sqlite:///{source_path}")
-    db.create_all()
+    import musicround.models  # noqa: F401 - populate db.metadata for CLI use.
 
+    source_engine = create_engine(f"sqlite:///{source_path}")
     try:
         with source_engine.connect() as source, target_engine.begin() as target:
             source_inspector = inspect(source)
+            target_inspector = inspect(target)
             results = []
             for table in db.metadata.sorted_tables:
                 source_rows = _count_table(source, table.name, source_inspector)
-                target_rows_before = _count_table(target, table.name)
+                target_rows_before = _count_table(target, table.name, target_inspector)
                 results.append(
                     TableCopyResult(
                         table=table.name,
@@ -88,9 +91,15 @@ def migrate_sqlite_to_configured_database(
 
             copied_results = results
             if execute:
+                db.metadata.create_all(bind=target)
                 if replace_target:
                     _delete_target_rows(target)
-                copied_results = _copy_tables(source, target, source_inspector)
+                copied_results = _copy_tables(
+                    source,
+                    target,
+                    source_inspector,
+                    {result.table: result.target_rows_before for result in results},
+                )
                 _reset_postgres_sequences(target_engine, target)
 
             return {
@@ -122,7 +131,12 @@ def _count_table(connection, table_name: str, inspector=None) -> int:
     return int(result.scalar() or 0)
 
 
-def _copy_tables(source, target, source_inspector) -> list[TableCopyResult]:
+def _copy_tables(
+    source,
+    target,
+    source_inspector,
+    target_rows_before_by_table: dict[str, int],
+) -> list[TableCopyResult]:
     results: list[TableCopyResult] = []
     for table in db.metadata.sorted_tables:
         if not source_inspector.has_table(table.name):
@@ -132,19 +146,23 @@ def _copy_tables(source, target, source_inspector) -> list[TableCopyResult]:
             selected_columns = [
                 column for column in table.columns if column.name in source_columns
             ]
-            rows = [
-                dict(row._mapping)
-                for row in source.execute(select(*selected_columns)).fetchall()
-            ]
-            source_rows = len(rows)
-            if rows:
-                target.execute(table.insert(), rows)
+            source_rows = 0
+            if selected_columns:
+                rows_result = source.execute(select(*selected_columns))
+                while rows := rows_result.fetchmany(COPY_BATCH_SIZE):
+                    source_rows += len(rows)
+                    target.execute(
+                        table.insert(),
+                        [dict(row._mapping) for row in rows],
+                    )
+            else:
+                source_rows = _count_table(source, table.name, source_inspector)
         target_rows_after = _count_table(target, table.name)
         results.append(
             TableCopyResult(
                 table=table.name,
                 source_rows=source_rows,
-                target_rows_before=0,
+                target_rows_before=target_rows_before_by_table.get(table.name, 0),
                 target_rows_after=target_rows_after,
             )
         )

--- a/run.py
+++ b/run.py
@@ -1,5 +1,7 @@
 from dotenv import load_dotenv
-from musicround import create_app
+from flask import Flask
+from musicround import _configure_database_uri, create_app, db
+from musicround.config import Config
 from musicround.version import get_version_str, VERSION_INFO
 import contextlib
 import json
@@ -9,6 +11,15 @@ import argparse
 
 # Load environment variables
 load_dotenv()
+
+
+def _create_database_cli_app():
+    """Create the minimum app context needed for database CLI commands."""
+    app = Flask(__name__)
+    app.config.from_object(Config)
+    _configure_database_uri(app)
+    db.init_app(app)
+    return app
 
 def main():
     # Create argument parser
@@ -102,9 +113,8 @@ def main():
                 )
                 return 78
             with contextlib.redirect_stdout(sys.stderr):
-                app = create_app()
+                app = _create_database_cli_app()
             with app.app_context():
-                from musicround import db
                 from musicround.helpers.database_migration import (
                     DatabaseMigrationError,
                     migrate_sqlite_to_configured_database,
@@ -124,9 +134,6 @@ def main():
                 print(json.dumps(result, indent=2, sort_keys=True))
                 return 0
 
-        from flask import Flask
-        from musicround import _configure_database_uri
-        from musicround.config import Config
         from musicround.helpers.database_config import (
             database_summary,
             is_legacy_data_sqlite_uri,

--- a/tests/test_run_cli.py
+++ b/tests/test_run_cli.py
@@ -211,6 +211,11 @@ def test_database_migrate_sqlite_dry_run_reports_safe_counts(
     monkeypatch.setenv("AUTOMATION_TOKEN", "test-automation-token-for-testing")
     monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", f"sqlite:///{target}")
     monkeypatch.setattr(
+        run,
+        "create_app",
+        lambda: (_ for _ in ()).throw(AssertionError("full app factory called")),
+    )
+    monkeypatch.setattr(
         sys,
         "argv",
         [
@@ -245,14 +250,16 @@ def test_database_migrate_sqlite_execute_copies_rows(
 ):
     """Explicit execution should copy rows into an empty configured target."""
     import run
+    from musicround.helpers import database_migration
 
     source = tmp_path / "source.db"
     target = tmp_path / "target.db"
-    _create_source_sqlite(source, songs=1)
+    _create_source_sqlite(source, songs=2)
 
     monkeypatch.setenv("SECRET_KEY", "test-secret-key-for-testing-only")
     monkeypatch.setenv("AUTOMATION_TOKEN", "test-automation-token-for-testing")
     monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", f"sqlite:///{target}")
+    monkeypatch.setattr(database_migration, "COPY_BATCH_SIZE", 1)
     monkeypatch.setattr(
         sys,
         "argv",
@@ -273,10 +280,52 @@ def test_database_migrate_sqlite_execute_copies_rows(
 
     assert exit_code == 0
     assert payload["mode"] == "execute"
-    assert payload["total_target_rows_after"] == 1
-    assert _table_payload(payload, "song")["target_rows_after"] == 1
+    assert payload["total_target_rows_after"] == 2
+    assert _table_payload(payload, "song")["target_rows_after"] == 2
     with sqlite3.connect(target) as connection:
         assert connection.execute("SELECT title FROM song").fetchone()[0] == "Test Song"
+
+
+def test_database_migrate_sqlite_execute_reports_existing_target_rows(
+    monkeypatch,
+    capsys,
+    tmp_path,
+):
+    """Execute output should preserve per-table pre-copy counts."""
+    import run
+
+    source = tmp_path / "source.db"
+    target = tmp_path / "target.db"
+    _create_source_sqlite(source, songs=2)
+    _create_source_sqlite(target, songs=1)
+
+    monkeypatch.setenv("SECRET_KEY", "test-secret-key-for-testing-only")
+    monkeypatch.setenv("AUTOMATION_TOKEN", "test-automation-token-for-testing")
+    monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", f"sqlite:///{target}")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run.py",
+            "database",
+            "migrate-sqlite",
+            "--source",
+            str(source),
+            "--allow-sqlite-target",
+            "--execute",
+            "--replace-target",
+        ],
+    )
+
+    exit_code = run.main()
+    output = capsys.readouterr().out
+    payload = json.loads(output)
+    song_payload = _table_payload(payload, "song")
+
+    assert exit_code == 0
+    assert payload["total_target_rows_before"] == 1
+    assert song_payload["target_rows_before"] == 1
+    assert song_payload["target_rows_after"] == 2
 
 
 def _create_source_sqlite(path, *, songs: int) -> None:


### PR DESCRIPTION
## Summary\n- avoid full app startup side effects for the database migrate-sqlite CLI path\n- bind target schema creation to the configured target engine and preserve per-table pre-copy counts\n- copy rows in bounded batches instead of loading each table with fetchall\n\n## Validation\n- python3 -m py_compile run.py musicround/helpers/database_migration.py tests/test_run_cli.py\n- git diff --check\n- FLASK_ENV=testing SECRET_KEY=ci-test-secret-key AUTOMATION_TOKEN=ci-test-automation-token /tmp/qb-164-followup-py312/bin/python -m pytest tests/test_run_cli.py -q