### PR TITLE
Make app data directory configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added planned quiz dates to the browser round calendar with quizmaster visibility and linked-round actions.
 - Added PostgreSQL component-variable database configuration so Kubernetes/CNPG deployments can use `PGHOST`, `PGDATABASE`, `PGUSER`, and `PGPASSWORD` without storing one full database URI secret.
 - Added a dry-run-first SQLite-to-managed-database migration CLI with row-count validation, target safety checks, and credential-safe output.
+- Added configurable `DATA_DIR` support for custom MP3s, backups, Spotify cache files, and authenticated data downloads.
 
 ### Fixed
 - Hid internal/noisy import tags from the music-round builder while keeping raw tags in storage, and mapped common public aliases such as `hip hop` to `Hip-Hop`.

--- a/docs/admin-guide/configuration.md
+++ b/docs/admin-guide/configuration.md
@@ -94,6 +94,11 @@ For optimal metadata quality, we recommend configuring at least Spotify and Last
 SQLALCHEMY_DATABASE_URI=sqlite:///data/song_data.db
 SQLALCHEMY_TRACK_MODIFICATIONS=False
 
+# Application file storage
+DATA_DIR=/data
+ROUND_MP3_DIR=/data/rounds
+ROUND_PDF_DIR=/data/pdfs
+
 # For MySQL/MariaDB:
 # SQLALCHEMY_DATABASE_URI=mysql+pymysql://username:password@localhost/musicround
 

--- a/musicround/config.py
+++ b/musicround/config.py
@@ -85,6 +85,7 @@ class Config:
 
     # Round artifact storage. These directories must already exist and be
     # writable before MP3/PDF generation, export, scheduling, or delivery.
+    DATA_DIR = os.getenv("DATA_DIR", "/data")
     ROUND_MP3_DIR = os.getenv("ROUND_MP3_DIR", "/data/rounds")
     ROUND_PDF_DIR = os.getenv("ROUND_PDF_DIR", "/data/pdfs")
     

--- a/musicround/helpers/backup_helper.py
+++ b/musicround/helpers/backup_helper.py
@@ -13,6 +13,7 @@ import tempfile
 from flask import current_app
 
 from musicround.helpers.database_config import database_summary, is_sqlite_database_uri
+from musicround.helpers.paths import app_data_path, backup_dir
 
 # Set up logging
 logger = logging.getLogger(__name__)
@@ -135,11 +136,11 @@ def create_backup(backup_name=None, include_mp3s=True, include_config=True):
             backup_name = f"backup_{timestamp}"
         
         # Ensure backup directory exists
-        backup_dir = os.path.join('/data', 'backups')
-        os.makedirs(backup_dir, exist_ok=True)
+        backups_path = backup_dir()
+        os.makedirs(backups_path, exist_ok=True)
         
         # Create backup zip file path
-        backup_path = os.path.join(backup_dir, f"{backup_name}.zip")
+        backup_path = os.path.join(backups_path, f"{backup_name}.zip")
         
         # Create a temporary directory for collecting files
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -268,17 +269,17 @@ def list_backups():
     Returns:
         list: List of backup information dictionaries
     """
-    backup_dir = os.path.join('/data', 'backups')
+    backups_path = backup_dir()
     
-    if not os.path.exists(backup_dir):
-        os.makedirs(backup_dir, exist_ok=True)
+    if not os.path.exists(backups_path):
+        os.makedirs(backups_path, exist_ok=True)
         return []
     
     backups = []
     
-    for filename in os.listdir(backup_dir):
+    for filename in os.listdir(backups_path):
         if filename.endswith('.zip'):
-            backup_path = os.path.join(backup_dir, filename)
+            backup_path = os.path.join(backups_path, filename)
             try:
                 # Extract metadata from ZIP file
                 with zipfile.ZipFile(backup_path, 'r') as zipf:
@@ -325,8 +326,8 @@ def delete_backup(backup_filename):
     Returns:
         dict: Operation status information
     """
-    backup_dir = os.path.join('/data', 'backups')
-    backup_path = os.path.join(backup_dir, backup_filename)
+    backups_path = backup_dir()
+    backup_path = os.path.join(backups_path, backup_filename)
     
     if not os.path.exists(backup_path):
         return {
@@ -357,8 +358,8 @@ def restore_backup(backup_filename):
     Returns:
         dict: Operation status information
     """
-    backup_dir = os.path.join('/data', 'backups')
-    backup_path = os.path.join(backup_dir, backup_filename)
+    backups_path = backup_dir()
+    backup_path = os.path.join(backups_path, backup_filename)
     
     if not os.path.exists(backup_path):
         return {
@@ -517,8 +518,8 @@ def verify_backup(backup_filename):
     Returns:
         dict: Verification result
     """
-    backup_dir = os.path.join('/data', 'backups')
-    backup_path = os.path.join(backup_dir, backup_filename)
+    backups_path = backup_dir()
+    backup_path = os.path.join(backups_path, backup_filename)
     
     if not os.path.exists(backup_path):
         return {
@@ -681,7 +682,7 @@ def get_backup_summary():
         "schedule_time": schedule_time,
         "schedule_frequency": schedule_frequency,
         "next_backup": next_backup,
-        "backup_location": "/data/backups",
+        "backup_location": backup_dir(),
         "retention_days": retention_days,
         "supports_application_backup": application_backup["supported"],
         "backup_warning": application_backup["warning"],
@@ -871,8 +872,8 @@ def upload_backup(file):
     """
     try:
         # Ensure backup directory exists
-        backup_dir = os.path.join('/data', 'backups')
-        os.makedirs(backup_dir, exist_ok=True)
+        backups_path = backup_dir()
+        os.makedirs(backups_path, exist_ok=True)
         
         # Generate a unique filename with timestamp
         timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
@@ -881,7 +882,7 @@ def upload_backup(file):
         # This preserves the original filename but ensures uniqueness
         secure_filename = file.filename.replace(' ', '_')
         save_filename = f"{timestamp}_{secure_filename}"
-        save_path = os.path.join(backup_dir, save_filename)
+        save_path = os.path.join(backups_path, save_filename)
         
         # Save the uploaded file
         file.save(save_path)
@@ -960,7 +961,7 @@ def update_ofelia_config(retention_days=30):
         schedule_cron = frequency_map.get(schedule_frequency, '@daily')
         
         # Determine the config file path - use environment variable or default
-        config_dir = os.environ.get('OFELIA_CONFIG_DIR', '/data/config')
+        config_dir = os.environ.get('OFELIA_CONFIG_DIR', app_data_path('config'))
         os.makedirs(config_dir, exist_ok=True)
         config_path = os.path.join(config_dir, 'ofelia.ini')
         

--- a/musicround/helpers/paths.py
+++ b/musicround/helpers/paths.py
@@ -1,0 +1,27 @@
+"""Application data-path helpers."""
+
+from __future__ import annotations
+
+import os
+
+from flask import current_app
+
+
+def app_data_dir() -> str:
+    """Return the configured application data directory."""
+    return current_app.config.get("DATA_DIR", "/data")
+
+
+def app_data_path(*parts: str) -> str:
+    """Return a path below the configured application data directory."""
+    return os.path.join(app_data_dir(), *parts)
+
+
+def backup_dir() -> str:
+    """Return the configured backup directory."""
+    return app_data_path("backups")
+
+
+def custom_mp3_dir() -> str:
+    """Return the configured custom MP3 base directory."""
+    return app_data_path("custommp3")

--- a/musicround/helpers/spotify_direct.py
+++ b/musicround/helpers/spotify_direct.py
@@ -8,6 +8,7 @@ import time
 import requests
 import logging
 from flask import current_app
+from musicround.helpers.paths import app_data_path
 
 class SpotifyDirectClient:
     """
@@ -17,7 +18,7 @@ class SpotifyDirectClient:
     def __init__(self, client_id=None, client_secret=None, cache_path=None, bearer_token=None):
         self.client_id = client_id or current_app.config['SPOTIFY_CLIENT_ID']
         self.client_secret = client_secret or current_app.config['SPOTIFY_CLIENT_SECRET']
-        self.cache_path = cache_path or os.path.join('/data', '.spotifycache')
+        self.cache_path = cache_path or app_data_path('.spotifycache')
         self.base_url = 'https://api.spotify.com/v1'
         self.token_url = 'https://accounts.spotify.com/api/token'
         self.access_token = bearer_token  # Use provided bearer token if available

--- a/musicround/helpers/utils.py
+++ b/musicround/helpers/utils.py
@@ -10,6 +10,8 @@ from werkzeug.utils import secure_filename
 import requests
 import json
 
+from musicround.helpers.paths import app_data_path, custom_mp3_dir
+
 
 def is_safe_url(target):
     """Return whether a redirect target is an app-local absolute path."""
@@ -57,7 +59,7 @@ def get_user_mp3_directory(username):
     Returns:
         str: Path to the user's MP3 directory
     """
-    base_dir = os.path.join('/data', 'custommp3')
+    base_dir = custom_mp3_dir()
     user_dir = os.path.join(base_dir, secure_filename(username))
     
     # Create directories if they don't exist
@@ -127,8 +129,8 @@ def get_mp3_path(user, mp3_type):
     user_setting_attr = f"{mp3_type}_mp3"
     user_mp3_path = getattr(user, user_setting_attr)
     
-    if user_mp3_path and os.path.exists(os.path.join('/data', user_mp3_path)):
-        return os.path.join('/data', user_mp3_path)
+    if user_mp3_path and os.path.exists(app_data_path(user_mp3_path)):
+        return app_data_path(user_mp3_path)
     
     # Fall back to the default MP3
     return os.path.join(current_app.root_path, 'static', 'audio', f'{mp3_type}.mp3')

--- a/musicround/routes/core.py
+++ b/musicround/routes/core.py
@@ -11,6 +11,7 @@ from musicround.config import Config
 import requests
 import traceback
 from musicround.helpers.auth_helpers import oauth, update_oauth_tokens
+from musicround.helpers.paths import app_data_dir, app_data_path
 from musicround.helpers.spotify_helper import get_spotify_token, get_spotify_user_info
 from datetime import datetime
 from authlib.integrations.base_client.errors import OAuthError
@@ -486,8 +487,8 @@ def serve_user_audio(filepath):
     Serve user custom audio files from the data directory
     """
     # Resolve the real path to prevent path traversal attacks
-    base_dir = os.path.realpath('/data')
-    requested_path = os.path.realpath(os.path.join('/data', filepath))
+    base_dir = os.path.realpath(app_data_dir())
+    requested_path = os.path.realpath(app_data_path(filepath))
     if not requested_path.startswith(base_dir + os.sep) and requested_path != base_dir:
         abort(404)
         
@@ -498,4 +499,4 @@ def serve_user_audio(filepath):
             if username != current_user.username and not current_user.is_admin:
                 abort(403)
     
-    return send_from_directory('/data', filepath)
+    return send_from_directory(app_data_dir(), filepath)

--- a/musicround/routes/rounds.py
+++ b/musicround/routes/rounds.py
@@ -20,6 +20,7 @@ from reportlab.lib.pagesizes import A4
 from reportlab.pdfgen import canvas
 from musicround.helpers.auth_helpers import oauth
 from musicround.helpers.email_helper import send_email as send_quiz_email
+from musicround.helpers.paths import app_data_path
 from musicround.helpers.storage_health import (
     check_round_artifact_storage,
     round_mp3_dir,
@@ -331,7 +332,7 @@ def _selected_track_hint_audio(round_id):
     for script in scripts:
         if not script.cue_position:
             continue
-        path = os.path.join('/data', script.generated_mp3_path)
+        path = app_data_path(script.generated_mp3_path)
         try:
             hints[script.cue_position] = AudioSegment.from_mp3(path)
         except Exception as exc:

--- a/musicround/routes/users.py
+++ b/musicround/routes/users.py
@@ -15,6 +15,7 @@ from musicround.models import db, User, Role, SystemSetting
 from musicround.helpers.utils import get_available_voices, is_safe_url
 from musicround.helpers.auth_helpers import oauth, find_or_create_user, update_oauth_tokens, get_google_user_info, get_authentik_user_info, get_spotify_user_info, get_oauth_redirect_uri
 from musicround.helpers.oauth_status import dropbox_token_status, spotify_token_status, token_notice
+from musicround.helpers.paths import app_data_dir, backup_dir
 from musicround.helpers.spotify_helper import (
     clear_manual_spotify_bearer_token,
     get_spotify_token,
@@ -1578,8 +1579,8 @@ def download_backup(filename):
         abort(400, "Invalid file type")
     
     # Only allow downloading from the backup directory
-    backup_dir = os.path.join('/data', 'backups')
-    backup_path = os.path.join(backup_dir, filename)
+    backups_path = backup_dir()
+    backup_path = os.path.join(backups_path, filename)
     
     # Check if the file exists
     if not os.path.exists(backup_path):
@@ -1740,8 +1741,8 @@ def system_health():
     
     # Check important directories
     dirs_to_check = [
-        {"path": '/data', "name": "Data Directory"},
-        {"path": '/data/backups', "name": "Backups Directory"},
+        {"path": app_data_dir(), "name": "Data Directory"},
+        {"path": backup_dir(), "name": "Backups Directory"},
         {"path": round_mp3_dir(), "name": "Round MP3 Directory"},
         {"path": round_pdf_dir(), "name": "Round PDF Directory"},
         {"path": os.path.join(current_app.root_path, 'static'), "name": "Static Files"}

--- a/musicround/services/automation.py
+++ b/musicround/services/automation.py
@@ -19,6 +19,7 @@ from sqlalchemy import or_
 from musicround import db
 from musicround.helpers.email_helper import send_email
 from musicround.helpers.import_helper import ImportHelper
+from musicround.helpers.paths import app_data_path
 from musicround.helpers.storage_health import (
     check_round_artifact_storage,
     require_round_artifact_storage,
@@ -1556,7 +1557,7 @@ def _round_audio_components(
         for script in _selected_track_hint_scripts(round_id):
             if not script.cue_position:
                 continue
-            path = os.path.join("/data", script.generated_mp3_path)
+            path = app_data_path(script.generated_mp3_path)
             try:
                 components["hint_audio_ms"][script.cue_position] = len(AudioSegment.from_mp3(path))
             except Exception as exc:

--- a/tests/test_backup_helper.py
+++ b/tests/test_backup_helper.py
@@ -526,6 +526,17 @@ class TestGetBackupSummary:
         assert 'schedule_enabled' in summary
         assert 'backup_location' in summary
 
+    def test_get_backup_summary_uses_configured_data_dir(self, app, tmp_path):
+        """Backup summary should report the configured backup location."""
+        from musicround.helpers.backup_helper import get_backup_summary
+
+        app.config["DATA_DIR"] = str(tmp_path)
+
+        with patch('musicround.helpers.backup_helper.list_backups', return_value=[]):
+            summary = get_backup_summary()
+
+        assert summary['backup_location'] == os.path.join(str(tmp_path), 'backups')
+
     def test_get_backup_summary_with_backups(self, app):
         """Test get_backup_summary with existing backups."""
         from musicround.helpers.backup_helper import get_backup_summary

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -119,6 +119,57 @@ class TestAllowedFile:
         assert allowed_file('My Great Song.mp3') is True
 
 
+class TestConfiguredDataPaths:
+    """Tests for configured data-directory helpers."""
+
+    def test_app_data_path_uses_configured_data_dir(self, app, tmp_path):
+        from musicround.helpers.paths import app_data_path, backup_dir, custom_mp3_dir
+
+        app.config["DATA_DIR"] = str(tmp_path)
+
+        assert app_data_path("custommp3", "user", "intro.mp3") == os.path.join(
+            str(tmp_path),
+            "custommp3",
+            "user",
+            "intro.mp3",
+        )
+        assert backup_dir() == os.path.join(str(tmp_path), "backups")
+        assert custom_mp3_dir() == os.path.join(str(tmp_path), "custommp3")
+
+    def test_user_mp3_directory_uses_configured_data_dir(self, app, tmp_path):
+        from musicround.helpers.utils import get_user_mp3_directory
+
+        app.config["DATA_DIR"] = str(tmp_path)
+
+        path = get_user_mp3_directory("User Name")
+
+        assert path == os.path.join(str(tmp_path), "custommp3", "User_Name")
+        assert os.path.isdir(path)
+
+    def test_get_mp3_path_uses_configured_data_dir(self, app, tmp_path):
+        from musicround.helpers.utils import get_mp3_path
+
+        app.config["DATA_DIR"] = str(tmp_path)
+        custom_path = tmp_path / "custommp3" / "user" / "intro.mp3"
+        custom_path.parent.mkdir(parents=True)
+        custom_path.write_bytes(b"mp3")
+
+        user = type("User", (), {"intro_mp3": "custommp3/user/intro.mp3"})()
+
+        assert get_mp3_path(user, "intro") == str(custom_path)
+
+    def test_spotify_direct_cache_uses_configured_data_dir(self, app, tmp_path):
+        from musicround.helpers.spotify_direct import SpotifyDirectClient
+
+        app.config["DATA_DIR"] = str(tmp_path)
+        app.config["SPOTIFY_CLIENT_ID"] = "client-id"
+        app.config["SPOTIFY_CLIENT_SECRET"] = "client-secret"
+
+        client = SpotifyDirectClient(bearer_token="token")
+
+        assert client.cache_path == os.path.join(str(tmp_path), ".spotifycache")
+
+
 class TestGetAvailableVoices:
     """Tests for the get_available_voices function."""
 


### PR DESCRIPTION
## Summary
- add a shared `DATA_DIR` helper for app-local file paths
- make custom MP3 uploads, backup storage, Spotify cache, authenticated data downloads, and hint-audio reads use the configured data directory
- document `DATA_DIR`, `ROUND_MP3_DIR`, and `ROUND_PDF_DIR` in the admin configuration guide

## Why
After the managed database work, #12/#126 still need the app to be less tied to one `/data` mount. This slice keeps the existing defaults but lets deployments move request-time file writes and reads to a different shared/app-data location without changing every caller.

## Validation
- `SECRET_KEY=test-secret-key-for-testing-only AUTOMATION_TOKEN=test-automation-token-for-testing .venv/bin/pytest tests/test_utils.py tests/test_backup_helper.py tests/test_additional_branches.py -q`
- `SECRET_KEY=test-secret-key-for-testing-only AUTOMATION_TOKEN=test-automation-token-for-testing .venv/bin/pytest tests/test_automation_service.py::TestAssetInspection tests/test_rounds_routes.py::TestRoundMp3Hints -q`
- `.venv/bin/python -m py_compile musicround/helpers/paths.py musicround/helpers/utils.py musicround/helpers/backup_helper.py musicround/routes/core.py musicround/routes/users.py musicround/helpers/spotify_direct.py musicround/services/automation.py musicround/routes/rounds.py tests/test_utils.py tests/test_backup_helper.py`
- `git diff --check`

Refs #12
Refs #126


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable application storage paths, letting audio files, backups, cached Spotify data, and uploaded MP3s be stored in a custom data directory.
  * Documented the new storage-related settings in the admin configuration guide.

* **Bug Fixes**
  * Updated file handling throughout the app to use the configured storage location instead of fixed paths, improving backup, audio playback, and health-check behavior.
  * Added test coverage for configured path handling and backup location reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->