### PR TITLE
Address PR 190 review follow-ups

### DIFF
--- a/migrations/add_seed_source_registry.py
+++ b/migrations/add_seed_source_registry.py
@@ -23,6 +23,16 @@ def _index_exists(inspector, table_name, index_name):
     return any(index.get("name") == index_name for index in inspector.get_indexes(table_name))
 
 
+def _foreign_key_exists(inspector, table_name, referred_table, constrained_columns):
+    expected_columns = set(constrained_columns)
+    for foreign_key in inspector.get_foreign_keys(table_name):
+        if foreign_key.get("referred_table") != referred_table:
+            continue
+        if set(foreign_key.get("constrained_columns") or []) == expected_columns:
+            return True
+    return False
+
+
 def _create_index(conn, inspector, table_name, index_name, columns):
     if _index_exists(inspector, table_name, index_name):
         return False
@@ -31,6 +41,74 @@ def _create_index(conn, inspector, table_name, index_name, columns):
     quoted_index = _quote(index_name, preparer)
     quoted_columns = ", ".join(_quote(column, preparer) for column in columns)
     conn.execute(text(f"CREATE INDEX {quoted_index} ON {quoted_table} ({quoted_columns})"))
+    return True
+
+
+def _create_seed_source_run_table(conn, table_name="seed_source_run"):
+    preparer = conn.dialect.identifier_preparer
+    quoted_table = _quote(table_name, preparer)
+    conn.execute(
+        text(
+            f"""
+            CREATE TABLE {quoted_table} (
+                id INTEGER PRIMARY KEY,
+                seed_source_id INTEGER NOT NULL,
+                status VARCHAR(30) NOT NULL DEFAULT 'planned',
+                started_at DATETIME NOT NULL,
+                completed_at DATETIME,
+                songs_seen INTEGER NOT NULL DEFAULT 0,
+                songs_imported INTEGER NOT NULL DEFAULT 0,
+                error_message TEXT,
+                notes TEXT,
+                FOREIGN KEY(seed_source_id) REFERENCES seed_source(id) ON DELETE CASCADE
+            )
+            """
+        )
+    )
+
+
+def _rebuild_seed_source_run_with_foreign_key(conn):
+    """Recreate legacy seed_source_run with the model's foreign key constraint."""
+    temp_table = "seed_source_run_with_fk"
+    preparer = conn.dialect.identifier_preparer
+    quoted_temp = _quote(temp_table, preparer)
+    quoted_run = _quote("seed_source_run", preparer)
+    _create_seed_source_run_table(conn, temp_table)
+    conn.execute(
+        text(
+            f"""
+            INSERT INTO {quoted_temp} (
+                id,
+                seed_source_id,
+                status,
+                started_at,
+                completed_at,
+                songs_seen,
+                songs_imported,
+                error_message,
+                notes
+            )
+            SELECT
+                run.id,
+                run.seed_source_id,
+                run.status,
+                run.started_at,
+                run.completed_at,
+                run.songs_seen,
+                run.songs_imported,
+                run.error_message,
+                run.notes
+            FROM {quoted_run} AS run
+            WHERE EXISTS (
+                SELECT 1
+                FROM seed_source AS source
+                WHERE source.id = run.seed_source_id
+            )
+            """
+        )
+    )
+    conn.execute(text(f"DROP TABLE {quoted_run}"))
+    conn.execute(text(f"ALTER TABLE {quoted_temp} RENAME TO {quoted_run}"))
     return True
 
 
@@ -77,24 +155,10 @@ def run_migration():
 
             inspector = inspect(db.engine)
             if not _table_exists(inspector, "seed_source_run"):
-                conn.execute(
-                    text(
-                        """
-                        CREATE TABLE seed_source_run (
-                            id INTEGER PRIMARY KEY,
-                            seed_source_id INTEGER NOT NULL,
-                            status VARCHAR(30) NOT NULL DEFAULT 'planned',
-                            started_at DATETIME NOT NULL,
-                            completed_at DATETIME,
-                            songs_seen INTEGER NOT NULL DEFAULT 0,
-                            songs_imported INTEGER NOT NULL DEFAULT 0,
-                            error_message TEXT,
-                            notes TEXT,
-                            FOREIGN KEY(seed_source_id) REFERENCES seed_source(id) ON DELETE CASCADE
-                        )
-                        """
-                    )
-                )
+                _create_seed_source_run_table(conn)
+                changes_made = True
+            elif not _foreign_key_exists(inspector, "seed_source_run", "seed_source", ["seed_source_id"]):
+                _rebuild_seed_source_run_with_foreign_key(conn)
                 changes_made = True
 
             inspector = inspect(db.engine)

--- a/musicround/routes/rounds.py
+++ b/musicround/routes/rounds.py
@@ -14,7 +14,7 @@ import json
 from flask import Blueprint, session, redirect, request, render_template, url_for, current_app, send_file, jsonify, flash, abort
 from flask_login import current_user, login_required
 from sqlalchemy import or_
-from sqlalchemy.orm import selectinload
+from sqlalchemy.orm import contains_eager
 from musicround.models import PlannedQuizRound, Round, RoundAudioScript, RoundExport, RoundShare, Song, User, db
 from pydub import AudioSegment
 from reportlab.lib.pagesizes import A4
@@ -493,7 +493,7 @@ def round_detail(round_id):
         round_shares = (
             RoundShare.query.filter_by(round_id=rnd.id)
             .join(User)
-            .options(selectinload(RoundShare.user))
+            .options(contains_eager(RoundShare.user))
             .order_by(User.username.asc(), RoundShare.id.asc())
             .all()
         )

--- a/musicround/services/automation.py
+++ b/musicround/services/automation.py
@@ -247,10 +247,23 @@ def _seed_source_run_summary(run: SeedSourceRun) -> dict[str, Any]:
 
 
 def _seed_source_summary(source: SeedSource, include_runs: bool = False) -> dict[str, Any]:
+    """Summarize a seed source and optionally include recent run history.
+
+    Args:
+        source: Seed source model to serialize.
+        include_runs: When true, include up to 20 recent runs and derive
+            latest_run from that fetched list. When false, only latest_run is
+            queried.
+
+    Returns:
+        Dictionary payload suitable for MCP and automation responses.
+    """
     ordered_runs = source.runs.order_by(SeedSourceRun.started_at.desc(), SeedSourceRun.id.desc())
-    runs = ordered_runs.limit(20).all() if include_runs else []
-    latest_run = runs[0] if include_runs and runs else None
-    if not include_runs:
+    if include_runs:
+        runs = ordered_runs.limit(20).all()
+        latest_run = runs[0] if runs else None
+    else:
+        runs = []
         latest_run = ordered_runs.first()
     payload = {
         "id": source.id,

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -329,6 +329,67 @@ def test_add_seed_source_registry_to_legacy_database(tmp_path):
     assert "idx_seed_source_run_source_status" in {index.name for index in SeedSourceRun.__table__.indexes}
 
 
+def test_add_seed_source_registry_rebuilds_existing_run_table_with_foreign_key(tmp_path):
+    """Legacy seed source run tables without constraints are rebuilt safely."""
+    database_path = tmp_path / "legacy-seed-source-run-no-fk.db"
+    with sqlite3.connect(database_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE seed_source (
+                id INTEGER PRIMARY KEY,
+                name VARCHAR(200) NOT NULL,
+                source_type VARCHAR(50) NOT NULL,
+                provider VARCHAR(100),
+                url VARCHAR(500),
+                cadence VARCHAR(50),
+                active BOOLEAN NOT NULL DEFAULT 1,
+                priority INTEGER NOT NULL DEFAULT 100,
+                created_at DATETIME NOT NULL,
+                UNIQUE(name, provider)
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE seed_source_run (
+                id INTEGER PRIMARY KEY,
+                seed_source_id INTEGER NOT NULL,
+                status VARCHAR(30) NOT NULL DEFAULT 'planned',
+                started_at DATETIME NOT NULL,
+                completed_at DATETIME,
+                songs_seen INTEGER NOT NULL DEFAULT 0,
+                songs_imported INTEGER NOT NULL DEFAULT 0,
+                error_message TEXT,
+                notes TEXT
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO seed_source (id, name, source_type, created_at) VALUES (1, 'Charts', 'chart', '2026-07-07')"
+        )
+        conn.execute(
+            "INSERT INTO seed_source_run (id, seed_source_id, status, started_at) VALUES (10, 1, 'success', '2026-07-07')"
+        )
+        conn.execute(
+            "INSERT INTO seed_source_run (id, seed_source_id, status, started_at) VALUES (11, 999, 'orphan', '2026-07-07')"
+        )
+
+    app = _legacy_app(database_path)
+    with app.app_context():
+        from migrations import add_seed_source_registry
+
+        assert add_seed_source_registry.run_migration() is True
+        assert add_seed_source_registry.run_migration() is None
+
+    assert any(
+        row[2] == "seed_source" and row[3] == "seed_source_id" and row[4] == "id"
+        for row in _foreign_keys(database_path, "seed_source_run")
+    )
+    with sqlite3.connect(database_path) as conn:
+        rows = conn.execute("SELECT id, seed_source_id, status FROM seed_source_run").fetchall()
+    assert rows == [(10, 1, "success")]
+
+
 def test_add_planned_quiz_rounds_to_legacy_database(tmp_path):
     """Existing databases get planned quiz production-board schema."""
     database_path = tmp_path / "legacy-planned-quiz.db"


### PR DESCRIPTION
## Summary\n- rebuild existing legacy seed_source_run tables so the seed_source foreign key is present\n- use contains_eager for the already-joined round share user query\n- clarify and simplify seed source summary run loading\n\n## Validation\n- python3 -m py_compile migrations/add_seed_source_registry.py musicround/services/automation.py musicround/routes/rounds.py tests/test_migrations.py\n- git diff --check\n\nFocused pytest remains blocked locally by the shared QuizzicalBeats venv hanging while importing the openai package before collection; CI should run the full suite.