### PR TITLE
Harden backup download path validation

### DIFF
--- a/musicround/routes/users.py
+++ b/musicround/routes/users.py
@@ -1573,14 +1573,19 @@ def download_backup(filename):
     """Download a backup file"""
     import os
     from flask import send_file, abort
+
+    if filename != os.path.basename(filename) or '/' in filename or '\\' in filename:
+        abort(400, "Invalid backup filename")
     
     # Security check: only allow .zip files
     if not filename.endswith('.zip'):
         abort(400, "Invalid file type")
     
     # Only allow downloading from the backup directory
-    backups_path = backup_dir()
-    backup_path = os.path.join(backups_path, filename)
+    backups_path = os.path.realpath(backup_dir())
+    backup_path = os.path.realpath(os.path.join(backups_path, filename))
+    if not backup_path.startswith(backups_path + os.sep) and backup_path != backups_path:
+        abort(400, "Invalid backup path")
     
     # Check if the file exists
     if not os.path.exists(backup_path):

--- a/tests/test_additional_branches.py
+++ b/tests/test_additional_branches.py
@@ -1,6 +1,7 @@
 """Additional tests for setup, system health, and API branches."""
 import json
 import pytest
+from werkzeug.exceptions import BadRequest
 from musicround.helpers.import_queue import ImportQueue
 from musicround.models import db, ImportJobRecord, User, Role, Song, Tag
 
@@ -261,6 +262,47 @@ class TestSystemHealthRoute:
         assert 'database-uri-secret' not in body
         assert 'health-secret' not in body
         assert 'traceback' not in body
+
+
+class TestBackupDownloadRoutes:
+    """Tests for admin backup download path validation."""
+
+    def test_download_backup_rejects_path_traversal_filename(
+        self,
+        app,
+        monkeypatch,
+        tmp_path,
+    ):
+        """Backup downloads should reject non-basename filenames."""
+        from musicround.routes import users
+
+        backups_path = tmp_path / "backups"
+        backups_path.mkdir()
+        (tmp_path / "other.zip").write_bytes(b"outside")
+        monkeypatch.setattr(users, "backup_dir", lambda: str(backups_path))
+
+        with app.test_request_context("/users/download-backup/ignored"):
+            with pytest.raises(BadRequest):
+                users.download_backup.__wrapped__.__wrapped__("../other.zip")
+
+    def test_download_backup_serves_basename_zip(
+        self,
+        app,
+        monkeypatch,
+        tmp_path,
+    ):
+        """Valid backup basenames still download from the configured backup dir."""
+        from musicround.routes import users
+
+        backups_path = tmp_path / "backups"
+        backups_path.mkdir()
+        (backups_path / "safe.zip").write_bytes(b"backup")
+        monkeypatch.setattr(users, "backup_dir", lambda: str(backups_path))
+
+        with app.test_request_context("/users/download-backup/safe.zip"):
+            response = users.download_backup.__wrapped__.__wrapped__("safe.zip")
+
+        assert response.status_code == 200
 
 
 class TestSongApiExtendedBranches:


### PR DESCRIPTION
## Summary
- reject path traversal and nested path segments in backup download filenames
- resolve backup paths before serving archives
- add route-level regression coverage for traversal rejection and valid ZIP download

## Validation
- python3 -m py_compile musicround/routes/users.py tests/test_additional_branches.py
- git diff --check
- FLASK_ENV=testing SECRET_KEY=ci-test-secret-key AUTOMATION_TOKEN=ci-test-automation-token /tmp/qb-164-followup-py312/bin/python -m pytest tests/test_additional_branches.py -q