### PR TITLE
Relax round package duration gating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added configurable `DATA_DIR` support for custom MP3s, backups, Spotify cache files, and authenticated data downloads.
 
 ### Fixed
+- Relaxed the round package duration gate so small MP3 length differences are
+  reported as review warnings while full missing-song-scale mismatches still
+  block delivery.
+- Split round quality feedback into blocking issues and warnings for browser,
+  email, scheduled-email, and MCP flows.
+- Made the round detail MP3 flow clearer: click reuses or creates an MP3, while
+  Shift-click or the modal regenerate action forces a fresh render.
 - Stopped Docker Compose from hard-coding the SQLite database URI so `.env`
   PostgreSQL component variables can exercise the managed-database path.
 - Made the implicit SQLite fallback follow `DATA_DIR` so local/dev deployments no longer create `/data/song_data.db` when a different app-data directory is configured.

--- a/docs/developer-guide/mcp.md
+++ b/docs/developer-guide/mcp.md
@@ -136,6 +136,12 @@ report's `failed_positions`, call `suggest_replacement_songs`, then call
 `replace_round_song`. Regenerate assets after any replacement because the
 generated MP3/PDF flags are invalidated.
 
+`inspect_round_package` distinguishes hard blockers from review warnings. The
+`ok` field is false only when blocking issues exist, while `warnings` and
+`report.warnings` should be surfaced to the user or agent as repair hints. Small
+MP3 duration differences can be warnings; mismatches large enough to resemble a
+missing preview slot remain blocking render failures.
+
 When the status is `needs_more_songs`, call `suggest_additional_songs`, then
 `add_round_song` until the round has exactly eight playable songs. Regenerate
 assets and rerun `inspect_round_package` before sending.

--- a/docs/user-guide/exporting-rounds.md
+++ b/docs/user-guide/exporting-rounds.md
@@ -30,6 +30,11 @@ repair feedback, including missing or too-short previews and replacement actions
 Scheduled emails use the same gate and keep a failed export message on the round
 so the issue can be repaired before resending.
 
+Some checks are warnings rather than delivery blockers. For example, a small MP3
+duration difference is shown for review, while a mismatch large enough to suggest
+a missing song remains blocked until the MP3 is regenerated or the round is
+repaired.
+
 ## Dropbox Export
 
 Quizzical Beats integrates with Dropbox to easily store your rounds in the cloud:

--- a/musicround/routes/rounds.py
+++ b/musicround/routes/rounds.py
@@ -656,15 +656,19 @@ def round_quality(round_id):
             value = min(maximum, value)
         return value
 
-    def parse_float_query_arg(name, default):
+    def parse_float_query_arg(name, default, minimum=None):
         raw_value = request.args.get(name)
         if raw_value in (None, ''):
             return default
         try:
-            return float(raw_value)
+            value = float(raw_value)
         except (TypeError, ValueError):
             invalid_parameters.append({'name': name, 'value': raw_value})
             return default
+        if minimum is not None and value < minimum:
+            invalid_parameters.append({'name': name, 'value': raw_value})
+            return default
+        return value
 
     expected_song_count = parse_int_query_arg(
         'expected_song_count',
@@ -672,11 +676,12 @@ def round_quality(round_id):
         minimum=1,
         maximum=25,
     )
-    min_preview_seconds = parse_float_query_arg('min_preview_seconds', 20.0)
-    max_preview_seconds = parse_float_query_arg('max_preview_seconds', 35.0)
+    min_preview_seconds = parse_float_query_arg('min_preview_seconds', 20.0, minimum=0.0)
+    max_preview_seconds = parse_float_query_arg('max_preview_seconds', 35.0, minimum=0.0)
     duration_tolerance_seconds = parse_float_query_arg(
         'duration_tolerance_seconds',
         automation.DEFAULT_MP3_DURATION_TOLERANCE_SECONDS,
+        minimum=0.0,
     )
     if invalid_parameters:
         return _automation_error_response(

--- a/musicround/services/automation.py
+++ b/musicround/services/automation.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import re
 import csv
+import math
 import tempfile
 from datetime import datetime, timedelta, timezone
 from typing import Any, Iterable
@@ -1889,10 +1890,14 @@ def inspect_round_package(
     """Validate a generated round bundle before it is allowed to leave by email."""
     if expected_song_count < 1:
         raise AutomationError("expected_song_count must be at least 1.")
+    if not math.isfinite(min_preview_seconds) or not math.isfinite(max_preview_seconds):
+        raise AutomationError("preview duration limits must be finite.")
     if min_preview_seconds < 0 or max_preview_seconds < 0:
         raise AutomationError("preview duration limits must not be negative.")
     if min_preview_seconds > max_preview_seconds:
         raise AutomationError("min_preview_seconds must not exceed max_preview_seconds.")
+    if not math.isfinite(duration_tolerance_seconds):
+        raise AutomationError("duration_tolerance_seconds must be finite.")
     if duration_tolerance_seconds < 0:
         raise AutomationError("duration_tolerance_seconds must not be negative.")
 

--- a/musicround/services/automation.py
+++ b/musicround/services/automation.py
@@ -63,6 +63,8 @@ AUTOMATION_MP3_INSPECTION_ERROR = "MP3 inspection failed."
 AUTOMATION_MP3_GENERATION_ERROR = "MP3 generation failed. Check the server logs."
 AUTOMATION_SCHEDULED_EMAIL_ERROR = "Scheduled round email failed. Check the server logs."
 DEFAULT_MP3_DURATION_TOLERANCE_SECONDS = 30.0
+MIN_MP3_DURATION_MISMATCH_BLOCK_SECONDS = 40.0
+MP3_DURATION_MISSING_SLOT_FACTOR = 0.75
 
 
 def _round_song_ids(round_obj: Round) -> list[int]:
@@ -1571,8 +1573,9 @@ def _quality_issue(
     message: str,
     song: Song | None = None,
     details: dict[str, Any] | None = None,
+    severity: str = "error",
 ) -> dict[str, Any]:
-    issue: dict[str, Any] = {"code": code, "severity": "error", "message": message}
+    issue: dict[str, Any] = {"code": code, "severity": severity, "message": message}
     if song:
         issue["song"] = {
             "id": song.id,
@@ -1584,6 +1587,10 @@ def _quality_issue(
     if details:
         issue["details"] = details
     return issue
+
+
+def _blocking_quality_issues(issues: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [issue for issue in issues if issue.get("severity", "error") != "warning"]
 
 
 def _download_preview_audio(
@@ -1743,30 +1750,45 @@ def _round_repair_report(quality: dict[str, Any]) -> dict[str, Any]:
     status = quality.get("status", "blocked")
     ok = bool(quality.get("ok"))
     issues = quality.get("issues", [])
+    blocking_issues = _blocking_quality_issues(issues)
+    warning_issues = [issue for issue in issues if issue.get("severity") == "warning"]
     remediation = quality.get("remediation", [])
     preview_checks = quality.get("preview_checks", [])
 
     if ok:
         headline = f"{round_label} is ready to send."
+        warning_suffix = (
+            f" {len(warning_issues)} warning(s) should be reviewed."
+            if warning_issues
+            else ""
+        )
         summary = (
             f"{quality.get('resolved_song_count', quality.get('song_count', 0))} songs, "
-            "all previews and generated assets passed the package gate."
+            "all blocking preview and generated asset checks passed the package gate."
+            f"{warning_suffix}"
         )
     else:
         headline = f"{round_label} is blocked: {status}."
         summary = (
-            f"{len(issues)} issue(s) found. Expected "
+            f"{len(blocking_issues)} blocker(s) found. Expected "
             f"{quality.get('expected_song_count')} songs, found "
             f"{quality.get('resolved_song_count', quality.get('song_count'))} playable songs."
         )
 
     blockers: list[str] = []
-    for issue in issues:
+    warnings: list[str] = []
+    for issue in blocking_issues:
         song = issue.get("song")
         prefix = ""
         if song:
             prefix = f"{song.get('artist')} - {song.get('title')}: "
         blockers.append(f"{prefix}{issue.get('message')}")
+    for issue in warning_issues:
+        song = issue.get("song")
+        prefix = ""
+        if song:
+            prefix = f"{song.get('artist')} - {song.get('title')}: "
+        warnings.append(f"{prefix}{issue.get('message')}")
 
     failed_positions = []
     for check in preview_checks:
@@ -1834,6 +1856,9 @@ def _round_repair_report(quality: dict[str, Any]) -> dict[str, Any]:
     if blockers:
         markdown_lines.extend(["", "## Blockers"])
         markdown_lines.extend(f"- {blocker}" for blocker in blockers)
+    if warnings:
+        markdown_lines.extend(["", "## Warnings"])
+        markdown_lines.extend(f"- {warning}" for warning in warnings)
     if actions:
         markdown_lines.extend(["", "## Repair actions"])
         markdown_lines.extend(f"- {action['message']}" for action in actions)
@@ -1845,6 +1870,7 @@ def _round_repair_report(quality: dict[str, Any]) -> dict[str, Any]:
         "status": status,
         "ok": ok,
         "blockers": blockers,
+        "warnings": warnings,
         "failed_positions": failed_positions,
         "actions": actions,
         "next_step": next_step,
@@ -1861,6 +1887,15 @@ def inspect_round_package(
     duration_tolerance_seconds: float = DEFAULT_MP3_DURATION_TOLERANCE_SECONDS,
 ) -> dict[str, Any]:
     """Validate a generated round bundle before it is allowed to leave by email."""
+    if expected_song_count < 1:
+        raise AutomationError("expected_song_count must be at least 1.")
+    if min_preview_seconds < 0 or max_preview_seconds < 0:
+        raise AutomationError("preview duration limits must not be negative.")
+    if min_preview_seconds > max_preview_seconds:
+        raise AutomationError("min_preview_seconds must not exceed max_preview_seconds.")
+    if duration_tolerance_seconds < 0:
+        raise AutomationError("duration_tolerance_seconds must not be negative.")
+
     round_obj = db.session.get(Round, round_id)
     if not round_obj:
         raise AutomationError(f"Round {round_id} was not found.")
@@ -1885,6 +1920,7 @@ def inspect_round_package(
     preview_checks: list[dict[str, Any]] = []
     remediation: list[dict[str, Any]] = []
     total_preview_ms = 0
+    preview_ms_by_position: dict[int, int] = {}
     service_health = {
         "artifact_storage": artifact_storage_service_health(),
         "spotify": spotify_service_health(user),
@@ -2002,6 +2038,7 @@ def inspect_round_package(
             elif audio:
                 duration_seconds = len(audio) / 1000
                 total_preview_ms += len(audio)
+                preview_ms_by_position[index] = len(audio)
                 check["duration_seconds"] = round(duration_seconds, 3)
                 check["ok"] = True
                 if duration_seconds < min_preview_seconds:
@@ -2071,13 +2108,24 @@ def inspect_round_package(
             + sum((components.get("hint_audio_ms") or {}).values())
             + 2 * total_preview_ms
         )
+        track_slot_ms = []
+        number_audio_ms = components.get("number_audio_ms") or []
+        hint_audio_ms = components.get("hint_audio_ms") or {}
+        for position, preview_ms in preview_ms_by_position.items():
+            number_ms = number_audio_ms[position - 1] if position - 1 < len(number_audio_ms) else 0
+            track_slot_ms.append((2 * preview_ms) + (2 * number_ms) + hint_audio_ms.get(position, 0))
+        if track_slot_ms:
+            components["expected_track_slot_seconds"] = [
+                round(value / 1000, 3) for value in track_slot_ms
+            ]
+            components["minimum_expected_track_slot_seconds"] = round(min(track_slot_ms) / 1000, 3)
 
     pdf_result: dict[str, Any] | None = None
     mp3_result: dict[str, Any] | None = None
     try:
         pdf_result = inspect_pdf_quality(round_id=round_id)
         for warning in pdf_result.get("warnings", []):
-            issues.append(_quality_issue("pdf_quality_warning", warning))
+            issues.append(_quality_issue("pdf_quality_warning", warning, severity="warning"))
     except Exception as exc:
         current_app.logger.error("PDF inspection failed for round %s: %s", round_id, exc, exc_info=True)
         issues.append(_quality_issue("pdf_inspection_failed", AUTOMATION_PDF_INSPECTION_ERROR))
@@ -2085,7 +2133,7 @@ def inspect_round_package(
     try:
         mp3_result = inspect_mp3_quality(round_id=round_id)
         for warning in mp3_result.get("warnings", []):
-            issues.append(_quality_issue("mp3_quality_warning", warning))
+            issues.append(_quality_issue("mp3_quality_warning", warning, severity="warning"))
     except Exception as exc:
         current_app.logger.error("MP3 inspection failed for round %s: %s", round_id, exc, exc_info=True)
         issues.append(_quality_issue("mp3_inspection_failed", AUTOMATION_MP3_INSPECTION_ERROR))
@@ -2095,6 +2143,17 @@ def inspect_round_package(
         actual_seconds = float(mp3_result["duration_seconds"])
         delta_seconds = actual_seconds - expected_seconds
         if abs(delta_seconds) > duration_tolerance_seconds:
+            minimum_slot_seconds = components.get("minimum_expected_track_slot_seconds")
+            missing_slot_threshold = (
+                max(
+                    duration_tolerance_seconds,
+                    MIN_MP3_DURATION_MISMATCH_BLOCK_SECONDS,
+                    minimum_slot_seconds * MP3_DURATION_MISSING_SLOT_FACTOR,
+                )
+                if minimum_slot_seconds
+                else max(duration_tolerance_seconds, MIN_MP3_DURATION_MISMATCH_BLOCK_SECONDS)
+            )
+            severity = "error" if abs(delta_seconds) >= missing_slot_threshold else "warning"
             issue = _quality_issue(
                 "round_mp3_duration_mismatch",
                 (
@@ -2107,7 +2166,9 @@ def inspect_round_package(
                     "expected_seconds": round(expected_seconds, 3),
                     "delta_seconds": round(delta_seconds, 3),
                     "tolerance_seconds": duration_tolerance_seconds,
+                    "blocking_threshold_seconds": round(missing_slot_threshold, 3),
                 },
+                severity=severity,
             )
             issues.append(issue)
             remediation.append(
@@ -2118,12 +2179,13 @@ def inspect_round_package(
                 }
             )
 
-    issue_codes = {issue["code"] for issue in issues}
-    if not issues:
+    blocking_issues = _blocking_quality_issues(issues)
+    blocking_issue_codes = {issue["code"] for issue in blocking_issues}
+    if not blocking_issues:
         status = "ok"
-    elif issue_codes & {"actual_song_count_mismatch", "resolved_song_count_mismatch"}:
+    elif blocking_issue_codes & {"actual_song_count_mismatch", "resolved_song_count_mismatch"}:
         status = "needs_more_songs" if len(songs) < expected_song_count else "blocked"
-    elif issue_codes & {
+    elif blocking_issue_codes & {
         "missing_deezer_id",
         "missing_preview_url",
         "preview_too_short",
@@ -2131,13 +2193,13 @@ def inspect_round_package(
         "preview_download_failed",
     }:
         status = "needs_substitution"
-    elif issue_codes & {
+    elif blocking_issue_codes & {
         "artifact_storage_missing",
         "artifact_storage_not_directory",
         "artifact_storage_not_writable",
     }:
         status = "storage_unhealthy"
-    elif issue_codes & {"pdf_inspection_failed", "mp3_inspection_failed", "round_mp3_duration_mismatch"}:
+    elif blocking_issue_codes & {"pdf_inspection_failed", "mp3_inspection_failed", "round_mp3_duration_mismatch"}:
         status = "render_failed"
     else:
         status = "blocked"
@@ -2159,9 +2221,11 @@ def inspect_round_package(
         "pdf": pdf_result,
         "mp3": mp3_result,
         "issues": issues,
-        "hints": [issue["message"] for issue in issues],
+        "warnings": [issue for issue in issues if issue.get("severity") == "warning"],
+        "blocking_issue_count": len(blocking_issues),
+        "hints": [issue["message"] for issue in blocking_issues],
         "remediation": remediation,
-        "ok": not issues,
+        "ok": not blocking_issues,
     }
     result["report"] = _round_repair_report(result)
     return result

--- a/musicround/templates/round_detail.html
+++ b/musicround/templates/round_detail.html
@@ -286,8 +286,8 @@
                 <i class="fas fa-file-audio fa-3x"></i>
             </div>
             <h3 class="text-xl font-semibold mb-4 text-navy-800 text-center font-montserrat">Generate MP3</h3>
-            <p class="text-gray-600 mb-4 text-center text-sm">Create or refresh the audio file with all songs to play during your quiz.</p>
-            <button id="generate-mp3-btn" title="Shift-click to regenerate the MP3" class="bg-orange-500 hover:bg-orange-600 text-white py-2 px-4 rounded transition-colors w-full font-semibold">
+            <p class="text-gray-600 mb-4 text-center text-sm">Create the audio file with all songs to play during your quiz. Shift-click to force a fresh render.</p>
+            <button id="generate-mp3-btn" title="Click to use or create the MP3. Shift-click to regenerate it." class="bg-orange-500 hover:bg-orange-600 text-white py-2 px-4 rounded transition-colors w-full font-semibold">
                 <i class="fas fa-music mr-2"></i> Generate MP3
             </button>
         </div>
@@ -1017,8 +1017,12 @@
         function renderQualityReport(data) {
             const report = data.report || {};
             const quality = data.quality || {};
-            const badgeClass = report.ok ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800';
+            const warnings = report.warnings || [];
+            const badgeClass = report.ok
+                ? (warnings.length ? 'bg-yellow-100 text-yellow-800' : 'bg-green-100 text-green-800')
+                : 'bg-red-100 text-red-800';
             const blockers = (report.blockers || []).map(item => `<li>${escapeHtml(item)}</li>`).join('');
+            const warningItems = warnings.map(item => `<li>${escapeHtml(item)}</li>`).join('');
             const actions = (report.actions || []).map(item => `<li>${escapeHtml(item.message)}</li>`).join('');
             const failed = (report.failed_positions || []).map(item => {
                 const position = Number(item.position) || '';
@@ -1030,6 +1034,7 @@
                     <span>${escapeHtml(report.summary || '')}</span>
                 </div>
                 ${blockers ? `<div class="mb-3"><h3 class="font-semibold text-red-800">Blockers</h3><ul class="list-disc pl-5">${blockers}</ul></div>` : ''}
+                ${warningItems ? `<div class="mb-3"><h3 class="font-semibold text-yellow-800">Warnings</h3><ul class="list-disc pl-5">${warningItems}</ul></div>` : ''}
                 ${actions ? `<div class="mb-3"><h3 class="font-semibold text-navy-800">Repair Actions</h3><ul class="list-disc pl-5">${actions}</ul></div>` : ''}
                 ${failed ? `<div><h3 class="font-semibold text-orange-800 mb-2">Failed Positions</h3>${failed}</div>` : ''}
             `;
@@ -1171,7 +1176,7 @@
                 if (data.success) {
                     if (data.mp3_status === 'exists') {
                         mp3StatusTitle.textContent = 'MP3 Already Exists';
-                        mp3StatusMessage.textContent = 'An MP3 is already available. Download it or regenerate it.';
+                        mp3StatusMessage.textContent = 'An MP3 is already available. Download it, use Shift-click on Generate MP3, or press Regenerate MP3 here to force a fresh render.';
                         regenerateMp3Btn.classList.remove('hidden');
                     } else {
                         mp3StatusTitle.textContent = forceRegenerate ? 'MP3 Regenerated Successfully' : 'MP3 Generated Successfully';

--- a/tests/test_automation_service.py
+++ b/tests/test_automation_service.py
@@ -943,6 +943,30 @@ class TestAssetInspection:
             assert result["status"] == "needs_substitution"
             assert any(issue["code"] == "preview_too_short" for issue in result["issues"])
 
+    def test_inspect_round_package_rejects_invalid_duration_parameters(self, app):
+        with app.app_context():
+            song = _create_song(title="Parameter", artist="Artist", deezer_id="123")
+            round_id = automation.create_round(
+                name="Bad Parameters",
+                round_type="manual",
+                song_ids=[song.id],
+            )["round"]["id"]
+
+            with pytest.raises(automation.AutomationError, match="must not exceed"):
+                automation.inspect_round_package(
+                    round_id,
+                    expected_song_count=1,
+                    min_preview_seconds=35,
+                    max_preview_seconds=20,
+                )
+
+            with pytest.raises(automation.AutomationError, match="must not be negative"):
+                automation.inspect_round_package(
+                    round_id,
+                    expected_song_count=1,
+                    duration_tolerance_seconds=-1,
+                )
+
     def test_inspect_round_package_tolerates_minor_mp3_duration_variance(self, app):
         with app.app_context():
             user = _create_user()
@@ -984,6 +1008,57 @@ class TestAssetInspection:
                 issue["code"] == "round_mp3_duration_mismatch"
                 for issue in result["issues"]
             )
+
+    def test_inspect_round_package_warns_for_small_mp3_duration_shortfall(self, app):
+        with app.app_context():
+            user = _create_user()
+            song = _create_song(title="Warn Only", artist="Artist", deezer_id="123")
+            round_id = automation.create_round(
+                name="Small Shortfall",
+                round_type="manual",
+                song_ids=[song.id],
+            )["round"]["id"]
+
+            with (
+                patch(
+                    "musicround.services.automation._download_preview_audio",
+                    return_value=("https://example.test/preview.mp3", AudioSegment.silent(duration=30000), None),
+                ),
+                patch(
+                    "musicround.services.automation._round_audio_components",
+                    return_value=(
+                        {"custom_audio_ms": {"intro": 1000, "replay": 1000, "outro": 1000}, "number_audio_ms": [1000]},
+                        [],
+                    ),
+                ),
+                patch(
+                    "musicround.services.automation.inspect_pdf_quality",
+                    return_value={"warnings": [], "ok": True},
+                ),
+                patch(
+                    "musicround.services.automation.inspect_mp3_quality",
+                    return_value={"warnings": [], "ok": True, "duration_seconds": 50},
+                ),
+            ):
+                result = automation.inspect_round_package(
+                    round_id,
+                    user_id=user.id,
+                    expected_song_count=1,
+                    duration_tolerance_seconds=10,
+                )
+
+            warning = next(
+                issue for issue in result["issues"]
+                if issue["code"] == "round_mp3_duration_mismatch"
+            )
+            assert result["expected_duration_seconds"] == 65
+            assert result["status"] == "ok"
+            assert result["ok"] is True
+            assert warning["severity"] == "warning"
+            assert result["blocking_issue_count"] == 0
+            assert result["warnings"] == [warning]
+            assert "Warnings" in result["report"]["markdown"]
+            assert result["report"]["blockers"] == []
 
     def test_inspect_round_package_blocks_material_mp3_duration_shortfall(self, app):
         with app.app_context():
@@ -1038,10 +1113,11 @@ class TestAssetInspection:
 
             assert result["expected_duration_seconds"] == 339
             assert result["status"] == "render_failed"
-            assert any(
-                issue["code"] == "round_mp3_duration_mismatch"
-                for issue in result["issues"]
+            mismatch = next(
+                issue for issue in result["issues"]
+                if issue["code"] == "round_mp3_duration_mismatch"
             )
+            assert mismatch["severity"] == "error"
 
     def test_inspect_round_package_warns_for_large_mp3_duration_mismatch(self, app):
         with app.app_context():
@@ -1080,10 +1156,11 @@ class TestAssetInspection:
 
             assert result["expected_duration_seconds"] == 65
             assert result["status"] == "render_failed"
-            assert any(
-                issue["code"] == "round_mp3_duration_mismatch"
-                for issue in result["issues"]
+            mismatch = next(
+                issue for issue in result["issues"]
+                if issue["code"] == "round_mp3_duration_mismatch"
             )
+            assert mismatch["severity"] == "error"
 
     def test_round_audio_component_failures_hide_exception_details(self, app):
         with app.app_context():

--- a/tests/test_automation_service.py
+++ b/tests/test_automation_service.py
@@ -967,6 +967,20 @@ class TestAssetInspection:
                     duration_tolerance_seconds=-1,
                 )
 
+            for parameter_name in ("min_preview_seconds", "max_preview_seconds", "duration_tolerance_seconds"):
+                with pytest.raises(automation.AutomationError, match="must be finite"):
+                    automation.inspect_round_package(
+                        round_id,
+                        expected_song_count=1,
+                        **{parameter_name: float("nan")},
+                    )
+                with pytest.raises(automation.AutomationError, match="must be finite"):
+                    automation.inspect_round_package(
+                        round_id,
+                        expected_song_count=1,
+                        **{parameter_name: float("inf")},
+                    )
+
     def test_inspect_round_package_tolerates_minor_mp3_duration_variance(self, app):
         with app.app_context():
             user = _create_user()

--- a/tests/test_rounds_routes.py
+++ b/tests/test_rounds_routes.py
@@ -635,6 +635,7 @@ class TestRoundDetailRoute:
             '?expected_song_count=many'
             '&min_preview_seconds=short'
             '&duration_tolerance_seconds=wide'
+            '&max_preview_seconds=-1'
         )
 
         assert response.status_code == 400
@@ -645,6 +646,7 @@ class TestRoundDetailRoute:
                 'invalid_parameters': [
                     {'name': 'expected_song_count', 'value': 'many'},
                     {'name': 'min_preview_seconds', 'value': 'short'},
+                    {'name': 'max_preview_seconds', 'value': '-1'},
                     {'name': 'duration_tolerance_seconds', 'value': 'wide'},
                 ],
             },


### PR DESCRIPTION
## Summary
- classify small generated-MP3 duration mismatches as review warnings while keeping missing-song-scale mismatches blocking
- split package quality feedback into blockers and warnings for MCP/browser/email flows
- clarify browser MP3 regenerate behavior and document warning semantics

## Local validation
- .venv/bin/python -m py_compile musicround/services/automation.py musicround/routes/rounds.py
- SECRET_KEY=test-secret AUTOMATION_TOKEN=test-token .venv/bin/pytest tests/test_automation_service.py -k 'inspect_round_package or round_repair_report or email_round_blocks_when_package_quality_fails or schedule_round_email_blocks_when_quality_fails or process_due_scheduled_round_email_persists_quality_feedback' -q
- SECRET_KEY=test-secret AUTOMATION_TOKEN=test-token .venv/bin/pytest tests/test_rounds_routes.py -k 'quality or mp3 or mail_route' -q
- SECRET_KEY=test-secret AUTOMATION_TOKEN=test-token .venv/bin/pytest tests/test_app_factory.py tests/test_automation_service.py -k 'inspect_round_package or round_repair_report or schedule_round_email or process_due_scheduled_round_email or email_round_blocks_when_package_quality_fails' tests/test_rounds_routes.py -k 'quality or mp3 or mail_route' -q
- git diff --check