### PR TITLE
Add round sharing access audit trail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   until exactly eight pasted rows resolve to catalog songs.
 - Added browser round sharing controls for owners/admins to grant and revoke
   viewer/editor access from the round detail page.
+- Added persistent round-sharing audit events with MCP access for collaboration
+  workflows.
 - Added a chart/festival seed-source registry with run history, Flask-Admin
   views, migrations, and MCP automation helpers.
 - Added a browser round-ops workflow with round calendar, catalog/fatigue analytics, quizmaster planning briefs, round review/approval state, package quality inspection, actionable replacement suggestions, and browser review of announcement and per-track hint script drafts.

--- a/docs/developer-guide/backlog-status.md
+++ b/docs/developer-guide/backlog-status.md
@@ -35,7 +35,7 @@ issue after verification or continue with the remaining follow-up.
 | #73 Add MCP tool to draft round intro, replay, and outro scripts | Ready to close | `draft_round_audio_scripts`, MCP docs, round detail actions | Verify one draft for a real round after deploy. |
 | #74 Store and review generated TTS scripts before audio assignment | Ready to close | `RoundAudioScript`, review routes, `generate_tts_from_script` | Verify approved script-to-audio assignment with configured TTS provider. |
 | #75 Add chart and festival seed source registry | Partial | `SeedSource`, `SeedSourceRun`, admin views, MCP registry/run tools | Scrapers/importers for individual chart/festival providers remain separate slices. |
-| #79 Add round ownership and sharing roles | Partial | `RoundShare`, owner filtering, edit checks, MCP share tools, browser share/revoke UI | Public links, audit log, and richer roles remain open. |
+| #79 Add round ownership and sharing roles | Partial | `RoundShare`, `RoundAccessEvent`, owner filtering, edit checks, MCP share tools, browser share/revoke UI | Public links and richer roles remain open. |
 | #126 Move production database configuration off SQLite `/data` | Operational / partial | Managed DB config, migration CLI, runbook, Compose managed-db profile | Live Kubernetes secret/config cutover and scheduled-email smoke remain. |
 | #12 Remove SQLite/RWO singleton | Operational / partial | Same as #126, plus app config hardening | Requires managed DB cutover, stateless replicas, and backup replacement. |
 | #17/#48/#49 Repair and clean broken round emails | Operational | Quality gate and repair tooling exist | Needs live QB/Gmail inspection and cleanup, not repo-only code. |
@@ -45,7 +45,7 @@ issue after verification or continue with the remaining follow-up.
 1. Close or comment the "ready to close" issues after a release smoke confirms
    the linked browser/MCP behavior.
 2. For #75, add first provider-specific source fetchers on top of the registry.
-3. For #79, add access-audit events and optional public read-only links around
+3. For #79, add optional public read-only links and richer role policy around
    `RoundShare`.
 5. For #126/#12, continue with live deployment configuration only through the
    existing 1Password-backed secret flow and credential-safe Kubernetes checks.

--- a/docs/developer-guide/database-schema.md
+++ b/docs/developer-guide/database-schema.md
@@ -225,6 +225,22 @@ The `RoundShare` table stores explicit round access grants.
 | role       | String(20)  | Share role (viewer, editor)          |
 | created_at | DateTime    | When the share was created           |
 
+### RoundAccessEvent
+
+The `RoundAccessEvent` table stores an audit trail for ownership and sharing
+changes on collaborative rounds.
+
+| Column         | Type        | Description                                  |
+|----------------|-------------|----------------------------------------------|
+| id             | Integer     | Primary key                                  |
+| round_id       | Integer     | Foreign key to Round                         |
+| actor_user_id  | Integer     | User who performed the action, when known    |
+| target_user_id | Integer     | User whose access changed, when applicable   |
+| action         | String(40)  | Event type such as share_created/revoked     |
+| role           | String(20)  | Role involved in the event                   |
+| details        | Text        | Optional event details                       |
+| created_at     | DateTime    | When the event was recorded                  |
+
 ### RoundAudioScript
 
 The `RoundAudioScript` table stores reviewable intro, replay, and outro text

--- a/docs/developer-guide/mcp.md
+++ b/docs/developer-guide/mcp.md
@@ -54,6 +54,7 @@ The MCP server exposes these tools:
 | `share_round` | Share a round with another quizmaster as viewer or editor. |
 | `list_round_shares` | List explicit share grants for a round. |
 | `revoke_round_share` | Remove a user's share grant from a round. |
+| `list_round_access_events` | List recent ownership and sharing audit events for a round. |
 | `register_seed_source` | Create or update a chart, festival, editorial, curated, or playlist seed source. |
 | `list_seed_sources` | List configured catalog seed sources for agent planning. |
 | `record_seed_source_run` | Record seed-source read/import attempts and outcomes. |
@@ -95,8 +96,8 @@ songs have already appeared in rounds and avoid tracks without playable
 previews.
 
 The generic datastore CRUD tools operate on mapped SQLAlchemy models, including
-`song`, `round`, `round_share`, `round_audio_script`, `tag`, `song_tag`, `user`,
-`role`, `user_preferences`, `planned_quiz_round`, `round_export`,
+`song`, `round`, `round_share`, `round_access_event`, `round_audio_script`,
+`tag`, `song_tag`, `user`, `role`, `user_preferences`, `planned_quiz_round`, `round_export`,
 `system_setting`, and `import_job_record`. Read results redact fields whose
 names contain `password`, `token`, or `secret` unless `include_sensitive` is
 explicitly set.

--- a/docs/developer-guide/mcp.md
+++ b/docs/developer-guide/mcp.md
@@ -51,10 +51,10 @@ The MCP server exposes these tools:
 | `compile_round` | Create a named round from explicit song IDs or selection criteria. |
 | `rename_round` | Set or clear a round name. |
 | `set_round_owner` | Assign or clear the quizmaster owner for a round. |
-| `share_round` | Share a round with another quizmaster as viewer or editor. |
+| `share_round` | Share a round with another quizmaster as viewer or editor via system automation. |
 | `list_round_shares` | List explicit share grants for a round. |
-| `revoke_round_share` | Remove a user's share grant from a round. |
-| `list_round_access_events` | List recent ownership and sharing audit events for a round. |
+| `revoke_round_share` | Remove a user's share grant from a round via system automation. |
+| `list_round_access_events` | List recent ownership and sharing audit events for a round; requires an owner/admin requester. |
 | `register_seed_source` | Create or update a chart, festival, editorial, curated, or playlist seed source. |
 | `list_seed_sources` | List configured catalog seed sources for agent planning. |
 | `record_seed_source_run` | Record seed-source read/import attempts and outcomes. |

--- a/migrations/add_round_collaboration_and_audio_scripts.py
+++ b/migrations/add_round_collaboration_and_audio_scripts.py
@@ -116,7 +116,7 @@ def run_migration():
                             action VARCHAR(40) NOT NULL,
                             role VARCHAR(20),
                             details TEXT,
-                            created_at DATETIME
+                            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
                         )
                         """
                     )

--- a/migrations/add_round_collaboration_and_audio_scripts.py
+++ b/migrations/add_round_collaboration_and_audio_scripts.py
@@ -104,6 +104,25 @@ def run_migration():
                 )
                 changes_made = True
 
+            if not _table_exists(inspector, "round_access_event"):
+                conn.execute(
+                    text(
+                        """
+                        CREATE TABLE round_access_event (
+                            id INTEGER PRIMARY KEY,
+                            round_id INTEGER NOT NULL,
+                            actor_user_id INTEGER,
+                            target_user_id INTEGER,
+                            action VARCHAR(40) NOT NULL,
+                            role VARCHAR(20),
+                            details TEXT,
+                            created_at DATETIME
+                        )
+                        """
+                    )
+                )
+                changes_made = True
+
             inspector = inspect(db.engine)
             if _table_exists(inspector, "round_audio_script"):
                 script_columns = _columns(inspector, "round_audio_script")
@@ -115,6 +134,21 @@ def run_migration():
             for table_name, index_name, columns in (
                 ("round", "idx_round_owner_created", ["user_id", "created_at"]),
                 ("round_share", "idx_round_share_user", ["user_id", "role"]),
+                (
+                    "round_access_event",
+                    "idx_round_access_event_round_created",
+                    ["round_id", "created_at"],
+                ),
+                (
+                    "round_access_event",
+                    "idx_round_access_event_actor",
+                    ["actor_user_id", "created_at"],
+                ),
+                (
+                    "round_access_event",
+                    "idx_round_access_event_target",
+                    ["target_user_id", "created_at"],
+                ),
                 (
                     "round_audio_script",
                     "idx_round_audio_script_round_status",

--- a/migrations/add_round_collaboration_and_audio_scripts.py
+++ b/migrations/add_round_collaboration_and_audio_scripts.py
@@ -110,9 +110,9 @@ def run_migration():
                         """
                         CREATE TABLE round_access_event (
                             id INTEGER PRIMARY KEY,
-                            round_id INTEGER NOT NULL,
-                            actor_user_id INTEGER,
-                            target_user_id INTEGER,
+                            round_id INTEGER NOT NULL REFERENCES round(id) ON DELETE CASCADE,
+                            actor_user_id INTEGER REFERENCES user(id) ON DELETE SET NULL,
+                            target_user_id INTEGER REFERENCES user(id) ON DELETE SET NULL,
                             action VARCHAR(40) NOT NULL,
                             role VARCHAR(20),
                             details TEXT,

--- a/musicround/mcp_server.py
+++ b/musicround/mcp_server.py
@@ -295,13 +295,19 @@ def set_round_owner(
 
 
 @mcp.tool()
-def share_round(round_id: int, user_id: int, role: str = "viewer") -> dict[str, Any]:
+def share_round(
+    round_id: int,
+    user_id: int,
+    role: str = "viewer",
+    actor_user_id: int | None = None,
+) -> dict[str, Any]:
     """Share a round with another quizmaster as viewer or editor."""
     return _with_app_context(
         automation.share_round,
         round_id=round_id,
         user_id=user_id,
         role=role,
+        actor_user_id=actor_user_id,
     )
 
 
@@ -312,12 +318,27 @@ def list_round_shares(round_id: int) -> dict[str, Any]:
 
 
 @mcp.tool()
-def revoke_round_share(round_id: int, user_id: int) -> dict[str, Any]:
+def revoke_round_share(
+    round_id: int,
+    user_id: int,
+    actor_user_id: int | None = None,
+) -> dict[str, Any]:
     """Remove a user's share grant from a round."""
     return _with_app_context(
         automation.revoke_round_share,
         round_id=round_id,
         user_id=user_id,
+        actor_user_id=actor_user_id,
+    )
+
+
+@mcp.tool()
+def list_round_access_events(round_id: int, limit: int = 50) -> dict[str, Any]:
+    """List recent ownership and sharing audit events for a round."""
+    return _with_app_context(
+        automation.list_round_access_events,
+        round_id=round_id,
+        limit=limit,
     )
 
 

--- a/musicround/mcp_server.py
+++ b/musicround/mcp_server.py
@@ -299,15 +299,13 @@ def share_round(
     round_id: int,
     user_id: int,
     role: str = "viewer",
-    actor_user_id: int | None = None,
 ) -> dict[str, Any]:
-    """Share a round with another quizmaster as viewer or editor."""
+    """Share a round with another quizmaster as viewer or editor via system automation."""
     return _with_app_context(
         automation.share_round,
         round_id=round_id,
         user_id=user_id,
         role=role,
-        actor_user_id=actor_user_id,
     )
 
 
@@ -321,24 +319,27 @@ def list_round_shares(round_id: int) -> dict[str, Any]:
 def revoke_round_share(
     round_id: int,
     user_id: int,
-    actor_user_id: int | None = None,
 ) -> dict[str, Any]:
-    """Remove a user's share grant from a round."""
+    """Remove a user's share grant from a round via system automation."""
     return _with_app_context(
         automation.revoke_round_share,
         round_id=round_id,
         user_id=user_id,
-        actor_user_id=actor_user_id,
     )
 
 
 @mcp.tool()
-def list_round_access_events(round_id: int, limit: int = 50) -> dict[str, Any]:
+def list_round_access_events(
+    round_id: int,
+    requester_user_id: int,
+    limit: int = 50,
+) -> dict[str, Any]:
     """List recent ownership and sharing audit events for a round."""
     return _with_app_context(
         automation.list_round_access_events,
         round_id=round_id,
         limit=limit,
+        requester_user_id=requester_user_id,
     )
 
 

--- a/musicround/models.py
+++ b/musicround/models.py
@@ -361,9 +361,7 @@ class RoundShare(db.Model):
 
 
 class RoundAccessEvent(db.Model):
-    """
-    Audit events for round ownership and sharing changes.
-    """
+    """Audit events for round ownership and sharing changes."""
     __tablename__ = 'round_access_event'
 
     id = db.Column(db.Integer, primary_key=True)
@@ -385,7 +383,8 @@ class RoundAccessEvent(db.Model):
     actor = db.relationship('User', foreign_keys=[actor_user_id])
     target_user = db.relationship('User', foreign_keys=[target_user_id])
 
-    def __repr__(self):
+    def __repr__(self) -> str:
+        """Return a compact debug representation."""
         return f"RoundAccessEvent(round_id={self.round_id}, action='{self.action}')"
 
 

--- a/musicround/models.py
+++ b/musicround/models.py
@@ -360,6 +360,35 @@ class RoundShare(db.Model):
         return f"RoundShare(round_id={self.round_id}, user_id={self.user_id}, role='{self.role}')"
 
 
+class RoundAccessEvent(db.Model):
+    """
+    Audit events for round ownership and sharing changes.
+    """
+    __tablename__ = 'round_access_event'
+
+    id = db.Column(db.Integer, primary_key=True)
+    round_id = db.Column(db.Integer, db.ForeignKey('round.id', ondelete='CASCADE'), nullable=False)
+    actor_user_id = db.Column(db.Integer, db.ForeignKey('user.id', ondelete='SET NULL'), nullable=True)
+    target_user_id = db.Column(db.Integer, db.ForeignKey('user.id', ondelete='SET NULL'), nullable=True)
+    action = db.Column(db.String(40), nullable=False)
+    role = db.Column(db.String(20), nullable=True)
+    details = db.Column(db.Text, nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+    __table_args__ = (
+        db.Index('idx_round_access_event_round_created', 'round_id', 'created_at'),
+        db.Index('idx_round_access_event_actor', 'actor_user_id', 'created_at'),
+        db.Index('idx_round_access_event_target', 'target_user_id', 'created_at'),
+    )
+
+    round = db.relationship('Round', backref=db.backref('access_events', lazy='dynamic'))
+    actor = db.relationship('User', foreign_keys=[actor_user_id])
+    target_user = db.relationship('User', foreign_keys=[target_user_id])
+
+    def __repr__(self):
+        return f"RoundAccessEvent(round_id={self.round_id}, action='{self.action}')"
+
+
 class RoundAudioScript(db.Model):
     """
     Reviewable intro/replay/outro script drafts for a round before TTS generation.

--- a/musicround/routes/rounds.py
+++ b/musicround/routes/rounds.py
@@ -15,7 +15,7 @@ from flask import Blueprint, session, redirect, request, render_template, url_fo
 from flask_login import current_user, login_required
 from sqlalchemy import or_
 from sqlalchemy.orm import contains_eager
-from musicround.models import PlannedQuizRound, Round, RoundAudioScript, RoundExport, RoundShare, Song, User, db
+from musicround.models import PlannedQuizRound, Round, RoundAccessEvent, RoundAudioScript, RoundExport, RoundShare, Song, User, db
 from pydub import AudioSegment
 from reportlab.lib.pagesizes import A4
 from reportlab.pdfgen import canvas
@@ -498,6 +498,16 @@ def round_detail(round_id):
             .all()
         )
 
+        can_manage_shares = _can_manage_round_shares(rnd)
+        round_access_events = []
+        if can_manage_shares:
+            round_access_events = (
+                RoundAccessEvent.query.filter_by(round_id=rnd.id)
+                .order_by(RoundAccessEvent.created_at.desc(), RoundAccessEvent.id.desc())
+                .limit(10)
+                .all()
+            )
+
         return render_template(
             'round_detail.html',
             round=rnd,
@@ -508,7 +518,8 @@ def round_detail(round_id):
             audio_scripts=audio_scripts,
             scheduled_exports=scheduled_exports,
             round_shares=round_shares,
-            can_manage_shares=_can_manage_round_shares(rnd),
+            can_manage_shares=can_manage_shares,
+            round_access_events=round_access_events,
         )
     else:
         return 'Round not found'
@@ -609,7 +620,7 @@ def add_round_share(round_id):
         return redirect(url_for('rounds.round_detail', round_id=round_id))
 
     try:
-        automation.share_round(round_id, target_user.id, role=role)
+        automation.share_round(round_id, target_user.id, role=role, actor_user_id=current_user.id)
     except AutomationError as exc:
         flash(str(exc), 'error')
     else:
@@ -626,7 +637,7 @@ def delete_round_share(round_id, user_id):
         abort(403)
 
     try:
-        automation.revoke_round_share(round_id, user_id)
+        automation.revoke_round_share(round_id, user_id, actor_user_id=current_user.id)
     except AutomationError as exc:
         flash(str(exc), 'error')
     else:

--- a/musicround/routes/rounds.py
+++ b/musicround/routes/rounds.py
@@ -14,7 +14,7 @@ import json
 from flask import Blueprint, session, redirect, request, render_template, url_for, current_app, send_file, jsonify, flash, abort
 from flask_login import current_user, login_required
 from sqlalchemy import or_
-from sqlalchemy.orm import contains_eager
+from sqlalchemy.orm import contains_eager, joinedload
 from musicround.models import PlannedQuizRound, Round, RoundAccessEvent, RoundAudioScript, RoundExport, RoundShare, Song, User, db
 from pydub import AudioSegment
 from reportlab.lib.pagesizes import A4
@@ -503,6 +503,10 @@ def round_detail(round_id):
         if can_manage_shares:
             round_access_events = (
                 RoundAccessEvent.query.filter_by(round_id=rnd.id)
+                .options(
+                    joinedload(RoundAccessEvent.actor),
+                    joinedload(RoundAccessEvent.target_user),
+                )
                 .order_by(RoundAccessEvent.created_at.desc(), RoundAccessEvent.id.desc())
                 .limit(10)
                 .all()

--- a/musicround/services/automation.py
+++ b/musicround/services/automation.py
@@ -230,6 +230,12 @@ def _record_round_access_event(
     return event
 
 
+def _validate_round_access_actor(actor_user_id: int | None) -> int | None:
+    if actor_user_id is None:
+        return None
+    return _find_user(actor_user_id).id
+
+
 def _round_summary(round_obj: Round) -> dict[str, Any]:
     ids = _round_song_ids(round_obj)
     ordered = _ordered_round_songs(round_obj)
@@ -982,6 +988,7 @@ def share_round(
     if not round_obj:
         raise AutomationError(f"Round {round_id} was not found.")
     user = _find_user(user_id)
+    actor_user_id = _validate_round_access_actor(actor_user_id)
     if round_obj.user_id == user.id:
         raise AutomationError("The owner already has access to this round.")
 
@@ -1030,6 +1037,7 @@ def revoke_round_share(
     actor_user_id: int | None = None,
 ) -> dict[str, Any]:
     """Remove a user's explicit share grant from a round."""
+    actor_user_id = _validate_round_access_actor(actor_user_id)
     share = RoundShare.query.filter_by(round_id=round_id, user_id=user_id).first()
     if not share:
         raise AutomationError(f"Round {round_id} is not shared with user {user_id}.")

--- a/musicround/services/automation.py
+++ b/musicround/services/automation.py
@@ -39,6 +39,7 @@ from musicround.models import (
     ImportJobRecord,
     PlannedQuizRound,
     Round,
+    RoundAccessEvent,
     RoundAudioScript,
     RoundExport,
     RoundShare,
@@ -191,6 +192,42 @@ def _round_share_summary(share: RoundShare) -> dict[str, Any]:
         "created_at": _datetime_payload(share.created_at),
         "user": _user_summary(share.user),
     }
+
+
+def _round_access_event_summary(event: RoundAccessEvent) -> dict[str, Any]:
+    return {
+        "id": event.id,
+        "round_id": event.round_id,
+        "action": event.action,
+        "role": event.role,
+        "details": event.details,
+        "created_at": _datetime_payload(event.created_at),
+        "actor_user_id": event.actor_user_id,
+        "actor": _user_summary(event.actor),
+        "target_user_id": event.target_user_id,
+        "target_user": _user_summary(event.target_user),
+    }
+
+
+def _record_round_access_event(
+    round_obj: Round,
+    action: str,
+    *,
+    actor_user_id: int | None = None,
+    target_user_id: int | None = None,
+    role: str | None = None,
+    details: str | None = None,
+) -> RoundAccessEvent:
+    event = RoundAccessEvent(
+        round_id=round_obj.id,
+        actor_user_id=actor_user_id,
+        target_user_id=target_user_id,
+        action=action,
+        role=role,
+        details=details,
+    )
+    db.session.add(event)
+    return event
 
 
 def _round_summary(round_obj: Round) -> dict[str, Any]:
@@ -935,6 +972,7 @@ def share_round(
     round_id: int,
     user_id: int,
     role: str = "viewer",
+    actor_user_id: int | None = None,
 ) -> dict[str, Any]:
     """Grant a user access to a round for future collaboration workflows."""
     if role not in {"viewer", "editor"}:
@@ -955,10 +993,18 @@ def share_round(
     share.role = role
     round_obj.visibility = "shared"
     round_obj.updated_at = datetime.utcnow()
+    event = _record_round_access_event(
+        round_obj,
+        "share_created" if created else "share_updated",
+        actor_user_id=actor_user_id,
+        target_user_id=user.id,
+        role=role,
+    )
     db.session.commit()
     return {
         "created": created,
         "share": _round_share_summary(share),
+        "access_event": _round_access_event_summary(event),
         "round": _round_summary(round_obj),
     }
 
@@ -978,7 +1024,11 @@ def list_round_shares(round_id: int) -> dict[str, Any]:
     }
 
 
-def revoke_round_share(round_id: int, user_id: int) -> dict[str, Any]:
+def revoke_round_share(
+    round_id: int,
+    user_id: int,
+    actor_user_id: int | None = None,
+) -> dict[str, Any]:
     """Remove a user's explicit share grant from a round."""
     share = RoundShare.query.filter_by(round_id=round_id, user_id=user_id).first()
     if not share:
@@ -987,6 +1037,15 @@ def revoke_round_share(round_id: int, user_id: int) -> dict[str, Any]:
     round_obj = db.session.get(Round, round_id)
     db.session.delete(share)
     db.session.flush()
+    event = None
+    if round_obj:
+        event = _record_round_access_event(
+            round_obj,
+            "share_revoked",
+            actor_user_id=actor_user_id,
+            target_user_id=user_id,
+            role=removed.get("role"),
+        )
     if round_obj and round_obj.visibility == "shared" and round_obj.shares.count() == 0:
         round_obj.visibility = "private"
         round_obj.updated_at = datetime.utcnow()
@@ -994,7 +1053,27 @@ def revoke_round_share(round_id: int, user_id: int) -> dict[str, Any]:
     return {
         "revoked": True,
         "share": removed,
+        "access_event": _round_access_event_summary(event) if event else None,
         "round": _round_summary(round_obj) if round_obj else None,
+    }
+
+
+def list_round_access_events(round_id: int, limit: int = 50) -> dict[str, Any]:
+    """List recent ownership and sharing audit events for a round."""
+    round_obj = db.session.get(Round, round_id)
+    if not round_obj:
+        raise AutomationError(f"Round {round_id} was not found.")
+    normalized_limit = max(1, min(int(limit or 50), 200))
+    events = (
+        RoundAccessEvent.query.filter_by(round_id=round_id)
+        .order_by(RoundAccessEvent.created_at.desc(), RoundAccessEvent.id.desc())
+        .limit(normalized_limit)
+        .all()
+    )
+    return {
+        "round_id": round_id,
+        "count": len(events),
+        "events": [_round_access_event_summary(event) for event in events],
     }
 
 

--- a/musicround/services/automation.py
+++ b/musicround/services/automation.py
@@ -236,6 +236,15 @@ def _validate_round_access_actor(actor_user_id: int | None) -> int | None:
     return _find_user(actor_user_id).id
 
 
+def _validate_round_access_requester(round_obj: Round, requester_user_id: int | None) -> None:
+    if requester_user_id is None:
+        return
+    requester = _find_user(requester_user_id)
+    if requester.is_admin or round_obj.user_id == requester.id:
+        return
+    raise AutomationError("Only the round owner or an admin can view round access events.")
+
+
 def _round_summary(round_obj: Round) -> dict[str, Any]:
     ids = _round_song_ids(round_obj)
     ordered = _ordered_round_songs(round_obj)
@@ -1066,12 +1075,21 @@ def revoke_round_share(
     }
 
 
-def list_round_access_events(round_id: int, limit: int = 50) -> dict[str, Any]:
+def list_round_access_events(
+    round_id: int,
+    limit: int = 50,
+    requester_user_id: int | None = None,
+) -> dict[str, Any]:
     """List recent ownership and sharing audit events for a round."""
     round_obj = db.session.get(Round, round_id)
     if not round_obj:
         raise AutomationError(f"Round {round_id} was not found.")
-    normalized_limit = max(1, min(int(limit or 50), 200))
+    _validate_round_access_requester(round_obj, requester_user_id)
+    try:
+        requested_limit = int(limit or 50)
+    except (TypeError, ValueError) as exc:
+        raise AutomationError("limit must be an integer.") from exc
+    normalized_limit = max(1, min(requested_limit, 200))
     events = (
         RoundAccessEvent.query.filter_by(round_id=round_id)
         .order_by(RoundAccessEvent.created_at.desc(), RoundAccessEvent.id.desc())

--- a/musicround/templates/round_detail.html
+++ b/musicround/templates/round_detail.html
@@ -134,6 +134,36 @@
             </form>
             {% endif %}
         </div>
+        {% if can_manage_shares %}
+        <div class="mt-6 border-t border-gray-200 pt-4">
+            <h3 class="text-lg font-semibold text-navy-800 mb-3">Access History</h3>
+            {% if round_access_events %}
+            <div class="space-y-2">
+                {% for event in round_access_events %}
+                <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-2 text-sm border border-gray-200 rounded-md p-3">
+                    <div>
+                        <span class="font-semibold text-gray-900">{{ event.action|replace('_', ' ')|title }}</span>
+                        {% if event.role %}
+                        <span class="text-gray-500">as {{ event.role }}</span>
+                        {% endif %}
+                        {% if event.target_user %}
+                        <span class="text-gray-700">for {{ event.target_user.username }}</span>
+                        {% endif %}
+                    </div>
+                    <div class="text-gray-500">
+                        {% if event.actor %}
+                        by {{ event.actor.username }} ·
+                        {% endif %}
+                        {{ event.created_at.strftime('%Y-%m-%d %H:%M') if event.created_at else 'unknown time' }}
+                    </div>
+                </div>
+                {% endfor %}
+            </div>
+            {% else %}
+            <p class="text-sm text-gray-500">No sharing changes have been recorded yet.</p>
+            {% endif %}
+        </div>
+        {% endif %}
     </div>
 
     <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-8">

--- a/tests/test_automation_service.py
+++ b/tests/test_automation_service.py
@@ -510,6 +510,27 @@ class TestRoundAutomation:
             assert RoundAccessEvent.query.count() == 2
             assert db.session.get(Round, round_id).visibility == "private"
 
+    def test_share_round_rejects_invalid_actor_user_id(self, app):
+        with app.app_context():
+            owner = _create_user(username="owner", email="owner@example.test")
+            viewer = _create_user(username="viewer", email="viewer@example.test")
+            song = _create_song(title="Shared", artist="A")
+            round_id = automation.create_round(
+                name="Share Me",
+                round_type="manual",
+                song_ids=[song.id],
+                user_id=owner.id,
+            )["round"]["id"]
+
+            with pytest.raises(automation.AutomationError, match="User 9999"):
+                automation.share_round(round_id, viewer.id, actor_user_id=9999)
+
+            automation.share_round(round_id, viewer.id, actor_user_id=owner.id)
+            with pytest.raises(automation.AutomationError, match="User 9999"):
+                automation.revoke_round_share(round_id, viewer.id, actor_user_id=9999)
+
+            assert RoundAccessEvent.query.count() == 1
+
 
 class TestAssetInspection:
     """Tests for generated asset quality checks."""

--- a/tests/test_automation_service.py
+++ b/tests/test_automation_service.py
@@ -531,6 +531,31 @@ class TestRoundAutomation:
 
             assert RoundAccessEvent.query.count() == 1
 
+    def test_list_round_access_events_requires_owner_or_admin_requester(self, app):
+        with app.app_context():
+            owner = _create_user(username="owner", email="owner@example.test")
+            viewer = _create_user(username="viewer", email="viewer@example.test")
+            admin = _create_user(username="admin", email="admin@example.test")
+            admin.is_admin = True
+            song = _create_song(title="Shared", artist="A")
+            round_id = automation.create_round(
+                name="Share Me",
+                round_type="manual",
+                song_ids=[song.id],
+                user_id=owner.id,
+            )["round"]["id"]
+            automation.share_round(round_id, viewer.id, actor_user_id=owner.id)
+
+            owner_events = automation.list_round_access_events(round_id, requester_user_id=owner.id)
+            admin_events = automation.list_round_access_events(round_id, requester_user_id=admin.id)
+            with pytest.raises(automation.AutomationError, match="owner or an admin"):
+                automation.list_round_access_events(round_id, requester_user_id=viewer.id)
+            with pytest.raises(automation.AutomationError, match="limit must be an integer"):
+                automation.list_round_access_events(round_id, limit="many", requester_user_id=owner.id)
+
+            assert owner_events["count"] == 1
+            assert admin_events["count"] == 1
+
 
 class TestAssetInspection:
     """Tests for generated asset quality checks."""

--- a/tests/test_automation_service.py
+++ b/tests/test_automation_service.py
@@ -17,6 +17,7 @@ from musicround.models import (
     ImportJobRecord,
     PlannedQuizRound,
     Round,
+    RoundAccessEvent,
     RoundAudioScript,
     RoundExport,
     RoundShare,
@@ -486,16 +487,27 @@ class TestRoundAutomation:
                 user_id=owner.id,
             )["round"]["id"]
 
-            shared = automation.share_round(round_id, viewer.id, role="editor")
+            shared = automation.share_round(round_id, viewer.id, role="editor", actor_user_id=owner.id)
             listed = automation.list_round_shares(round_id)
-            revoked = automation.revoke_round_share(round_id, viewer.id)
+            events_after_share = automation.list_round_access_events(round_id)
+            revoked = automation.revoke_round_share(round_id, viewer.id, actor_user_id=owner.id)
+            events_after_revoke = automation.list_round_access_events(round_id)
 
             assert shared["created"] is True
             assert shared["share"]["role"] == "editor"
+            assert shared["access_event"]["action"] == "share_created"
+            assert shared["access_event"]["actor_user_id"] == owner.id
+            assert shared["access_event"]["target_user_id"] == viewer.id
             assert listed["count"] == 1
             assert listed["owner"]["id"] == owner.id
+            assert events_after_share["count"] == 1
+            assert events_after_share["events"][0]["action"] == "share_created"
             assert revoked["revoked"] is True
+            assert revoked["access_event"]["action"] == "share_revoked"
+            assert events_after_revoke["count"] == 2
+            assert events_after_revoke["events"][0]["action"] == "share_revoked"
             assert RoundShare.query.count() == 0
+            assert RoundAccessEvent.query.count() == 2
             assert db.session.get(Round, round_id).visibility == "private"
 
 
@@ -1613,6 +1625,7 @@ class TestDatastoreCrudAutomation:
 
             assert "song" in schema["object_types"]
             assert "round" in schema["object_types"]
+            assert "round_access_event" in schema["object_types"]
             assert "user" in schema["object_types"]
             song_schema = next(
                 item for item in schema["objects"] if item["object_type"] == "song"

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -265,6 +265,9 @@ def test_add_round_collaboration_and_audio_scripts_to_legacy_database(tmp_path):
     assert "idx_round_access_event_actor" in _index_names(
         database_path, "round_access_event"
     )
+    assert "idx_round_access_event_target" in _index_names(
+        database_path, "round_access_event"
+    )
     assert "idx_round_audio_script_round_status" in _index_names(
         database_path, "round_audio_script"
     )
@@ -280,6 +283,16 @@ def test_add_round_collaboration_and_audio_scripts_to_legacy_database(tmp_path):
     created_at_column = access_event_columns["created_at"]
     assert created_at_column[3] == 1
     assert created_at_column[4] == "CURRENT_TIMESTAMP"
+    access_event_foreign_keys = _foreign_keys(database_path, "round_access_event")
+    assert ("round", "round_id", "id", "CASCADE") in {
+        (row[2], row[3], row[4], row[6]) for row in access_event_foreign_keys
+    }
+    assert ("user", "actor_user_id", "id", "SET NULL") in {
+        (row[2], row[3], row[4], row[6]) for row in access_event_foreign_keys
+    }
+    assert ("user", "target_user_id", "id", "SET NULL") in {
+        (row[2], row[3], row[4], row[6]) for row in access_event_foreign_keys
+    }
     assert "user_id" in Round.__table__.columns.keys()
     assert RoundShare.__tablename__ == "round_share"
     assert RoundAccessEvent.__tablename__ == "round_access_event"

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -272,6 +272,14 @@ def test_add_round_collaboration_and_audio_scripts_to_legacy_database(tmp_path):
         database_path, "round_audio_script"
     )
     assert "cue_position" in _column_names(database_path, "round_audio_script")
+    with sqlite3.connect(database_path) as conn:
+        access_event_columns = {
+            column[1]: column
+            for column in conn.execute("PRAGMA table_info(round_access_event)")
+        }
+    created_at_column = access_event_columns["created_at"]
+    assert created_at_column[3] == 1
+    assert created_at_column[4] == "CURRENT_TIMESTAMP"
     assert "user_id" in Round.__table__.columns.keys()
     assert RoundShare.__tablename__ == "round_share"
     assert RoundAccessEvent.__tablename__ == "round_access_event"

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -9,6 +9,7 @@ from musicround.models import (
     ImportJobRecord,
     PlannedQuizRound,
     Round,
+    RoundAccessEvent,
     RoundAudioScript,
     RoundExport,
     RoundShare,
@@ -255,8 +256,15 @@ def test_add_round_collaboration_and_audio_scripts_to_legacy_database(tmp_path):
     assert {"user_id", "visibility"}.issubset(round_columns)
     assert "idx_round_owner_created" in _index_names(database_path, "round")
     assert "round_share" in _table_names(database_path)
+    assert "round_access_event" in _table_names(database_path)
     assert "round_audio_script" in _table_names(database_path)
     assert "idx_round_share_user" in _index_names(database_path, "round_share")
+    assert "idx_round_access_event_round_created" in _index_names(
+        database_path, "round_access_event"
+    )
+    assert "idx_round_access_event_actor" in _index_names(
+        database_path, "round_access_event"
+    )
     assert "idx_round_audio_script_round_status" in _index_names(
         database_path, "round_audio_script"
     )
@@ -266,6 +274,7 @@ def test_add_round_collaboration_and_audio_scripts_to_legacy_database(tmp_path):
     assert "cue_position" in _column_names(database_path, "round_audio_script")
     assert "user_id" in Round.__table__.columns.keys()
     assert RoundShare.__tablename__ == "round_share"
+    assert RoundAccessEvent.__tablename__ == "round_access_event"
     assert RoundAudioScript.__tablename__ == "round_audio_script"
     assert "cue_position" in RoundAudioScript.__table__.columns.keys()
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -282,6 +282,7 @@ class TestRoundCollaborationModels:
         assert round_.access_events.count() == 1
         assert round_.access_events.first().actor.id == owner.id
         assert round_.access_events.first().target_user.id == viewer.id
+        assert repr(event) == f"RoundAccessEvent(round_id={round_.id}, action='share_created')"
 
     def test_round_audio_script_creation(self, app):
         """Intro/replay/outro text can be stored before TTS generation."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,7 +3,7 @@ import pytest
 from datetime import datetime, timedelta
 from musicround.models import (
     db, User, Role, UserPreferences, Tag, SongTag, Song,
-    PlannedQuizRound, Round, RoundAudioScript, RoundExport, RoundShare, SystemSetting,
+    PlannedQuizRound, Round, RoundAccessEvent, RoundAudioScript, RoundExport, RoundShare, SystemSetting,
     ImportJobRecord,
 )
 
@@ -251,6 +251,37 @@ class TestRoundCollaborationModels:
 
         assert round_.shares.count() == 1
         assert viewer.shared_rounds.first().round_id == round_.id
+
+    def test_round_access_event_tracks_actor_and_target(self, app):
+        """Round sharing changes keep a persistent audit event."""
+        owner = User(username='auditowner', email='auditowner@example.com')
+        viewer = User(username='auditviewer', email='auditviewer@example.com')
+        db.session.add_all([owner, viewer])
+        db.session.commit()
+        round_ = Round(
+            name='Audited Round',
+            round_type='manual',
+            round_criteria_used='test',
+            songs='1',
+            owner=owner,
+            visibility='shared',
+        )
+        db.session.add(round_)
+        db.session.commit()
+
+        event = RoundAccessEvent(
+            round=round_,
+            actor=owner,
+            target_user=viewer,
+            action='share_created',
+            role='viewer',
+        )
+        db.session.add(event)
+        db.session.commit()
+
+        assert round_.access_events.count() == 1
+        assert round_.access_events.first().actor.id == owner.id
+        assert round_.access_events.first().target_user.id == viewer.id
 
     def test_round_audio_script_creation(self, app):
         """Intro/replay/outro text can be stored before TTS generation."""

--- a/tests/test_rounds_routes.py
+++ b/tests/test_rounds_routes.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from unittest.mock import patch, mock_open
 from flask import jsonify
 from pydub import AudioSegment
-from musicround.models import db, PlannedQuizRound, User, Song, Round, RoundAudioScript, RoundExport, RoundShare
+from musicround.models import db, PlannedQuizRound, User, Song, Round, RoundAccessEvent, RoundAudioScript, RoundExport, RoundShare
 from musicround.routes.rounds import ROUND_QUALITY_SESSION_REPORT_MAX_CHARS, _session_quality_report
 
 
@@ -529,9 +529,19 @@ class TestRoundDetailRoute:
         assert b'share_target_ui' in add_response.data
         assert b'share_target_ui@example.com' in add_response.data
         assert b'Editor' in add_response.data
+        assert b'Access History' in add_response.data
+        assert b'Share Created' in add_response.data
+        assert b'by share_owner_ui' in add_response.data
         with app.app_context():
             share = RoundShare.query.filter_by(round_id=round_id, user_id=target_id).one()
+            share_event = RoundAccessEvent.query.filter_by(
+                round_id=round_id,
+                target_user_id=target_id,
+                action='share_created',
+            ).one()
             assert share.role == 'editor'
+            assert share_event.actor_user_id == owner_id
+            assert share_event.role == 'editor'
             assert db.session.get(Round, round_id).visibility == 'shared'
 
         delete_response = client.post(
@@ -541,8 +551,16 @@ class TestRoundDetailRoute:
 
         assert delete_response.status_code == 200
         assert b'This round is not shared with other quizmasters.' in delete_response.data
+        assert b'Share Revoked' in delete_response.data
         with app.app_context():
             assert RoundShare.query.filter_by(round_id=round_id, user_id=target_id).count() == 0
+            revoke_event = RoundAccessEvent.query.filter_by(
+                round_id=round_id,
+                target_user_id=target_id,
+                action='share_revoked',
+            ).one()
+            assert revoke_event.actor_user_id == owner_id
+            assert revoke_event.role == 'editor'
             assert db.session.get(Round, round_id).visibility == 'private'
 
     def test_shared_editor_cannot_manage_round_shares(self, app, client):
@@ -571,6 +589,7 @@ class TestRoundDetailRoute:
 
         assert detail.status_code == 200
         assert b'id="round-share-form"' not in detail.data
+        assert b'Access History' not in detail.data
         assert b'share_admin_editor' in detail.data
         assert b'share_admin_editor@example.com' not in detail.data
         assert blocked.status_code == 403


### PR DESCRIPTION
## Summary
- add persistent round access audit events for share/update/revoke actions
- expose recent access events through MCP and the round detail page for owners/admins
- update migration, schema/MCP docs, backlog status, and focused tests

## Tests
- SECRET_KEY=test-secret-key-for-testing-only AUTOMATION_TOKEN=test-automation-token-for-testing .venv/bin/python -m pytest tests/test_models.py tests/test_automation_service.py tests/test_rounds_routes.py tests/test_migrations.py
- SECRET_KEY=test-secret-key-for-testing-only AUTOMATION_TOKEN=test-automation-token-for-testing .venv/bin/python -m pytest tests/test_automation_service.py::TestDatastoreCrudAutomation::test_datastore_schema_lists_mapped_models

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added access history for round sharing, showing recent ownership and permission changes in the round details page.
  * Added support for viewing recent sharing activity through the developer tooling.
  * Sharing and revoking access now capture the acting user for clearer collaboration tracking.

* **Bug Fixes**
  * Improved visibility into share changes by recording and displaying them consistently across the app and documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->