### PR TITLE
Address PR 189 review follow-ups

### DIFF
--- a/migrations/add_seed_source_registry.py
+++ b/migrations/add_seed_source_registry.py
@@ -89,7 +89,8 @@ def run_migration():
                             songs_seen INTEGER NOT NULL DEFAULT 0,
                             songs_imported INTEGER NOT NULL DEFAULT 0,
                             error_message TEXT,
-                            notes TEXT
+                            notes TEXT,
+                            FOREIGN KEY(seed_source_id) REFERENCES seed_source(id) ON DELETE CASCADE
                         )
                         """
                     )

--- a/musicround/routes/rounds.py
+++ b/musicround/routes/rounds.py
@@ -14,6 +14,7 @@ import json
 from flask import Blueprint, session, redirect, request, render_template, url_for, current_app, send_file, jsonify, flash, abort
 from flask_login import current_user, login_required
 from sqlalchemy import or_
+from sqlalchemy.orm import selectinload
 from musicround.models import PlannedQuizRound, Round, RoundAudioScript, RoundExport, RoundShare, Song, User, db
 from pydub import AudioSegment
 from reportlab.lib.pagesizes import A4
@@ -492,6 +493,7 @@ def round_detail(round_id):
         round_shares = (
             RoundShare.query.filter_by(round_id=rnd.id)
             .join(User)
+            .options(selectinload(RoundShare.user))
             .order_by(User.username.asc(), RoundShare.id.asc())
             .all()
         )

--- a/musicround/services/automation.py
+++ b/musicround/services/automation.py
@@ -247,9 +247,11 @@ def _seed_source_run_summary(run: SeedSourceRun) -> dict[str, Any]:
 
 
 def _seed_source_summary(source: SeedSource, include_runs: bool = False) -> dict[str, Any]:
-    latest_run = (
-        source.runs.order_by(SeedSourceRun.started_at.desc(), SeedSourceRun.id.desc()).first()
-    )
+    ordered_runs = source.runs.order_by(SeedSourceRun.started_at.desc(), SeedSourceRun.id.desc())
+    runs = ordered_runs.limit(20).all() if include_runs else []
+    latest_run = runs[0] if include_runs and runs else None
+    if not include_runs:
+        latest_run = ordered_runs.first()
     payload = {
         "id": source.id,
         "name": source.name,
@@ -265,10 +267,7 @@ def _seed_source_summary(source: SeedSource, include_runs: bool = False) -> dict
         "latest_run": _seed_source_run_summary(latest_run) if latest_run else None,
     }
     if include_runs:
-        payload["runs"] = [
-            _seed_source_run_summary(run)
-            for run in source.runs.order_by(SeedSourceRun.started_at.desc(), SeedSourceRun.id.desc()).limit(20).all()
-        ]
+        payload["runs"] = [_seed_source_run_summary(run) for run in runs]
     return payload
 
 

--- a/musicround/templates/round_detail.html
+++ b/musicround/templates/round_detail.html
@@ -90,7 +90,9 @@
                     <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 border border-gray-200 rounded-md p-3">
                         <div>
                             <div class="font-semibold text-gray-900">{{ share.user.username }}</div>
+                            {% if can_manage_shares %}
                             <div class="text-sm text-gray-500">{{ share.user.email }}</div>
+                            {% endif %}
                         </div>
                         <div class="flex items-center gap-3">
                             <span class="px-2 py-1 text-xs font-semibold rounded-full {% if share.role == 'editor' %}bg-blue-100 text-blue-800{% else %}bg-gray-100 text-gray-800{% endif %}">

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -40,6 +40,11 @@ def _index_names(database_path, table_name):
         return [row[1] for row in conn.execute(f"PRAGMA index_list({table_name})").fetchall()]
 
 
+def _foreign_keys(database_path, table_name):
+    with sqlite3.connect(database_path) as conn:
+        return conn.execute(f"PRAGMA foreign_key_list({table_name})").fetchall()
+
+
 def _table_names(database_path):
     with sqlite3.connect(database_path) as conn:
         return [
@@ -314,6 +319,10 @@ def test_add_seed_source_registry_to_legacy_database(tmp_path):
     assert "idx_seed_source_type_active" in _index_names(database_path, "seed_source")
     assert "idx_seed_source_run_source_status" in _index_names(database_path, "seed_source_run")
     assert "notes" in _column_names(database_path, "seed_source")
+    assert any(
+        row[2] == "seed_source" and row[3] == "seed_source_id" and row[4] == "id"
+        for row in _foreign_keys(database_path, "seed_source_run")
+    )
     assert SeedSource.__tablename__ == "seed_source"
     assert SeedSourceRun.__tablename__ == "seed_source_run"
     assert "idx_seed_source_type_active" in {index.name for index in SeedSource.__table__.indexes}

--- a/tests/test_rounds_routes.py
+++ b/tests/test_rounds_routes.py
@@ -527,6 +527,7 @@ class TestRoundDetailRoute:
 
         assert add_response.status_code == 200
         assert b'share_target_ui' in add_response.data
+        assert b'share_target_ui@example.com' in add_response.data
         assert b'Editor' in add_response.data
         with app.app_context():
             share = RoundShare.query.filter_by(round_id=round_id, user_id=target_id).one()
@@ -570,6 +571,8 @@ class TestRoundDetailRoute:
 
         assert detail.status_code == 200
         assert b'id="round-share-form"' not in detail.data
+        assert b'share_admin_editor' in detail.data
+        assert b'share_admin_editor@example.com' not in detail.data
         assert blocked.status_code == 403
 
     def test_update_round_review_marks_approval(self, app, client):


### PR DESCRIPTION
## Summary\n- hide share-recipient email addresses from non-managers and eager-load share users\n- add the seed_source_run foreign key in the legacy migration\n- reuse fetched seed-source runs when include_runs is requested\n\n## Validation\n- python3 -m py_compile musicround/routes/rounds.py migrations/add_seed_source_registry.py musicround/services/automation.py tests/test_migrations.py tests/test_rounds_routes.py\n- git diff --check\n\nPytest could not run locally because the available shared QuizzicalBeats venv hangs while importing the openai package before test collection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved round share details so email addresses are shown only to people with share-management access.
  * Round detail pages now load shared-user information more reliably.
  * Seed source records now maintain a stronger link to related run data, improving data consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->