### PR TITLE
Allow Compose to use managed database config

### DIFF
--- a/.env.demo
+++ b/.env.demo
@@ -25,8 +25,20 @@ ACRCLOUD_TOKEN=your-acrcloud-token
 LASTFM_API_KEY=your-lastfm-api-key
 
 # Database configuration
-SQLALCHEMY_DATABASE_URI=sqlite:///data/song_data.db
+# Leave SQLALCHEMY_DATABASE_URI blank for the local SQLite fallback. The app
+# will create song_data.db inside DATA_DIR. Production should use a managed
+# database and enable DATABASE_REQUIRE_MANAGED=true.
+# SQLALCHEMY_DATABASE_URI=sqlite:////data/song_data.db
 SQLALCHEMY_TRACK_MODIFICATIONS=False
+DATA_DIR=/data
+ROUND_MP3_DIR=/data/rounds
+ROUND_PDF_DIR=/data/pdfs
+# DATABASE_REQUIRE_MANAGED=true
+# PGHOST=postgres-rw.namespace.svc.cluster.local
+# PGPORT=5432
+# PGDATABASE=quizzicalbeats
+# PGUSER=quizzicalbeats
+# PGPASSWORD=change-me
 
 # HTTPS Configuration (for reverse proxy environments)
 # Set to True when running behind a reverse proxy with HTTPS offloading (e.g., Traefik)

--- a/.env.example
+++ b/.env.example
@@ -27,13 +27,21 @@ PERMANENT_SESSION_LIFETIME_HOURS=12
 # ============================================================================
 # DATABASE CONFIGURATION
 # ============================================================================
-SQLALCHEMY_DATABASE_URI=sqlite:///data/song_data.db
-# Clear or remove SQLALCHEMY_DATABASE_URI before using PGHOST/PGDATABASE/
-# PGUSER/PGPASSWORD in production; the full URI takes precedence when set.
+# Leave SQLALCHEMY_DATABASE_URI blank for the local SQLite fallback. The app
+# will create song_data.db inside DATA_DIR. Production should use a managed
+# database and enable DATABASE_REQUIRE_MANAGED=true.
+# SQLALCHEMY_DATABASE_URI=sqlite:////data/song_data.db
 SQLALCHEMY_TRACK_MODIFICATIONS=False
-# Production can alternatively set PGHOST, PGDATABASE, PGUSER, and PGPASSWORD
-# instead of one full SQLALCHEMY_DATABASE_URI. This keeps generated database
-# credentials split when using CNPG/Kubernetes secretKeyRef entries.
+
+DATA_DIR=/data
+ROUND_MP3_DIR=/data/rounds
+ROUND_PDF_DIR=/data/pdfs
+
+# Production can set PGHOST, PGDATABASE, PGUSER, and PGPASSWORD instead of one
+# full SQLALCHEMY_DATABASE_URI. This keeps generated database credentials split
+# when using CNPG/Kubernetes secretKeyRef entries. Clear or remove
+# SQLALCHEMY_DATABASE_URI before using PG* variables; the full URI takes
+# precedence when set.
 # DATABASE_REQUIRE_MANAGED=true
 # PGHOST=postgres-rw.namespace.svc.cluster.local
 # PGPORT=5432

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added an agentic backlog-status crosswalk that maps open GitHub issues to
+  implemented, partial, open, or live-operational follow-up slices.
 - Added a browser round-ops workflow with round calendar, catalog/fatigue analytics, quizmaster planning briefs, round review/approval state, package quality inspection, actionable replacement suggestions, and browser review of announcement and per-track hint script drafts.
 - Added a public-safe `/healthz` endpoint and reusable service-health payloads for database, artifact storage, Spotify, Dropbox, and email checks.
 - Added import queue and worker health to service-health payloads, including pending/dead-letter job warnings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added configurable `DATA_DIR` support for custom MP3s, backups, Spotify cache files, and authenticated data downloads.
 
 ### Fixed
+- Stopped Docker Compose from hard-coding the SQLite database URI so `.env`
+  PostgreSQL component variables can exercise the managed-database path.
 - Made the implicit SQLite fallback follow `DATA_DIR` so local/dev deployments no longer create `/data/song_data.db` when a different app-data directory is configured.
 - Hid internal/noisy import tags from the music-round builder while keeping raw tags in storage, and mapped common public aliases such as `hip hop` to `Hip-Hop`.
 - Stopped headered CSV playlist imports from treating the header row as a song and now flags missing artist/title cells for review.

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Comprehensive documentation is available at [quizzicalbeats.readthedocs.io](http
 - [User Guide](https://quizzicalbeats.readthedocs.io/user-guide/getting-started.html)
 - [Admin Guide](https://quizzicalbeats.readthedocs.io/admin-guide/installation.html)
 - [Developer Guide](https://quizzicalbeats.readthedocs.io/developer-guide/architecture.html)
+- [Agentic Backlog Status](docs/developer-guide/backlog-status.md) - issue crosswalk for local coding-agent work
 - [API Reference](https://quizzicalbeats.readthedocs.io/developer-guide/api-reference.html)
 - [FAQ](https://quizzicalbeats.readthedocs.io/faq.html)
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,14 @@
 
 4. Access the application at `http://localhost:5000`.
 
+   By default, Docker Compose uses the app's local SQLite fallback under
+   `/data`. To test the managed PostgreSQL path locally, set
+   `DATABASE_REQUIRE_MANAGED=true` plus `PGHOST=postgres`, `PGDATABASE`,
+   `PGUSER`, and `PGPASSWORD` in `.env`, then run:
+   ```bash
+   docker compose --profile managed-db up -d
+   ```
+
 #### Manual Installation
 
 1. Clone the repository:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,7 @@
 # Quizzical Beats - Project Roadmap
 
 **Version**: 2026.Q3
-**Last Updated**: July 6, 2026
+**Last Updated**: July 7, 2026
 
 ## Vision Statement
 
@@ -11,7 +11,7 @@ Quizzical Beats aims to be the premier platform for creating, managing, and deli
 
 **Latest Release**: v1.10 - "Import Infrastructure"
 **Active Development**: v2.x - Reliability, Performance, and Agentic Round Production
-**Repository Health**: ✅ Production-Ready
+**Repository Health**: 🟡 Production-hardening in progress; managed database cutover remains the main blocker
 
 ---
 
@@ -314,7 +314,7 @@ Quizzical Beats aims to be the premier platform for creating, managing, and deli
 ---
 
 #### v3.0 - "Rhythm Roundsmith" *(Q3 2026 - HIGH PRIORITY)*
-**Status**: 🔴 Not Started  
+**Status**: 🟡 In Progress
 **Priority**: High  
 **Effort**: 3-4 weeks
 
@@ -396,7 +396,7 @@ Quizzical Beats aims to be the premier platform for creating, managing, and deli
 ---
 
 #### v3.3 - "Alert Amplifier" *(Q3 2026 - MEDIUM PRIORITY)*
-**Status**: 🔴 Not Started  
+**Status**: 🟡 Partially Complete
 **Priority**: Medium  
 **Effort**: 1-2 weeks
 
@@ -449,7 +449,7 @@ Quizzical Beats aims to be the premier platform for creating, managing, and deli
 ---
 
 #### v4.1 - "Collaboration Core" *(Q4 2026 - MEDIUM PRIORITY)*
-**Status**: 🔴 Not Started  
+**Status**: 🟡 In Progress
 **Priority**: Medium  
 **Effort**: 3 weeks
 
@@ -475,7 +475,7 @@ Quizzical Beats aims to be the premier platform for creating, managing, and deli
 ---
 
 #### v4.2 - "Profile Personalizer" *(Q4 2026 - LOW PRIORITY)*
-**Status**: 🟡 Partially Complete  
+**Status**: 🟡 Partially Complete
 **Priority**: Low  
 **Effort**: 1 week
 
@@ -515,6 +515,14 @@ Quizzical Beats aims to be the premier platform for creating, managing, and deli
 ---
 
 ## 🔮 Future Considerations (2027+)
+
+## GitHub Issue Alignment
+
+The issue backlog has been split into repository-local slices and live
+operational work in [Agentic Backlog Status](docs/developer-guide/backlog-status.md).
+Agents should use that crosswalk before starting new work so completed slices
+such as import retry handling, text playlist parsing, round readiness badges,
+quizmaster context, planned quiz dates, and TTS script review are not rebuilt.
 
 ### Ideas Under Evaluation
 

--- a/TODO.md
+++ b/TODO.md
@@ -91,6 +91,12 @@
 
 ## 🆕 Upcoming Milestones
 
+## Backlog Alignment
+
+* [x] Add an agent-readable GitHub issue crosswalk in `docs/developer-guide/backlog-status.md`
+* [ ] Close or comment ready-to-close implementation issues after release smoke verification
+* [ ] Split partially completed issues into smaller browser/UI or operational follow-ups where needed
+
 
 ### 🎯 Milestone 10: **"Import Infrastructure" Release** – Queue & Worker Setup
 
@@ -260,4 +266,4 @@
   * [ ] Implement keyboard shortcuts in the application
   * [ ] Document keyboard shortcuts for power users when implemented
 
-*Last updated: July 6, 2026*
+*Last updated: July 7, 2026*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,9 @@ services:
       - FLASK_APP=run.py
       - FLASK_ENV=development  # Using the older style for compatibility
       - FLASK_DEBUG=1
-      - SQLALCHEMY_DATABASE_URI=sqlite:///data/song_data.db
+      - DATA_DIR=/data
+      - ROUND_MP3_DIR=/data/rounds
+      - ROUND_PDF_DIR=/data/pdfs
       - PYTHONUNBUFFERED=1
       # Hot reloading specific settings
       - FLASK_RUN_EXTRA_FILES=./templates:/app/templates,./static:/app/static
@@ -61,6 +63,25 @@ services:
       ofelia.job-local.my-test-job.schedule: "@hourly"
       ofelia.job-local.my-test-job.command: "date"
 
+  postgres:
+    image: postgres:16-alpine
+    profiles:
+      - managed-db
+    environment:
+      - POSTGRES_DB=${PGDATABASE:-quizzicalbeats}
+      - POSTGRES_USER=${PGUSER:-quizzicalbeats}
+      - POSTGRES_PASSWORD=${PGPASSWORD:-quizzicalbeats-dev-password-change-me}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U \"$${POSTGRES_USER}\" -d \"$${POSTGRES_DB}\""]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
 volumes:
   musicround_data:
+    driver: local
+  postgres_data:
     driver: local

--- a/docs/admin-guide/configuration.md
+++ b/docs/admin-guide/configuration.md
@@ -90,8 +90,7 @@ For optimal metadata quality, we recommend configuring at least Spotify and Last
 ### Database Configuration
 
 ```bash
-# SQLite (default)
-SQLALCHEMY_DATABASE_URI=sqlite:////data/song_data.db
+# SQLite fallback for local development. Leave SQLALCHEMY_DATABASE_URI unset.
 SQLALCHEMY_TRACK_MODIFICATIONS=False
 
 # Application file storage
@@ -104,11 +103,21 @@ ROUND_PDF_DIR=/data/pdfs
 
 # For PostgreSQL:
 # SQLALCHEMY_DATABASE_URI=postgresql://username:password@localhost/musicround
+
+# Or use split PostgreSQL variables for secretKeyRef-based deployments:
+# DATABASE_REQUIRE_MANAGED=true
+# PGHOST=postgres-rw.namespace.svc.cluster.local
+# PGPORT=5432
+# PGDATABASE=quizzicalbeats
+# PGUSER=quizzicalbeats
+# PGPASSWORD=change-me
 ```
 
 When `SQLALCHEMY_DATABASE_URI` is omitted, the local SQLite fallback is created
 as `song_data.db` inside `DATA_DIR`. Production deployments should configure
-PostgreSQL instead and enable `DATABASE_REQUIRE_MANAGED=true`.
+PostgreSQL instead and enable `DATABASE_REQUIRE_MANAGED=true`. If both
+`SQLALCHEMY_DATABASE_URI` and `PG*` variables are set, the full URI wins; remove
+or blank it before relying on split PostgreSQL variables.
 
 ### OAuth Provider Configuration
 

--- a/docs/admin-guide/installation.md
+++ b/docs/admin-guide/installation.md
@@ -43,6 +43,30 @@ The easiest way to deploy Quizzical Beats is using Docker:
 
 4. Access the application at `http://localhost:5000`
 
+### Local PostgreSQL Compose Profile
+
+The default Compose setup is for development and leaves the database URI unset,
+so the app creates a SQLite fallback at `/data/song_data.db`. To exercise the
+managed-database path locally, configure split PostgreSQL variables in `.env`:
+
+```bash
+DATABASE_REQUIRE_MANAGED=true
+PGHOST=postgres
+PGPORT=5432
+PGDATABASE=quizzicalbeats
+PGUSER=quizzicalbeats
+PGPASSWORD=change-this-local-password
+```
+
+Then start the app with the managed database profile:
+
+```bash
+docker compose --profile managed-db up -d
+```
+
+Do not set `SQLALCHEMY_DATABASE_URI` at the same time unless you intentionally
+want the full URI to take precedence over the `PG*` variables.
+
 ### Docker Volume Configuration
 
 The Docker setup creates several persistent volumes:

--- a/docs/developer-guide/backlog-status.md
+++ b/docs/developer-guide/backlog-status.md
@@ -1,0 +1,52 @@
+# Agentic Backlog Status
+
+Last updated: July 7, 2026
+
+This page keeps the GitHub issue backlog aligned with what is actually present
+in the codebase. It is meant for coding agents before they pick the next local
+work block: do not rebuild a slice listed as "ready to close"; either close the
+issue after verification or continue with the remaining follow-up.
+
+## Status Key
+
+- **Ready to close**: implemented in code and covered by focused tests or
+  documentation.
+- **Partial**: a meaningful core slice exists, but the GitHub issue still has
+  remaining acceptance criteria.
+- **Open**: not yet implemented beyond planning or documentation.
+- **Operational**: requires live QB, Gmail, Kubernetes, or secret-backed
+  verification rather than only repository changes.
+
+## Current Issue Crosswalk
+
+| Issue | Status | Evidence in repo | Remaining work |
+| --- | --- | --- | --- |
+| #56 Add readiness and schedule status columns to rounds list | Ready to close | `musicround/routes/rounds.py`, `musicround/templates/rounds.html`, `tests/test_rounds_routes.py` | Verify deployed rounds list after release. |
+| #57 Normalize and curate tags shown in the round builder | Ready to close | `musicround/routes/generate.py`, `tests/test_generate.py` | Verify production tag dropdown contains no internal import tags. |
+| #58 Reduce song library memory usage and lazy-load previews | Ready to close | `musicround/routes/core.py`, `musicround/templates/view_songs.html`, `tests/test_final_coverage.py` | Browser-smoke large catalog after deploy. |
+| #65 ROADMAP.md / TODO.md status drift | Ready to close after this doc lands | `ROADMAP.md`, `TODO.md`, this status page | Close once this crosswalk is merged. |
+| #66 Add retry and dead-letter handling for import jobs | Ready to close | `musicround/helpers/import_queue.py`, `musicround/services/automation.py`, `tests/test_import_queue.py` | Verify one failed import can be retried in production. |
+| #67 Expose import progress events for active jobs | Ready to close | `musicround/mcp_server.py`, `musicround/services/automation.py`, `musicround/templates/import_queue_status.html` | Optional browser auto-refresh polish can be a separate issue. |
+| #68 Add text and CSV playlist parser service | Ready to close | `musicround/services/automation.py`, `musicround/mcp_server.py`, `tests/test_automation_service.py` | None for parser/MCP scope. |
+| #69 Add review workflow for low-confidence text imports | Partial | Parser returns reviewable unresolved rows through MCP | Browser review UI remains open; keep issue or split browser UI follow-up. |
+| #70 Add quizmaster preference model and MCP summary | Ready to close | `UserPreferences`, `quizmaster_context`, MCP docs | Verify one real quizmaster context call in MCP after deploy. |
+| #71 Add planned quiz date model for scheduled round generation | Ready to close | `PlannedQuizRound`, browser calendar, MCP planning tools | Verify upcoming production quiz dates render after deploy. |
+| #72 Add recent usage and fatigue summary API for agents | Ready to close | `recent_usage_summary`, `round_analytics_summary`, `round_planning_brief` | None for API/MCP scope. |
+| #73 Add MCP tool to draft round intro, replay, and outro scripts | Ready to close | `draft_round_audio_scripts`, MCP docs, round detail actions | Verify one draft for a real round after deploy. |
+| #74 Store and review generated TTS scripts before audio assignment | Ready to close | `RoundAudioScript`, review routes, `generate_tts_from_script` | Verify approved script-to-audio assignment with configured TTS provider. |
+| #75 Add chart and festival seed source registry | Open | Roadmap only | Build source registry model/service and seed-source admin review. |
+| #79 Add round ownership and sharing roles | Partial | `RoundShare`, owner filtering, edit checks, MCP share tools | Invite UI, public links, audit log, and richer roles remain open. |
+| #126 Move production database configuration off SQLite `/data` | Operational / partial | Managed DB config, migration CLI, runbook, Compose managed-db profile | Live Kubernetes secret/config cutover and scheduled-email smoke remain. |
+| #12 Remove SQLite/RWO singleton | Operational / partial | Same as #126, plus app config hardening | Requires managed DB cutover, stateless replicas, and backup replacement. |
+| #17/#48/#49 Repair and clean broken round emails | Operational | Quality gate and repair tooling exist | Needs live QB/Gmail inspection and cleanup, not repo-only code. |
+
+## Next Local Work Blocks
+
+1. Close or comment the "ready to close" issues after a release smoke confirms
+   the linked browser/MCP behavior.
+2. For #69, build the browser review page for unresolved text playlist rows.
+3. For #75, add a chart/festival source registry and ingestion-run model before
+   adding scrapers.
+4. For #79, add invite/search UI and access-audit events around `RoundShare`.
+5. For #126/#12, continue with live deployment configuration only through the
+   existing 1Password-backed secret flow and credential-safe Kubernetes checks.

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,7 @@ This documentation is organized into several sections:
 - **[User Guide](user-guide/getting-started.md)**: Learn how to use Quizzical Beats
 - **[Admin Guide](admin-guide/installation.md)**: Installation and maintenance information
 - **[Developer Guide](developer-guide/architecture.md)**: Technical documentation for developers
+- **[Agentic Backlog Status](developer-guide/backlog-status.md)**: Current GitHub issue crosswalk for coding agents
 - **[FAQ](faq.md)**: Frequently asked questions
 - **[Changelog](changelog.md)**: Version history and feature additions
 


### PR DESCRIPTION
## Summary
- Stop Docker Compose from hard-coding a SQLite database URI for the web service so PG* values from `.env` can take effect.
- Add an opt-in `managed-db` Compose profile with a local Postgres service for exercising managed database startup.
- Update env examples, README, admin configuration, installation docs, and changelog with the SQLite fallback vs managed database split.

## Why
This removes a local/runtime configuration trap on the path to #126: Compose previously set SQLite even when operators configured split PostgreSQL variables in `.env`, which made managed-database testing look configured while the app still stayed on SQLite.

## Validation
- Parsed `docker-compose.yml` with PyYAML and asserted the web service no longer sets `SQLALCHEMY_DATABASE_URI` while the `managed-db` Postgres profile is present.
- `SECRET_KEY=test-secret AUTOMATION_TOKEN=test-token .venv/bin/pytest tests/test_app_factory.py -q`
- `git diff --check`

Note: Docker/Compose binaries are not installed in this local runner, so `docker compose config` could not be executed here.

Refs #12
Refs #126

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer setup options for running the app with either local SQLite fallback or a managed PostgreSQL configuration.
  * Introduced new guidance for switching Docker Compose to the managed database profile.

* **Documentation**
  * Expanded installation, configuration, roadmap, and developer docs with updated database setup steps and reference links.
  * Added a new backlog-status reference to help track current work and remaining items.

* **Bug Fixes**
  * Removed the hard-coded default database path so configuration behavior is more predictable across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->