### PR TITLE
Require managed-db Postgres password

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,7 +70,7 @@ services:
     environment:
       - POSTGRES_DB=${PGDATABASE:-quizzicalbeats}
       - POSTGRES_USER=${PGUSER:-quizzicalbeats}
-      - POSTGRES_PASSWORD=${PGPASSWORD:-quizzicalbeats-dev-password-change-me}
+      - POSTGRES_PASSWORD=${PGPASSWORD:-}
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:

--- a/docs/admin-guide/installation.md
+++ b/docs/admin-guide/installation.md
@@ -64,6 +64,10 @@ Then start the app with the managed database profile:
 docker compose --profile managed-db up -d
 ```
 
+The managed database profile intentionally does not provide a default
+`PGPASSWORD`. Set it before starting the profile; otherwise the local Postgres
+service will refuse to initialize instead of using a known password.
+
 Do not set `SQLALCHEMY_DATABASE_URI` at the same time unless you intentionally
 want the full URI to take precedence over the `PG*` variables.
 


### PR DESCRIPTION
## Summary
- require PGPASSWORD when the managed-db Compose profile is enabled
- document the fail-fast behavior in the Docker installation guide

## Validation
- git diff --check
- python3 guard check for the required PGPASSWORD expansion and removed default password
- Docker Compose config validation not run: docker is not installed in this environment