### PR TITLE
Make SQLite fallback use DATA_DIR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added configurable `DATA_DIR` support for custom MP3s, backups, Spotify cache files, and authenticated data downloads.
 
 ### Fixed
+- Made the implicit SQLite fallback follow `DATA_DIR` so local/dev deployments no longer create `/data/song_data.db` when a different app-data directory is configured.
 - Hid internal/noisy import tags from the music-round builder while keeping raw tags in storage, and mapped common public aliases such as `hip hop` to `Hip-Hop`.
 - Stopped headered CSV playlist imports from treating the header row as a song and now flags missing artist/title cells for review.
 - Removed dead duplicate import and export helpers, and made the legacy Spotify diagnostics route use the configured Authlib client instead of a missing app-level Spotify client.

--- a/docs/admin-guide/configuration.md
+++ b/docs/admin-guide/configuration.md
@@ -106,6 +106,10 @@ ROUND_PDF_DIR=/data/pdfs
 # SQLALCHEMY_DATABASE_URI=postgresql://username:password@localhost/musicround
 ```
 
+When `SQLALCHEMY_DATABASE_URI` is omitted, the local SQLite fallback is created
+as `song_data.db` inside `DATA_DIR`. Production deployments should configure
+PostgreSQL instead and enable `DATABASE_REQUIRE_MANAGED=true`.
+
 ### OAuth Provider Configuration
 
 ```bash

--- a/docs/admin-guide/configuration.md
+++ b/docs/admin-guide/configuration.md
@@ -91,7 +91,7 @@ For optimal metadata quality, we recommend configuring at least Spotify and Last
 
 ```bash
 # SQLite (default)
-SQLALCHEMY_DATABASE_URI=sqlite:///data/song_data.db
+SQLALCHEMY_DATABASE_URI=sqlite:////data/song_data.db
 SQLALCHEMY_TRACK_MODIFICATIONS=False
 
 # Application file storage
@@ -177,7 +177,7 @@ Then edit the `.env` file with your actual configuration values:
 # Example .env file (simplified)
 SECRET_KEY=your-secure-secret-key
 DEBUG=True
-SQLALCHEMY_DATABASE_URI=sqlite:///data/song_data.db
+SQLALCHEMY_DATABASE_URI=sqlite:////data/song_data.db
 SPOTIFY_CLIENT_ID=your-spotify-client-id
 SPOTIFY_CLIENT_SECRET=your-spotify-client-secret
 # Add other variables as needed

--- a/musicround/__init__.py
+++ b/musicround/__init__.py
@@ -31,7 +31,14 @@ csrf = CSRFProtect()
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
 DEFAULT_DATABASE_DIR = '/data'
-DEFAULT_DATABASE_PATH = os.path.join(DEFAULT_DATABASE_DIR, 'song_data.db')
+
+
+def _default_database_dir(app):
+    return app.config.get('DATA_DIR') or os.environ.get('DATA_DIR') or DEFAULT_DATABASE_DIR
+
+
+def _default_database_path(app):
+    return os.path.join(_default_database_dir(app), 'song_data.db')
 
 
 def _configure_database_uri(app):
@@ -59,14 +66,16 @@ def _configure_database_uri(app):
     if managed_error:
         raise RuntimeError(managed_error)
 
-    if not os.path.exists(DEFAULT_DATABASE_DIR):
-        os.makedirs(DEFAULT_DATABASE_DIR, exist_ok=True)
-    app.config['SQLALCHEMY_DATABASE_URI'] = f'sqlite:///{DEFAULT_DATABASE_PATH}'
+    fallback_database_dir = _default_database_dir(app)
+    fallback_database_path = _default_database_path(app)
+    if not os.path.exists(fallback_database_dir):
+        os.makedirs(fallback_database_dir, exist_ok=True)
+    app.config['SQLALCHEMY_DATABASE_URI'] = f'sqlite:///{fallback_database_path}'
     app.config['DATABASE_BACKEND'] = 'sqlite'
     app.config['DATABASE_URI_REDACTED'] = 'sqlite:///[local-file]'
     app.logger.warning(
         "SQLALCHEMY_DATABASE_URI is not configured; using local SQLite fallback at %s",
-        DEFAULT_DATABASE_PATH,
+        fallback_database_path,
     )
 
 

--- a/musicround/__init__.py
+++ b/musicround/__init__.py
@@ -34,7 +34,7 @@ DEFAULT_DATABASE_DIR = '/data'
 
 
 def _default_database_dir(app):
-    return app.config.get('DATA_DIR') or os.environ.get('DATA_DIR') or DEFAULT_DATABASE_DIR
+    return os.environ.get('DATA_DIR') or app.config.get('DATA_DIR') or DEFAULT_DATABASE_DIR
 
 
 def _default_database_path(app):

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -137,9 +137,31 @@ def test_configure_database_uri_uses_sqlite_fallback(monkeypatch):
 def test_configure_database_uri_uses_configured_data_dir(monkeypatch, tmp_path):
     """SQLite fallback should follow DATA_DIR when deployments override it."""
     monkeypatch.delenv('SQLALCHEMY_DATABASE_URI', raising=False)
+    monkeypatch.delenv('DATA_DIR', raising=False)
     created_paths = []
     app = Flask(__name__)
     app.config['DATA_DIR'] = str(tmp_path)
+
+    monkeypatch.setattr('musicround.os.path.exists', lambda path: False)
+    monkeypatch.setattr(
+        'musicround.os.makedirs',
+        lambda path, exist_ok=False: created_paths.append((path, exist_ok)),
+    )
+
+    _configure_database_uri(app)
+
+    assert app.config['SQLALCHEMY_DATABASE_URI'] == f"sqlite:///{tmp_path}/song_data.db"
+    assert app.config['DATABASE_BACKEND'] == 'sqlite'
+    assert created_paths == [(str(tmp_path), True)]
+
+
+def test_configure_database_uri_prefers_env_data_dir(monkeypatch, tmp_path):
+    """SQLite fallback should follow DATA_DIR from the runtime environment."""
+    monkeypatch.delenv('SQLALCHEMY_DATABASE_URI', raising=False)
+    monkeypatch.setenv('DATA_DIR', str(tmp_path))
+    created_paths = []
+    app = Flask(__name__)
+    app.config['DATA_DIR'] = '/data'
 
     monkeypatch.setattr('musicround.os.path.exists', lambda path: False)
     monkeypatch.setattr(

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -117,6 +117,7 @@ def test_postgres_env_readiness_reports_only_key_names():
 def test_configure_database_uri_uses_sqlite_fallback(monkeypatch):
     """Test fallback SQLite path is only used when no URI is configured."""
     monkeypatch.delenv('SQLALCHEMY_DATABASE_URI', raising=False)
+    monkeypatch.delenv('DATA_DIR', raising=False)
     created_paths = []
     app = Flask(__name__)
 
@@ -131,6 +132,26 @@ def test_configure_database_uri_uses_sqlite_fallback(monkeypatch):
     assert app.config['SQLALCHEMY_DATABASE_URI'] == 'sqlite:////data/song_data.db'
     assert app.config['DATABASE_BACKEND'] == 'sqlite'
     assert created_paths == [('/data', True)]
+
+
+def test_configure_database_uri_uses_configured_data_dir(monkeypatch, tmp_path):
+    """SQLite fallback should follow DATA_DIR when deployments override it."""
+    monkeypatch.delenv('SQLALCHEMY_DATABASE_URI', raising=False)
+    created_paths = []
+    app = Flask(__name__)
+    app.config['DATA_DIR'] = str(tmp_path)
+
+    monkeypatch.setattr('musicround.os.path.exists', lambda path: False)
+    monkeypatch.setattr(
+        'musicround.os.makedirs',
+        lambda path, exist_ok=False: created_paths.append((path, exist_ok)),
+    )
+
+    _configure_database_uri(app)
+
+    assert app.config['SQLALCHEMY_DATABASE_URI'] == f"sqlite:///{tmp_path}/song_data.db"
+    assert app.config['DATABASE_BACKEND'] == 'sqlite'
+    assert created_paths == [(str(tmp_path), True)]
 
 
 def test_configure_database_uri_requires_managed_database(monkeypatch):


### PR DESCRIPTION
## Summary
- Make the implicit SQLite fallback database path follow the configured DATA_DIR before using the legacy /data default.
- Keep /data/song_data.db as the compatibility fallback when neither app config nor environment override is set.
- Document the fallback behavior and update the changelog.

## Why
This closes a deploy/runtime mismatch after configurable DATA_DIR support: local/dev deployments that intentionally use another app-data directory should not silently create or write /data/song_data.db.

## Validation
- SECRET_KEY=test-secret AUTOMATION_TOKEN=test-token .venv/bin/pytest tests/test_app_factory.py -q
- .venv/bin/python -m py_compile musicround/__init__.py tests/test_app_factory.py
- git diff --check

Refs #12
Refs #126