### PR TITLE
Build round review and seed source workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added an agentic backlog-status crosswalk that maps open GitHub issues to
   implemented, partial, open, or live-operational follow-up slices.
+- Added a browser text-playlist review workflow that blocks round creation
+  until exactly eight pasted rows resolve to catalog songs.
+- Added browser round sharing controls for owners/admins to grant and revoke
+  viewer/editor access from the round detail page.
+- Added a chart/festival seed-source registry with run history, Flask-Admin
+  views, migrations, and MCP automation helpers.
 - Added a browser round-ops workflow with round calendar, catalog/fatigue analytics, quizmaster planning briefs, round review/approval state, package quality inspection, actionable replacement suggestions, and browser review of announcement and per-track hint script drafts.
 - Added a public-safe `/healthz` endpoint and reusable service-health payloads for database, artifact storage, Spotify, Dropbox, and email checks.
 - Added import queue and worker health to service-health payloads, including pending/dead-letter job warnings.

--- a/docs/developer-guide/backlog-status.md
+++ b/docs/developer-guide/backlog-status.md
@@ -28,14 +28,14 @@ issue after verification or continue with the remaining follow-up.
 | #66 Add retry and dead-letter handling for import jobs | Ready to close | `musicround/helpers/import_queue.py`, `musicround/services/automation.py`, `tests/test_import_queue.py` | Verify one failed import can be retried in production. |
 | #67 Expose import progress events for active jobs | Ready to close | `musicround/mcp_server.py`, `musicround/services/automation.py`, `musicround/templates/import_queue_status.html` | Optional browser auto-refresh polish can be a separate issue. |
 | #68 Add text and CSV playlist parser service | Ready to close | `musicround/services/automation.py`, `musicround/mcp_server.py`, `tests/test_automation_service.py` | None for parser/MCP scope. |
-| #69 Add review workflow for low-confidence text imports | Partial | Parser returns reviewable unresolved rows through MCP | Browser review UI remains open; keep issue or split browser UI follow-up. |
+| #69 Add review workflow for low-confidence text imports | Ready to close after deploy smoke | Browser review UI, exact eight-song create gate, MCP/parser review payloads | Smoke paste one unresolved and one complete eight-song text list. |
 | #70 Add quizmaster preference model and MCP summary | Ready to close | `UserPreferences`, `quizmaster_context`, MCP docs | Verify one real quizmaster context call in MCP after deploy. |
 | #71 Add planned quiz date model for scheduled round generation | Ready to close | `PlannedQuizRound`, browser calendar, MCP planning tools | Verify upcoming production quiz dates render after deploy. |
 | #72 Add recent usage and fatigue summary API for agents | Ready to close | `recent_usage_summary`, `round_analytics_summary`, `round_planning_brief` | None for API/MCP scope. |
 | #73 Add MCP tool to draft round intro, replay, and outro scripts | Ready to close | `draft_round_audio_scripts`, MCP docs, round detail actions | Verify one draft for a real round after deploy. |
 | #74 Store and review generated TTS scripts before audio assignment | Ready to close | `RoundAudioScript`, review routes, `generate_tts_from_script` | Verify approved script-to-audio assignment with configured TTS provider. |
-| #75 Add chart and festival seed source registry | Open | Roadmap only | Build source registry model/service and seed-source admin review. |
-| #79 Add round ownership and sharing roles | Partial | `RoundShare`, owner filtering, edit checks, MCP share tools | Invite UI, public links, audit log, and richer roles remain open. |
+| #75 Add chart and festival seed source registry | Partial | `SeedSource`, `SeedSourceRun`, admin views, MCP registry/run tools | Scrapers/importers for individual chart/festival providers remain separate slices. |
+| #79 Add round ownership and sharing roles | Partial | `RoundShare`, owner filtering, edit checks, MCP share tools, browser share/revoke UI | Public links, audit log, and richer roles remain open. |
 | #126 Move production database configuration off SQLite `/data` | Operational / partial | Managed DB config, migration CLI, runbook, Compose managed-db profile | Live Kubernetes secret/config cutover and scheduled-email smoke remain. |
 | #12 Remove SQLite/RWO singleton | Operational / partial | Same as #126, plus app config hardening | Requires managed DB cutover, stateless replicas, and backup replacement. |
 | #17/#48/#49 Repair and clean broken round emails | Operational | Quality gate and repair tooling exist | Needs live QB/Gmail inspection and cleanup, not repo-only code. |
@@ -44,9 +44,8 @@ issue after verification or continue with the remaining follow-up.
 
 1. Close or comment the "ready to close" issues after a release smoke confirms
    the linked browser/MCP behavior.
-2. For #69, build the browser review page for unresolved text playlist rows.
-3. For #75, add a chart/festival source registry and ingestion-run model before
-   adding scrapers.
-4. For #79, add invite/search UI and access-audit events around `RoundShare`.
+2. For #75, add first provider-specific source fetchers on top of the registry.
+3. For #79, add access-audit events and optional public read-only links around
+   `RoundShare`.
 5. For #126/#12, continue with live deployment configuration only through the
    existing 1Password-backed secret flow and credential-safe Kubernetes checks.

--- a/docs/developer-guide/database-schema.md
+++ b/docs/developer-guide/database-schema.md
@@ -246,6 +246,42 @@ before it is turned into quizmaster audio.
 | created_at         | DateTime     | Creation timestamp                               |
 | updated_at         | DateTime     | Last update timestamp                            |
 
+### SeedSource
+
+The `SeedSource` table stores chart, festival, editorial, curated, and playlist
+sources that agents can use when planning catalog enrichment.
+
+| Column      | Type         | Description                                      |
+|-------------|--------------|--------------------------------------------------|
+| id          | Integer      | Primary key                                      |
+| name        | String(200)  | Human-readable source name                       |
+| source_type | String(50)   | chart, festival, editorial, curated, or playlist |
+| provider    | String(100)  | Source owner/provider                            |
+| url         | String(500)  | Source URL                                       |
+| cadence     | String(50)   | Expected refresh cadence                         |
+| active      | Boolean      | Whether agents should consider the source        |
+| priority    | Integer      | Lower values are considered first                |
+| notes       | Text         | Review notes and source constraints              |
+| created_at  | DateTime     | Creation timestamp                               |
+| updated_at  | DateTime     | Last update timestamp                            |
+
+### SeedSourceRun
+
+The `SeedSourceRun` table records read/import attempts for configured seed
+sources.
+
+| Column         | Type       | Description                                  |
+|----------------|------------|----------------------------------------------|
+| id             | Integer    | Primary key                                  |
+| seed_source_id | Integer    | Foreign key to SeedSource                    |
+| status         | String(30) | planned, running, success, partial, failed   |
+| started_at     | DateTime   | Run start timestamp                          |
+| completed_at   | DateTime   | Run completion timestamp                     |
+| songs_seen     | Integer    | Candidate songs seen in the source           |
+| songs_imported | Integer    | Songs imported or linked from the source     |
+| error_message  | Text       | Safe failure summary                         |
+| notes          | Text       | Run notes                                    |
+
 ### RoundExport
 
 The `RoundExport` table tracks exports of rounds to various destinations.

--- a/docs/developer-guide/mcp.md
+++ b/docs/developer-guide/mcp.md
@@ -54,6 +54,9 @@ The MCP server exposes these tools:
 | `share_round` | Share a round with another quizmaster as viewer or editor. |
 | `list_round_shares` | List explicit share grants for a round. |
 | `revoke_round_share` | Remove a user's share grant from a round. |
+| `register_seed_source` | Create or update a chart, festival, editorial, curated, or playlist seed source. |
+| `list_seed_sources` | List configured catalog seed sources for agent planning. |
+| `record_seed_source_run` | Record seed-source read/import attempts and outcomes. |
 | `suggest_replacement_songs` | Suggest catalog songs for one failed round position. |
 | `replace_round_song` | Replace one song at a 1-based round position and invalidate generated assets. |
 | `suggest_additional_songs` | Suggest catalog songs that can complete an incomplete round. |

--- a/migrations/add_seed_source_registry.py
+++ b/migrations/add_seed_source_registry.py
@@ -1,0 +1,125 @@
+"""Add seed source registry tables for chart and festival ingestion planning."""
+
+import logging
+
+from sqlalchemy import inspect, text
+
+logger = logging.getLogger(__name__)
+
+
+def _quote(identifier, preparer):
+    return preparer.quote(identifier)
+
+
+def _table_exists(inspector, table_name):
+    return table_name in set(inspector.get_table_names())
+
+
+def _columns(inspector, table_name):
+    return {column["name"] for column in inspector.get_columns(table_name)}
+
+
+def _index_exists(inspector, table_name, index_name):
+    return any(index.get("name") == index_name for index in inspector.get_indexes(table_name))
+
+
+def _create_index(conn, inspector, table_name, index_name, columns):
+    if _index_exists(inspector, table_name, index_name):
+        return False
+    preparer = conn.dialect.identifier_preparer
+    quoted_table = _quote(table_name, preparer)
+    quoted_index = _quote(index_name, preparer)
+    quoted_columns = ", ".join(_quote(column, preparer) for column in columns)
+    conn.execute(text(f"CREATE INDEX {quoted_index} ON {quoted_table} ({quoted_columns})"))
+    return True
+
+
+def run_migration():
+    """Backfill seed source registry tables on existing databases."""
+    try:
+        from musicround import db
+
+        changes_made = False
+        inspector = inspect(db.engine)
+        with db.engine.connect() as conn:
+            if not _table_exists(inspector, "seed_source"):
+                conn.execute(
+                    text(
+                        """
+                        CREATE TABLE seed_source (
+                            id INTEGER PRIMARY KEY,
+                            name VARCHAR(200) NOT NULL,
+                            source_type VARCHAR(50) NOT NULL,
+                            provider VARCHAR(100),
+                            url VARCHAR(500),
+                            cadence VARCHAR(50),
+                            active BOOLEAN NOT NULL DEFAULT 1,
+                            priority INTEGER NOT NULL DEFAULT 100,
+                            notes TEXT,
+                            created_at DATETIME NOT NULL,
+                            updated_at DATETIME,
+                            UNIQUE(name, provider)
+                        )
+                        """
+                    )
+                )
+                changes_made = True
+
+            inspector = inspect(db.engine)
+            if _table_exists(inspector, "seed_source"):
+                source_columns = _columns(inspector, "seed_source")
+                if "notes" not in source_columns:
+                    conn.execute(text("ALTER TABLE seed_source ADD COLUMN notes TEXT"))
+                    changes_made = True
+                if "updated_at" not in source_columns:
+                    conn.execute(text("ALTER TABLE seed_source ADD COLUMN updated_at DATETIME"))
+                    changes_made = True
+
+            inspector = inspect(db.engine)
+            if not _table_exists(inspector, "seed_source_run"):
+                conn.execute(
+                    text(
+                        """
+                        CREATE TABLE seed_source_run (
+                            id INTEGER PRIMARY KEY,
+                            seed_source_id INTEGER NOT NULL,
+                            status VARCHAR(30) NOT NULL DEFAULT 'planned',
+                            started_at DATETIME NOT NULL,
+                            completed_at DATETIME,
+                            songs_seen INTEGER NOT NULL DEFAULT 0,
+                            songs_imported INTEGER NOT NULL DEFAULT 0,
+                            error_message TEXT,
+                            notes TEXT
+                        )
+                        """
+                    )
+                )
+                changes_made = True
+
+            inspector = inspect(db.engine)
+            for table_name, index_name, columns in (
+                ("seed_source", "idx_seed_source_type_active", ["source_type", "active", "priority"]),
+                (
+                    "seed_source_run",
+                    "idx_seed_source_run_source_status",
+                    ["seed_source_id", "status", "started_at"],
+                ),
+            ):
+                if table_name not in set(inspector.get_table_names()):
+                    continue
+                existing_columns = _columns(inspector, table_name)
+                if all(column in existing_columns for column in columns):
+                    changes_made = _create_index(conn, inspector, table_name, index_name, columns) or changes_made
+
+            if changes_made:
+                conn.commit()
+
+        return True if changes_made else None
+    except Exception as exc:
+        logger.error("Migration add_seed_source_registry failed: %s", exc)
+        return False
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    run_migration()

--- a/musicround/mcp_server.py
+++ b/musicround/mcp_server.py
@@ -322,6 +322,71 @@ def revoke_round_share(round_id: int, user_id: int) -> dict[str, Any]:
 
 
 @mcp.tool()
+def register_seed_source(
+    name: str,
+    source_type: str,
+    provider: str | None = None,
+    url: str | None = None,
+    cadence: str | None = None,
+    priority: int = 100,
+    active: bool = True,
+    notes: str | None = None,
+) -> dict[str, Any]:
+    """Create or update a chart, festival, editorial, curated, or playlist seed source."""
+    return _with_app_context(
+        automation.register_seed_source,
+        name=name,
+        source_type=source_type,
+        provider=provider,
+        url=url,
+        cadence=cadence,
+        priority=priority,
+        active=active,
+        notes=notes,
+    )
+
+
+@mcp.tool()
+def list_seed_sources(
+    source_type: str | None = None,
+    active: bool | None = True,
+    include_runs: bool = False,
+    limit: int = 100,
+) -> dict[str, Any]:
+    """List configured catalog seed sources for agent planning."""
+    return _with_app_context(
+        automation.list_seed_sources,
+        source_type=source_type,
+        active=active,
+        include_runs=include_runs,
+        limit=limit,
+    )
+
+
+@mcp.tool()
+def record_seed_source_run(
+    seed_source_id: int,
+    status: str,
+    songs_seen: int = 0,
+    songs_imported: int = 0,
+    error_message: str | None = None,
+    notes: str | None = None,
+    completed: bool = True,
+) -> dict[str, Any]:
+    """Record a seed-source read/import attempt for later planning context."""
+    return _with_app_context(
+        automation.record_seed_source_run,
+        seed_source_id=seed_source_id,
+        status=status,
+        songs_seen=songs_seen,
+        songs_imported=songs_imported,
+        error_message=error_message,
+        notes=notes,
+        completed=completed,
+    )
+
+
+@mcp.tool()
 def suggest_replacement_songs(
     round_id: int,
     position: int,
@@ -700,6 +765,7 @@ def create_round_from_text_playlist(
     name: str | None = None,
     count: int = 8,
     min_confidence: float = 0.8,
+    user_id: int | None = None,
 ) -> dict[str, Any]:
     """Create a complete manual round from text rows that all resolve to catalog songs."""
     try:
@@ -709,6 +775,7 @@ def create_round_from_text_playlist(
             name=name,
             count=count,
             min_confidence=min_confidence,
+            user_id=user_id,
         )
     except automation.AutomationError as exc:
         if exc.details:

--- a/musicround/models.py
+++ b/musicround/models.py
@@ -496,6 +496,67 @@ class SystemSetting(db.Model):
         return {s.key: s.value for s in SystemSetting.query.all()}
 
 
+class SeedSource(db.Model):
+    """
+    Curated chart, festival, and editorial sources used to seed the song catalog.
+    """
+    __tablename__ = 'seed_source'
+
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(200), nullable=False)
+    source_type = db.Column(db.String(50), nullable=False)
+    provider = db.Column(db.String(100), nullable=True)
+    url = db.Column(db.String(500), nullable=True)
+    cadence = db.Column(db.String(50), nullable=True)
+    active = db.Column(db.Boolean, default=True, nullable=False)
+    priority = db.Column(db.Integer, default=100, nullable=False)
+    notes = db.Column(db.Text, nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = db.Column(db.DateTime, onupdate=datetime.utcnow)
+
+    __table_args__ = (
+        db.UniqueConstraint('name', 'provider', name='uq_seed_source_name_provider'),
+        db.Index('idx_seed_source_type_active', 'source_type', 'active', 'priority'),
+    )
+
+    runs = db.relationship('SeedSourceRun', back_populates='seed_source', lazy='dynamic', cascade='all, delete-orphan')
+
+    def __repr__(self):
+        return (
+            f"SeedSource(id={self.id}, name='{self.name}', "
+            f"type='{self.source_type}', provider='{self.provider}')"
+        )
+
+
+class SeedSourceRun(db.Model):
+    """
+    Import/read status for a configured seed source.
+    """
+    __tablename__ = 'seed_source_run'
+
+    id = db.Column(db.Integer, primary_key=True)
+    seed_source_id = db.Column(db.Integer, db.ForeignKey('seed_source.id', ondelete='CASCADE'), nullable=False)
+    status = db.Column(db.String(30), default='planned', nullable=False)
+    started_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    completed_at = db.Column(db.DateTime, nullable=True)
+    songs_seen = db.Column(db.Integer, default=0, nullable=False)
+    songs_imported = db.Column(db.Integer, default=0, nullable=False)
+    error_message = db.Column(db.Text, nullable=True)
+    notes = db.Column(db.Text, nullable=True)
+
+    __table_args__ = (
+        db.Index('idx_seed_source_run_source_status', 'seed_source_id', 'status', 'started_at'),
+    )
+
+    seed_source = db.relationship('SeedSource', back_populates='runs')
+
+    def __repr__(self):
+        return (
+            f"SeedSourceRun(seed_source_id={self.seed_source_id}, "
+            f"status='{self.status}', imported={self.songs_imported})"
+        )
+
+
 class ImportJobRecord(db.Model):
     """
     Database model for tracking import jobs

--- a/musicround/routes/db_admin.py
+++ b/musicround/routes/db_admin.py
@@ -10,7 +10,19 @@ try:
 except ImportError:
     _FLASK_ADMIN_V2 = False
 from flask_login import current_user, login_required
-from musicround.models import Song, Tag, SongTag, Round, User, Role, UserPreferences, SystemSetting, db
+from musicround.models import (
+    SeedSource,
+    SeedSourceRun,
+    Song,
+    Tag,
+    SongTag,
+    Round,
+    User,
+    Role,
+    UserPreferences,
+    SystemSetting,
+    db,
+)
 from functools import wraps
 import os
 import json
@@ -187,6 +199,20 @@ class SystemSettingModelView(AuthModelView):
     column_details_list = ['id', 'key']
     column_export_list = ['id', 'key']
 
+
+class SeedSourceModelView(AuthModelView):
+    column_searchable_list = ['name', 'provider', 'url']
+    column_filters = ['source_type', 'provider', 'active', 'cadence']
+    column_list = ['id', 'name', 'source_type', 'provider', 'active', 'priority', 'cadence', 'updated_at']
+    column_default_sort = ('priority', False)
+
+
+class SeedSourceRunModelView(AuthModelView):
+    column_searchable_list = ['error_message', 'notes']
+    column_filters = ['status', 'seed_source_id']
+    column_list = ['id', 'seed_source_id', 'status', 'songs_seen', 'songs_imported', 'started_at', 'completed_at']
+    column_default_sort = ('started_at', True)
+
 # Initialize the admin interface
 admin = None
 
@@ -219,6 +245,8 @@ def init_admin(app):
     admin.add_view(TagModelView(Tag, db.session, category="Music Data"))
     admin.add_view(SongTagModelView(SongTag, db.session, category="Music Data"))
     admin.add_view(RoundModelView(Round, db.session, category="Music Data"))
+    admin.add_view(SeedSourceModelView(SeedSource, db.session, category="Music Data"))
+    admin.add_view(SeedSourceRunModelView(SeedSourceRun, db.session, category="Music Data"))
     
     # User management
     admin.add_view(UserModelView(User, db.session, category="User Management"))

--- a/musicround/routes/generate.py
+++ b/musicround/routes/generate.py
@@ -7,6 +7,8 @@ from musicround.models import Song, Round, Tag, db
 from musicround.helpers.auth_helpers import oauth
 from musicround.helpers.import_helper import ImportHelper
 from musicround.helpers.spotify_helper import get_spotify_token
+from musicround.services import automation
+from musicround.services.automation import AutomationError
 
 generate_bp = Blueprint('generate', __name__)
 
@@ -665,6 +667,89 @@ def import_playlist():
                                expected_song_count=expected_song_count)
     
     return render_template('import_playlist.html')
+
+
+def _text_import_confidence():
+    raw_value = request.form.get('min_confidence', request.args.get('min_confidence', '0.8'))
+    try:
+        confidence = float(raw_value)
+    except (TypeError, ValueError):
+        return 0.8
+    return min(max(confidence, 0.5), 1.0)
+
+
+@generate_bp.route('/import-text-playlist', methods=['GET', 'POST'])
+@login_required
+def import_text_playlist():
+    """Review pasted text or CSV playlist rows before creating a quiz round."""
+    expected_song_count = current_app.config.get('SONGS_PER_ROUND', songs_per_round)
+    playlist_text = request.form.get('playlist_text', '')
+    round_name = request.form.get('round_name', '')
+    min_confidence = _text_import_confidence()
+    resolution = None
+
+    if request.method == 'POST':
+        if not playlist_text.strip():
+            flash('Paste at least one song row before reviewing the text playlist.', 'error')
+            return render_template(
+                'import_text_playlist.html',
+                expected_song_count=expected_song_count,
+                playlist_text=playlist_text,
+                round_name=round_name,
+                min_confidence=min_confidence,
+                resolution=resolution,
+            )
+
+        try:
+            resolution = automation.resolve_text_playlist(
+                playlist_text,
+                limit=500,
+                min_confidence=min_confidence,
+            )
+        except AutomationError as exc:
+            flash(str(exc), 'error')
+            return render_template(
+                'import_text_playlist.html',
+                expected_song_count=expected_song_count,
+                playlist_text=playlist_text,
+                round_name=round_name,
+                min_confidence=min_confidence,
+                resolution=resolution,
+            )
+
+        if request.form.get('action') == 'create':
+            if not resolution['ready_for_round']:
+                flash('Resolve every text row before creating a round.', 'error')
+            elif resolution['resolved_count'] != expected_song_count:
+                flash(
+                    f'Text playlist resolved {resolution["resolved_count"]} songs; '
+                    f'expected exactly {expected_song_count}.',
+                    'error',
+                )
+            else:
+                try:
+                    created = automation.create_round_from_text_playlist(
+                        playlist_text,
+                        name=round_name or None,
+                        count=expected_song_count,
+                        min_confidence=min_confidence,
+                        user_id=current_user.id,
+                    )
+                except AutomationError as exc:
+                    resolution = (exc.details or {}).get('resolution', resolution)
+                    flash(str(exc), 'error')
+                else:
+                    flash('Text playlist round created after review.', 'success')
+                    return redirect(url_for('rounds.round_detail', round_id=created['round']['id']))
+
+    return render_template(
+        'import_text_playlist.html',
+        expected_song_count=expected_song_count,
+        playlist_text=playlist_text,
+        round_name=round_name,
+        min_confidence=min_confidence,
+        resolution=resolution,
+    )
 
 @generate_bp.route('/save_round', methods=['POST'])
 @login_required

--- a/musicround/routes/rounds.py
+++ b/musicround/routes/rounds.py
@@ -14,7 +14,7 @@ import json
 from flask import Blueprint, session, redirect, request, render_template, url_for, current_app, send_file, jsonify, flash, abort
 from flask_login import current_user, login_required
 from sqlalchemy import or_
-from musicround.models import PlannedQuizRound, Round, RoundAudioScript, RoundExport, RoundShare, Song, db
+from musicround.models import PlannedQuizRound, Round, RoundAudioScript, RoundExport, RoundShare, Song, User, db
 from pydub import AudioSegment
 from reportlab.lib.pagesizes import A4
 from reportlab.pdfgen import canvas
@@ -213,6 +213,12 @@ def _can_edit_round(round_obj):
         return True
     share = round_obj.shares.filter_by(user_id=current_user.id).first()
     return bool(share and share.role == 'editor')
+
+
+def _can_manage_round_shares(round_obj):
+    if current_user.is_admin:
+        return True
+    return bool(round_obj.user_id and round_obj.user_id == current_user.id)
 
 
 def _get_visible_round_or_404(round_id):
@@ -483,6 +489,12 @@ def round_detail(round_id):
             .limit(10)
             .all()
         )
+        round_shares = (
+            RoundShare.query.filter_by(round_id=rnd.id)
+            .join(User)
+            .order_by(User.username.asc(), RoundShare.id.asc())
+            .all()
+        )
 
         return render_template(
             'round_detail.html',
@@ -493,6 +505,8 @@ def round_detail(round_id):
             round_quality_report=round_quality_report,
             audio_scripts=audio_scripts,
             scheduled_exports=scheduled_exports,
+            round_shares=round_shares,
+            can_manage_shares=_can_manage_round_shares(rnd),
         )
     else:
         return 'Round not found'
@@ -562,6 +576,59 @@ def update_round_review(round_id):
             'approved_at': rnd.approved_at.isoformat() if rnd.approved_at else None,
         })
     flash('Round review status updated', 'success')
+    return redirect(url_for('rounds.round_detail', round_id=round_id))
+
+
+@rounds_bp.route('/<int:round_id>/shares', methods=['POST'])
+@login_required
+def add_round_share(round_id):
+    """Grant another quizmaster access to a round."""
+    rnd = _get_visible_round_or_404(round_id)
+    if not _can_manage_round_shares(rnd):
+        abort(403)
+
+    user_query = (request.form.get('user_query') or '').strip()
+    role = (request.form.get('role') or 'viewer').strip().lower()
+    if role not in {'viewer', 'editor'}:
+        flash('Share role must be viewer or editor.', 'error')
+        return redirect(url_for('rounds.round_detail', round_id=round_id))
+    if not user_query:
+        flash('Enter a username or email address to share with.', 'error')
+        return redirect(url_for('rounds.round_detail', round_id=round_id))
+
+    target_user = User.query.filter(
+        or_(User.username == user_query, User.email == user_query)
+    ).first()
+    if not target_user:
+        flash('No quizmaster found for that username or email address.', 'error')
+        return redirect(url_for('rounds.round_detail', round_id=round_id))
+    if rnd.user_id == target_user.id:
+        flash('Round owners already have full access.', 'error')
+        return redirect(url_for('rounds.round_detail', round_id=round_id))
+
+    try:
+        automation.share_round(round_id, target_user.id, role=role)
+    except AutomationError as exc:
+        flash(str(exc), 'error')
+    else:
+        flash(f'Round shared with {target_user.username} as {role}.', 'success')
+    return redirect(url_for('rounds.round_detail', round_id=round_id))
+
+
+@rounds_bp.route('/<int:round_id>/shares/<int:user_id>/delete', methods=['POST'])
+@login_required
+def delete_round_share(round_id, user_id):
+    """Remove another quizmaster's access to a round."""
+    rnd = _get_visible_round_or_404(round_id)
+    if not _can_manage_round_shares(rnd):
+        abort(403)
+
+    try:
+        automation.revoke_round_share(round_id, user_id)
+    except AutomationError as exc:
+        flash(str(exc), 'error')
+    else:
+        flash('Round share removed.', 'success')
     return redirect(url_for('rounds.round_detail', round_id=round_id))
 
 

--- a/musicround/services/automation.py
+++ b/musicround/services/automation.py
@@ -41,6 +41,8 @@ from musicround.models import (
     RoundAudioScript,
     RoundExport,
     RoundShare,
+    SeedSource,
+    SeedSourceRun,
     Song,
     Tag,
     User,
@@ -228,6 +230,46 @@ def _planned_quiz_round_summary(plan: PlannedQuizRound) -> dict[str, Any]:
         "created_at": _datetime_payload(plan.created_at),
         "updated_at": _datetime_payload(plan.updated_at),
     }
+
+
+def _seed_source_run_summary(run: SeedSourceRun) -> dict[str, Any]:
+    return {
+        "id": run.id,
+        "seed_source_id": run.seed_source_id,
+        "status": run.status,
+        "started_at": _datetime_payload(run.started_at),
+        "completed_at": _datetime_payload(run.completed_at),
+        "songs_seen": run.songs_seen,
+        "songs_imported": run.songs_imported,
+        "error_message": run.error_message,
+        "notes": run.notes,
+    }
+
+
+def _seed_source_summary(source: SeedSource, include_runs: bool = False) -> dict[str, Any]:
+    latest_run = (
+        source.runs.order_by(SeedSourceRun.started_at.desc(), SeedSourceRun.id.desc()).first()
+    )
+    payload = {
+        "id": source.id,
+        "name": source.name,
+        "source_type": source.source_type,
+        "provider": source.provider,
+        "url": source.url,
+        "cadence": source.cadence,
+        "active": source.active,
+        "priority": source.priority,
+        "notes": source.notes,
+        "created_at": _datetime_payload(source.created_at),
+        "updated_at": _datetime_payload(source.updated_at),
+        "latest_run": _seed_source_run_summary(latest_run) if latest_run else None,
+    }
+    if include_runs:
+        payload["runs"] = [
+            _seed_source_run_summary(run)
+            for run in source.runs.order_by(SeedSourceRun.started_at.desc(), SeedSourceRun.id.desc()).limit(20).all()
+        ]
+    return payload
 
 
 def _find_user(user_id: int | None = None) -> User:
@@ -938,6 +980,112 @@ def revoke_round_share(round_id: int, user_id: int) -> dict[str, Any]:
         "revoked": True,
         "share": removed,
         "round": _round_summary(round_obj) if round_obj else None,
+    }
+
+
+def register_seed_source(
+    name: str,
+    source_type: str,
+    provider: str | None = None,
+    url: str | None = None,
+    cadence: str | None = None,
+    priority: int = 100,
+    active: bool = True,
+    notes: str | None = None,
+) -> dict[str, Any]:
+    """Create or update a catalog seed source for chart/festival ingestion."""
+    normalized_name = (name or "").strip()
+    normalized_type = (source_type or "").strip().lower()
+    normalized_provider = (provider or "").strip() or None
+    if not normalized_name:
+        raise AutomationError("name must not be empty.")
+    if normalized_type not in {"chart", "festival", "editorial", "curated", "playlist"}:
+        raise AutomationError("source_type must be chart, festival, editorial, curated, or playlist.")
+    if priority < 0 or priority > 1000:
+        raise AutomationError("priority must be between 0 and 1000.")
+
+    source = SeedSource.query.filter_by(
+        name=normalized_name,
+        provider=normalized_provider,
+    ).first()
+    created = source is None
+    if source is None:
+        source = SeedSource(name=normalized_name, provider=normalized_provider)
+        db.session.add(source)
+
+    source.source_type = normalized_type
+    source.url = (url or "").strip() or None
+    source.cadence = (cadence or "").strip() or None
+    source.priority = priority
+    source.active = bool(active)
+    source.notes = (notes or "").strip() or None
+    source.updated_at = datetime.utcnow()
+    db.session.commit()
+
+    return {"created": created, "seed_source": _seed_source_summary(source, include_runs=True)}
+
+
+def list_seed_sources(
+    source_type: str | None = None,
+    active: bool | None = True,
+    include_runs: bool = False,
+    limit: int = 100,
+) -> dict[str, Any]:
+    """List configured chart/festival seed sources for agent planning."""
+    if limit < 1 or limit > 500:
+        raise AutomationError("limit must be between 1 and 500.")
+    query = SeedSource.query
+    if source_type:
+        query = query.filter(SeedSource.source_type == source_type.strip().lower())
+    if active is not None:
+        query = query.filter(SeedSource.active.is_(bool(active)))
+    sources = (
+        query
+        .order_by(SeedSource.priority.asc(), SeedSource.name.asc(), SeedSource.id.asc())
+        .limit(limit)
+        .all()
+    )
+    return {
+        "count": len(sources),
+        "sources": [_seed_source_summary(source, include_runs=include_runs) for source in sources],
+    }
+
+
+def record_seed_source_run(
+    seed_source_id: int,
+    status: str,
+    songs_seen: int = 0,
+    songs_imported: int = 0,
+    error_message: str | None = None,
+    notes: str | None = None,
+    completed: bool = True,
+) -> dict[str, Any]:
+    """Record an import/read attempt for a seed source."""
+    source = db.session.get(SeedSource, seed_source_id)
+    if not source:
+        raise AutomationError(f"Seed source {seed_source_id} was not found.")
+    normalized_status = (status or "").strip().lower()
+    if normalized_status not in {"planned", "running", "success", "partial", "failed"}:
+        raise AutomationError("status must be planned, running, success, partial, or failed.")
+    if songs_seen < 0 or songs_imported < 0:
+        raise AutomationError("song counts must not be negative.")
+
+    run = SeedSourceRun(
+        seed_source_id=source.id,
+        status=normalized_status,
+        songs_seen=songs_seen,
+        songs_imported=songs_imported,
+        error_message=(error_message or "").strip() or None,
+        notes=(notes or "").strip() or None,
+        completed_at=datetime.utcnow() if completed else None,
+    )
+    db.session.add(run)
+    source.updated_at = datetime.utcnow()
+    db.session.commit()
+    return {
+        "recorded": True,
+        "seed_source": _seed_source_summary(source),
+        "run": _seed_source_run_summary(run),
     }
 
 
@@ -2328,6 +2476,7 @@ def create_round_from_text_playlist(
     name: str | None = None,
     count: int = 8,
     min_confidence: float = 0.8,
+    user_id: int | None = None,
 ) -> dict[str, Any]:
     """Create a manual round from a parsed text playlist only when all rows resolve."""
     resolved = resolve_text_playlist(text, limit=max(count, 1), min_confidence=min_confidence)
@@ -2359,6 +2508,7 @@ def create_round_from_text_playlist(
         round_type="manual",
         count=count,
         song_ids=song_ids,
+        user_id=user_id,
     )
     return {
         "created": True,

--- a/musicround/templates/import_playlist.html
+++ b/musicround/templates/import_playlist.html
@@ -6,7 +6,7 @@
 <div class="max-w-7xl mx-auto px-4 py-8">
     <div class="mb-8">
         <h1 class="text-3xl font-bold text-navy-800 font-montserrat mb-2">Import Playlist</h1>
-        <p class="text-gray-600">Create a music quiz round from a Spotify or Deezer playlist.</p>
+        <p class="text-gray-600">Create a music quiz round from a Spotify, Deezer, or reviewed text playlist.</p>
     </div>    <div class="bg-white shadow-md rounded-lg p-6">
         <form method="POST" action="{{ url_for('generate.import_playlist') }}" id="importPlaylistForm">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
@@ -55,6 +55,19 @@
                 </a>
             </div>
         </form>
+    </div>
+
+    <div class="mt-6 bg-white shadow-md rounded-lg p-6">
+        <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+            <div>
+                <h2 class="text-xl font-semibold text-navy-800 font-montserrat mb-1">Paste a text playlist</h2>
+                <p class="text-gray-600 text-sm">Review artist/title rows against the catalog before a round can be created.</p>
+            </div>
+            <a href="{{ url_for('generate.import_text_playlist') }}"
+               class="bg-teal-500 hover:bg-teal-600 text-white py-2 px-4 rounded-md transition-colors text-sm font-semibold inline-flex items-center justify-center">
+                <i class="fas fa-clipboard-list mr-2"></i>Review Text List
+            </a>
+        </div>
     </div>
 
     <div class="mt-8 bg-navy-50 rounded-lg p-6 border border-navy-100">

--- a/musicround/templates/import_text_playlist.html
+++ b/musicround/templates/import_text_playlist.html
@@ -1,0 +1,151 @@
+{% extends 'base.html' %}
+
+{% block title %}Review Text Playlist - Quizzical Beats{% endblock %}
+
+{% block content %}
+<div class="max-w-7xl mx-auto px-4 py-8">
+    <div class="mb-8">
+        <h1 class="text-3xl font-bold text-navy-800 font-montserrat mb-2">Review Text Playlist</h1>
+        <p class="text-gray-600">Paste a text or CSV song list, review catalog matches, then create a complete eight-song round.</p>
+    </div>
+
+    <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <section class="lg:col-span-1 bg-white shadow-md rounded-lg p-6">
+            <form method="POST" action="{{ url_for('generate.import_text_playlist') }}">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+
+                <div class="mb-4">
+                    <label class="block text-gray-700 text-sm font-bold mb-2" for="round_name">
+                        Round Name
+                    </label>
+                    <input class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+                           id="round_name" name="round_name" type="text" value="{{ round_name }}" placeholder="e.g. Pubquiz 2026-07-09">
+                </div>
+
+                <div class="mb-4">
+                    <label class="block text-gray-700 text-sm font-bold mb-2" for="min_confidence">
+                        Match Confidence
+                    </label>
+                    <select id="min_confidence" name="min_confidence" class="shadow border rounded w-full py-2 px-3 text-gray-700 focus:outline-none focus:shadow-outline">
+                        {% for value, label in [(0.7, 'Lenient'), (0.8, 'Standard'), (0.9, 'Strict')] %}
+                        <option value="{{ value }}" {% if min_confidence == value %}selected{% endif %}>{{ label }} ({{ value }})</option>
+                        {% endfor %}
+                    </select>
+                </div>
+
+                <div class="mb-5">
+                    <label class="block text-gray-700 text-sm font-bold mb-2" for="playlist_text">
+                        Songs
+                    </label>
+                    <textarea id="playlist_text" name="playlist_text" rows="14"
+                              class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+                              placeholder="Artist - Title&#10;Shania Twain - Man! I Feel Like a Woman!">{{ playlist_text }}</textarea>
+                    <p class="text-gray-600 text-xs italic mt-1">Preferred format: Artist - Title. CSV with artist/title headers also works.</p>
+                </div>
+
+                <div class="flex flex-col sm:flex-row gap-3">
+                    <button class="bg-teal-500 hover:bg-teal-600 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline transition-colors"
+                            type="submit" name="action" value="review">
+                        <i class="fas fa-search mr-2"></i>Review Matches
+                    </button>
+                    {% if resolution and resolution.ready_for_round and resolution.resolved_count == expected_song_count %}
+                    <button class="bg-orange-500 hover:bg-orange-600 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline transition-colors"
+                            type="submit" name="action" value="create">
+                        <i class="fas fa-plus-circle mr-2"></i>Create Round
+                    </button>
+                    {% endif %}
+                </div>
+            </form>
+        </section>
+
+        <section class="lg:col-span-2 bg-white shadow-md rounded-lg overflow-hidden">
+            <div class="p-4 bg-navy-50 border-b">
+                <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
+                    <div>
+                        <h2 class="text-xl font-semibold text-navy-800">Match Review</h2>
+                        <p class="text-sm text-gray-600 mt-1">Rounds must resolve exactly {{ expected_song_count }} playable catalog songs.</p>
+                    </div>
+                    {% if resolution %}
+                    <div class="flex flex-wrap gap-2 text-sm">
+                        <span class="px-2 py-1 rounded-full bg-green-100 text-green-800 font-semibold">{{ resolution.resolved_count }} resolved</span>
+                        <span class="px-2 py-1 rounded-full {% if resolution.unresolved_count %}bg-red-100 text-red-800{% else %}bg-gray-100 text-gray-800{% endif %} font-semibold">{{ resolution.unresolved_count }} unresolved</span>
+                    </div>
+                    {% endif %}
+                </div>
+            </div>
+
+            {% if resolution %}
+            {% if resolution.unresolved_count or resolution.resolved_count != expected_song_count %}
+            <div class="m-4 bg-yellow-50 border border-yellow-200 text-yellow-900 rounded-md p-4">
+                <p class="font-semibold">Review required before this can become a round.</p>
+                <p class="text-sm mt-1">Correct unresolved rows, add missing songs to the catalog, or replace tracks until exactly {{ expected_song_count }} rows resolve.</p>
+            </div>
+            {% else %}
+            <div class="m-4 bg-green-50 border border-green-200 text-green-900 rounded-md p-4">
+                <p class="font-semibold">Ready to create.</p>
+                <p class="text-sm mt-1">Every row resolved and the count matches the round size.</p>
+            </div>
+            {% endif %}
+
+            <div class="overflow-x-auto">
+                <table class="w-full table-auto">
+                    <thead class="bg-gray-100 text-gray-700">
+                        <tr>
+                            <th class="px-4 py-3 text-left font-semibold">Line</th>
+                            <th class="px-4 py-3 text-left font-semibold">Input</th>
+                            <th class="px-4 py-3 text-left font-semibold">Parsed</th>
+                            <th class="px-4 py-3 text-left font-semibold">Catalog Match</th>
+                            <th class="px-4 py-3 text-left font-semibold">Status</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-gray-200">
+                        {% for row in resolution.resolved + resolution.unresolved %}
+                        <tr class="{% if row.song %}bg-white{% else %}bg-red-50{% endif %}">
+                            <td class="px-4 py-3 text-sm text-gray-600">{{ row.line_number }}</td>
+                            <td class="px-4 py-3 text-sm text-gray-700">{{ row.raw_line }}</td>
+                            <td class="px-4 py-3">
+                                <div class="font-medium text-gray-900">{{ row.artist or 'Unknown artist' }}</div>
+                                <div class="text-sm text-gray-600">{{ row.title or 'Unknown title' }}</div>
+                                <div class="text-xs text-gray-500">Confidence {{ '%.0f'|format(row.confidence * 100) }}%</div>
+                            </td>
+                            <td class="px-4 py-3">
+                                {% if row.song %}
+                                <div class="font-medium text-gray-900">{{ row.song.artist }} - {{ row.song.title }}</div>
+                                <div class="text-xs text-gray-500">Song #{{ row.song.id }}{% if row.song.used_count is not none %}, used {{ row.song.used_count }}x{% endif %}</div>
+                                {% else %}
+                                <span class="text-sm text-gray-500">No catalog match</span>
+                                {% endif %}
+                            </td>
+                            <td class="px-4 py-3">
+                                {% if row.song %}
+                                <span class="px-2 py-1 text-xs font-semibold rounded-full bg-green-100 text-green-800">Resolved</span>
+                                {% else %}
+                                <span class="px-2 py-1 text-xs font-semibold rounded-full bg-red-100 text-red-800">Needs review</span>
+                                {% if row.issues %}
+                                <div class="mt-1 text-xs text-red-700">{{ row.issues|join(', ') }}</div>
+                                {% endif %}
+                                {% endif %}
+                            </td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+            {% else %}
+            <div class="p-8 text-center text-gray-500">
+                <p>Paste songs and review them before creating a round.</p>
+            </div>
+            {% endif %}
+        </section>
+    </div>
+
+    <div class="mt-6 flex gap-4 justify-center">
+        <a href="{{ url_for('generate.import_playlist') }}" class="inline-block bg-white hover:bg-gray-100 text-gray-700 border border-gray-300 py-2 px-4 rounded-md transition-colors text-sm font-semibold">
+            <i class="fas fa-link mr-1"></i> Import by Playlist URL
+        </a>
+        <a href="{{ url_for('generate.build_music_round') }}" class="inline-block bg-navy-700 hover:bg-navy-800 text-white py-2 px-4 rounded-md transition-colors text-sm font-semibold">
+            <i class="fas fa-arrow-left mr-1"></i> Back to Builder
+        </a>
+    </div>
+</div>
+{% endblock %}

--- a/musicround/templates/round_detail.html
+++ b/musicround/templates/round_detail.html
@@ -79,6 +79,61 @@
         </div>
     </div>
 
+    <div class="bg-white shadow-md rounded-lg p-6 mb-6">
+        <div class="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-6">
+            <div class="flex-1">
+                <h2 class="text-2xl font-bold text-navy-800 font-montserrat mb-2">Sharing</h2>
+                <p class="text-sm text-gray-600 mb-4">Give another quizmaster read-only or edit access to this round.</p>
+                {% if round_shares %}
+                <div class="space-y-2">
+                    {% for share in round_shares %}
+                    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 border border-gray-200 rounded-md p-3">
+                        <div>
+                            <div class="font-semibold text-gray-900">{{ share.user.username }}</div>
+                            <div class="text-sm text-gray-500">{{ share.user.email }}</div>
+                        </div>
+                        <div class="flex items-center gap-3">
+                            <span class="px-2 py-1 text-xs font-semibold rounded-full {% if share.role == 'editor' %}bg-blue-100 text-blue-800{% else %}bg-gray-100 text-gray-800{% endif %}">
+                                {{ share.role|capitalize }}
+                            </span>
+                            {% if can_manage_shares %}
+                            <form method="POST" action="{{ url_for('rounds.delete_round_share', round_id=round.id, user_id=share.user_id) }}">
+                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+                                <button type="submit" class="text-red-600 hover:text-red-800 text-sm font-semibold">
+                                    <i class="fas fa-times mr-1"></i>Remove
+                                </button>
+                            </form>
+                            {% endif %}
+                        </div>
+                    </div>
+                    {% endfor %}
+                </div>
+                {% else %}
+                <p class="text-sm text-gray-500">This round is not shared with other quizmasters.</p>
+                {% endif %}
+            </div>
+            {% if can_manage_shares %}
+            <form id="round-share-form" method="POST" action="{{ url_for('rounds.add_round_share', round_id=round.id) }}" class="lg:w-96 border border-gray-200 rounded-md p-4 bg-gray-50">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+                <div class="mb-3">
+                    <label class="block text-sm font-medium text-gray-700 mb-1" for="share_user_query">Username or email</label>
+                    <input id="share_user_query" name="user_query" type="text" class="px-3 py-2 border border-gray-300 rounded-md w-full" placeholder="quizmaster@example.com">
+                </div>
+                <div class="mb-4">
+                    <label class="block text-sm font-medium text-gray-700 mb-1" for="share_role">Role</label>
+                    <select id="share_role" name="role" class="px-3 py-2 border border-gray-300 rounded-md w-full">
+                        <option value="viewer">Viewer</option>
+                        <option value="editor">Editor</option>
+                    </select>
+                </div>
+                <button type="submit" class="w-full bg-teal-500 hover:bg-teal-600 text-white py-2 px-4 rounded transition-colors font-semibold">
+                    <i class="fas fa-user-plus mr-2"></i>Share Round
+                </button>
+            </form>
+            {% endif %}
+        </div>
+    </div>
+
     <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-8">
         <div class="bg-white shadow-md rounded-lg p-6 lg:col-span-2">
             <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-3 mb-4">

--- a/tests/test_automation_service.py
+++ b/tests/test_automation_service.py
@@ -20,6 +20,8 @@ from musicround.models import (
     RoundAudioScript,
     RoundExport,
     RoundShare,
+    SeedSource,
+    SeedSourceRun,
     Song,
     SongTag,
     Tag,
@@ -1705,6 +1707,7 @@ class TestAgentPlanningAutomation:
 
     def test_create_round_from_text_playlist_requires_exact_count(self, app):
         with app.app_context():
+            user = _create_user(username="textowner", email="textowner@example.test")
             _create_song(title="One", artist="A")
             _create_song(title="Two", artist="B")
 
@@ -1712,10 +1715,12 @@ class TestAgentPlanningAutomation:
                 "A - One\nB - Two",
                 name="Text Round",
                 count=2,
+                user_id=user.id,
             )
 
             assert result["created"] is True
             assert result["round"]["name"] == "Text Round"
+            assert result["round"]["owner_user_id"] == user.id
             assert result["round"]["song_ids"]
 
     def test_create_round_from_text_playlist_returns_review_payload(self, app):
@@ -1775,6 +1780,58 @@ class TestAgentPlanningAutomation:
                 warning["song"]["id"] != old_song.id
                 for warning in result["selected_song_warnings"]
             )
+
+    def test_seed_source_registry_records_runs(self, app):
+        with app.app_context():
+            registered = automation.register_seed_source(
+                name="Graspop headliners",
+                source_type="festival",
+                provider="manual",
+                url="https://example.test/graspop",
+                cadence="annual",
+                priority=20,
+                notes="Metal and rock headliner source",
+            )
+            source_id = registered["seed_source"]["id"]
+            run = automation.record_seed_source_run(
+                source_id,
+                status="success",
+                songs_seen=120,
+                songs_imported=80,
+                notes="Initial registry smoke",
+            )
+            listed = automation.list_seed_sources(source_type="festival", include_runs=True)
+
+            assert registered["created"] is True
+            assert run["run"]["songs_imported"] == 80
+            assert listed["count"] == 1
+            assert listed["sources"][0]["name"] == "Graspop headliners"
+            assert listed["sources"][0]["latest_run"]["status"] == "success"
+            assert listed["sources"][0]["runs"][0]["songs_seen"] == 120
+            assert SeedSource.query.count() == 1
+            assert SeedSourceRun.query.count() == 1
+
+    def test_seed_source_registry_updates_existing_source(self, app):
+        with app.app_context():
+            first = automation.register_seed_source(
+                name="Billboard Hot 100",
+                source_type="chart",
+                provider="billboard",
+                priority=10,
+            )
+            second = automation.register_seed_source(
+                name="Billboard Hot 100",
+                source_type="chart",
+                provider="billboard",
+                priority=5,
+                active=False,
+            )
+
+            assert first["created"] is True
+            assert second["created"] is False
+            assert second["seed_source"]["priority"] == 5
+            assert second["seed_source"]["active"] is False
+            assert SeedSource.query.count() == 1
 
     def test_quizmaster_context_includes_preferences_and_recent_usage(self, app):
         with app.app_context():

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -12,6 +12,8 @@ from musicround.models import (
     RoundAudioScript,
     RoundExport,
     RoundShare,
+    SeedSource,
+    SeedSourceRun,
     Song,
 )
 
@@ -295,6 +297,27 @@ def test_add_round_review_workflow_to_legacy_database(tmp_path):
     }.issubset(round_columns)
     assert "idx_round_review_status" in _index_names(database_path, "round")
     assert "review_status" in Round.__table__.columns.keys()
+
+
+def test_add_seed_source_registry_to_legacy_database(tmp_path):
+    """Legacy databases get seed source registry and run-status tables."""
+    database_path = tmp_path / "legacy-seed-source.db"
+    app = _legacy_app(database_path)
+    with app.app_context():
+        from migrations import add_seed_source_registry
+
+        assert add_seed_source_registry.run_migration() is True
+        assert add_seed_source_registry.run_migration() is None
+
+    assert "seed_source" in _table_names(database_path)
+    assert "seed_source_run" in _table_names(database_path)
+    assert "idx_seed_source_type_active" in _index_names(database_path, "seed_source")
+    assert "idx_seed_source_run_source_status" in _index_names(database_path, "seed_source_run")
+    assert "notes" in _column_names(database_path, "seed_source")
+    assert SeedSource.__tablename__ == "seed_source"
+    assert SeedSourceRun.__tablename__ == "seed_source_run"
+    assert "idx_seed_source_type_active" in {index.name for index in SeedSource.__table__.indexes}
+    assert "idx_seed_source_run_source_status" in {index.name for index in SeedSourceRun.__table__.indexes}
 
 
 def test_add_planned_quiz_rounds_to_legacy_database(tmp_path):

--- a/tests/test_rounds_routes.py
+++ b/tests/test_rounds_routes.py
@@ -504,6 +504,74 @@ class TestRoundDetailRoute:
         with app.app_context():
             assert db.session.get(Round, round_id).name == 'Editor Updated Round'
 
+    def test_round_owner_can_share_and_revoke_from_detail(self, app, client):
+        """Owners should be able to manage explicit round shares in the browser."""
+        _login(app, client, username='share_owner_ui', email='share_owner_ui@example.com')
+        _login(app, client, username='share_target_ui', email='share_target_ui@example.com')
+        song_id = _create_song(app, title='Share UI Song')
+        owner_id = _user_id(app, 'share_owner_ui')
+        target_id = _user_id(app, 'share_target_ui')
+        _login(app, client, username='share_owner_ui', email='share_owner_ui@example.com')
+        round_id = _create_round(app, [song_id], name='Owner Share UI Round')
+        with app.app_context():
+            round_ = db.session.get(Round, round_id)
+            round_.user_id = owner_id
+            round_.visibility = 'private'
+            db.session.commit()
+
+        add_response = client.post(
+            f'/rounds/{round_id}/shares',
+            data={'user_query': 'share_target_ui', 'role': 'editor'},
+            follow_redirects=True,
+        )
+
+        assert add_response.status_code == 200
+        assert b'share_target_ui' in add_response.data
+        assert b'Editor' in add_response.data
+        with app.app_context():
+            share = RoundShare.query.filter_by(round_id=round_id, user_id=target_id).one()
+            assert share.role == 'editor'
+            assert db.session.get(Round, round_id).visibility == 'shared'
+
+        delete_response = client.post(
+            f'/rounds/{round_id}/shares/{target_id}/delete',
+            follow_redirects=True,
+        )
+
+        assert delete_response.status_code == 200
+        assert b'This round is not shared with other quizmasters.' in delete_response.data
+        with app.app_context():
+            assert RoundShare.query.filter_by(round_id=round_id, user_id=target_id).count() == 0
+            assert db.session.get(Round, round_id).visibility == 'private'
+
+    def test_shared_editor_cannot_manage_round_shares(self, app, client):
+        """Edit access should not grant share administration."""
+        _login(app, client, username='share_admin_owner', email='share_admin_owner@example.com')
+        _login(app, client, username='share_admin_editor', email='share_admin_editor@example.com')
+        _login(app, client, username='share_admin_target', email='share_admin_target@example.com')
+        song_id = _create_song(app, title='Share Admin Song')
+        owner_id = _user_id(app, 'share_admin_owner')
+        editor_id = _user_id(app, 'share_admin_editor')
+        client.get('/users/logout')
+        _login(app, client, username='share_admin_editor', email='share_admin_editor@example.com')
+        round_id = _create_round(app, [song_id], name='Editor No Share Admin Round')
+        with app.app_context():
+            round_ = db.session.get(Round, round_id)
+            round_.user_id = owner_id
+            round_.visibility = 'shared'
+            db.session.add(RoundShare(round_id=round_id, user_id=editor_id, role='editor'))
+            db.session.commit()
+
+        detail = client.get(f'/rounds/{round_id}')
+        blocked = client.post(
+            f'/rounds/{round_id}/shares',
+            data={'user_query': 'share_admin_target', 'role': 'viewer'},
+        )
+
+        assert detail.status_code == 200
+        assert b'id="round-share-form"' not in detail.data
+        assert blocked.status_code == 403
+
     def test_update_round_review_marks_approval(self, app, client):
         """Review route should persist approved state and notes."""
         _login(app, client)

--- a/tests/test_text_playlist_import_routes.py
+++ b/tests/test_text_playlist_import_routes.py
@@ -1,0 +1,96 @@
+"""Tests for browser text playlist review and round creation."""
+
+from musicround.models import Round, Song, User, db
+
+
+def _login(app, client, username='textimporter', email='textimporter@example.test'):
+    with app.app_context():
+        if not User.query.filter_by(username=username).first():
+            user = User(username=username, email=email)
+            user.password = 'TextImportPass123!'
+            db.session.add(user)
+            db.session.commit()
+    client.post('/users/login', data={'username': username, 'password': 'TextImportPass123!'})
+
+
+def _create_song(title, artist):
+    song = Song(title=title, artist=artist, preview_url=f'https://example.test/{title}.mp3')
+    db.session.add(song)
+    db.session.commit()
+    return song
+
+
+def test_text_playlist_review_requires_login(client):
+    response = client.get('/import-text-playlist')
+
+    assert response.status_code == 302
+    assert 'login' in response.headers['Location'].lower()
+
+
+def test_text_playlist_review_shows_unresolved_rows(app, client):
+    _login(app, client)
+    with app.app_context():
+        _create_song('Known Song', 'Known Artist')
+
+    response = client.post(
+        '/import-text-playlist',
+        data={
+            'action': 'review',
+            'round_name': 'Needs Review',
+            'playlist_text': 'Known Artist - Known Song\nMissing Artist - Missing Song',
+        },
+    )
+
+    assert response.status_code == 200
+    assert b'1 resolved' in response.data
+    assert b'1 unresolved' in response.data
+    assert b'Review required before this can become a round.' in response.data
+    assert b'Missing Artist - Missing Song' in response.data
+    assert b'name="action" value="create"' not in response.data
+
+
+def test_text_playlist_review_blocks_wrong_song_count(app, client):
+    _login(app, client)
+    with app.app_context():
+        _create_song('One', 'A')
+        _create_song('Two', 'B')
+
+    response = client.post(
+        '/import-text-playlist',
+        data={
+            'action': 'create',
+            'round_name': 'Too Short',
+            'playlist_text': 'A - One\nB - Two',
+        },
+    )
+
+    assert response.status_code == 200
+    assert b'Text playlist resolved 2 songs; expected exactly 8.' in response.data
+    with app.app_context():
+        assert Round.query.count() == 0
+
+
+def test_text_playlist_create_redirects_to_round_detail(app, client):
+    _login(app, client)
+    with app.app_context():
+        for index in range(8):
+            _create_song(f'Title {index}', f'Artist {index}')
+
+    playlist_text = '\n'.join(f'Artist {index} - Title {index}' for index in range(8))
+    response = client.post(
+        '/import-text-playlist',
+        data={
+            'action': 'create',
+            'round_name': 'Text Import Round',
+            'playlist_text': playlist_text,
+        },
+    )
+
+    assert response.status_code == 302
+    assert '/rounds/' in response.headers['Location']
+    with app.app_context():
+        round_ = Round.query.one()
+        assert round_.name == 'Text Import Round'
+        assert round_.user_id is not None
+        assert round_.visibility == 'private'
+        assert len(round_.song_id_list) == 8


### PR DESCRIPTION
## Summary
- add a browser text-playlist review flow that blocks creation until exactly eight rows resolve
- add owner/admin round sharing controls on the round detail page
- add seed source registry/run tracking with admin views, migration, and MCP tools

## Validation
- `SECRET_KEY=test-secret AUTOMATION_TOKEN=test-token .venv/bin/pytest tests/test_text_playlist_import_routes.py tests/test_rounds_routes.py tests/test_automation_service.py tests/test_migrations.py -k 'text_playlist or share or shared or create_round_from_text_playlist_requires_exact_count or seed_source_registry' -q`
- `SECRET_KEY=test-secret AUTOMATION_TOKEN=test-token .venv/bin/pytest tests/test_app_factory.py -q`
- `.venv/bin/python -m py_compile musicround/routes/generate.py musicround/routes/rounds.py musicround/routes/db_admin.py musicround/services/automation.py musicround/mcp_server.py musicround/models.py migrations/add_seed_source_registry.py`
- `git diff --check`
