### PR TITLE
Add public round links and producer role policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   viewer/editor access from the round detail page.
 - Added persistent round-sharing audit events with MCP access for collaboration
   workflows.
+- Added token-based public read-only round links with owner/admin controls,
+  MCP helpers, and access-event audit entries.
 - Added a chart/festival seed-source registry with run history, Flask-Admin
   views, migrations, and MCP automation helpers.
 - Added a browser round-ops workflow with round calendar, catalog/fatigue analytics, quizmaster planning briefs, round review/approval state, package quality inspection, actionable replacement suggestions, and browser review of announcement and per-track hint script drafts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a browser text-playlist review workflow that blocks round creation
   until exactly eight pasted rows resolve to catalog songs.
 - Added browser round sharing controls for owners/admins to grant and revoke
-  viewer/editor access from the round detail page.
+  viewer/editor/producer access from the round detail page.
 - Added persistent round-sharing audit events with MCP access for collaboration
   workflows.
 - Added token-based public read-only round links with owner/admin controls,
   MCP helpers, and access-event audit entries.
+- Added producer sharing roles that can generate/export/send round assets
+  without granting owner-level sharing or delete rights.
 - Added a chart/festival seed-source registry with run history, Flask-Admin
   views, migrations, and MCP automation helpers.
 - Added a browser round-ops workflow with round calendar, catalog/fatigue analytics, quizmaster planning briefs, round review/approval state, package quality inspection, actionable replacement suggestions, and browser review of announcement and per-track hint script drafts.

--- a/docs/developer-guide/backlog-status.md
+++ b/docs/developer-guide/backlog-status.md
@@ -35,7 +35,7 @@ issue after verification or continue with the remaining follow-up.
 | #73 Add MCP tool to draft round intro, replay, and outro scripts | Ready to close | `draft_round_audio_scripts`, MCP docs, round detail actions | Verify one draft for a real round after deploy. |
 | #74 Store and review generated TTS scripts before audio assignment | Ready to close | `RoundAudioScript`, review routes, `generate_tts_from_script` | Verify approved script-to-audio assignment with configured TTS provider. |
 | #75 Add chart and festival seed source registry | Partial | `SeedSource`, `SeedSourceRun`, admin views, MCP registry/run tools | Scrapers/importers for individual chart/festival providers remain separate slices. |
-| #79 Add round ownership and sharing roles | Partial | `RoundShare`, `RoundAccessEvent`, owner filtering, edit checks, MCP share tools, browser share/revoke UI, tokenized public read-only links | Richer role policy remains open. |
+| #79 Add round ownership and sharing roles | Ready to close | `RoundShare`, `RoundAccessEvent`, owner filtering, viewer/editor/producer checks, MCP share tools, browser share/revoke UI, tokenized public read-only links | Verify browser and MCP roles after deploy. |
 | #126 Move production database configuration off SQLite `/data` | Operational / partial | Managed DB config, migration CLI, runbook, Compose managed-db profile | Live Kubernetes secret/config cutover and scheduled-email smoke remain. |
 | #12 Remove SQLite/RWO singleton | Operational / partial | Same as #126, plus app config hardening | Requires managed DB cutover, stateless replicas, and backup replacement. |
 | #17/#48/#49 Repair and clean broken round emails | Operational | Quality gate and repair tooling exist | Needs live QB/Gmail inspection and cleanup, not repo-only code. |
@@ -45,7 +45,5 @@ issue after verification or continue with the remaining follow-up.
 1. Close or comment the "ready to close" issues after a release smoke confirms
    the linked browser/MCP behavior.
 2. For #75, add first provider-specific source fetchers on top of the registry.
-3. For #79, add richer role policy around `RoundShare` and shared-round
-   operational actions.
-5. For #126/#12, continue with live deployment configuration only through the
+3. For #126/#12, continue with live deployment configuration only through the
    existing 1Password-backed secret flow and credential-safe Kubernetes checks.

--- a/docs/developer-guide/backlog-status.md
+++ b/docs/developer-guide/backlog-status.md
@@ -35,7 +35,7 @@ issue after verification or continue with the remaining follow-up.
 | #73 Add MCP tool to draft round intro, replay, and outro scripts | Ready to close | `draft_round_audio_scripts`, MCP docs, round detail actions | Verify one draft for a real round after deploy. |
 | #74 Store and review generated TTS scripts before audio assignment | Ready to close | `RoundAudioScript`, review routes, `generate_tts_from_script` | Verify approved script-to-audio assignment with configured TTS provider. |
 | #75 Add chart and festival seed source registry | Partial | `SeedSource`, `SeedSourceRun`, admin views, MCP registry/run tools | Scrapers/importers for individual chart/festival providers remain separate slices. |
-| #79 Add round ownership and sharing roles | Partial | `RoundShare`, `RoundAccessEvent`, owner filtering, edit checks, MCP share tools, browser share/revoke UI | Public links and richer roles remain open. |
+| #79 Add round ownership and sharing roles | Partial | `RoundShare`, `RoundAccessEvent`, owner filtering, edit checks, MCP share tools, browser share/revoke UI, tokenized public read-only links | Richer role policy remains open. |
 | #126 Move production database configuration off SQLite `/data` | Operational / partial | Managed DB config, migration CLI, runbook, Compose managed-db profile | Live Kubernetes secret/config cutover and scheduled-email smoke remain. |
 | #12 Remove SQLite/RWO singleton | Operational / partial | Same as #126, plus app config hardening | Requires managed DB cutover, stateless replicas, and backup replacement. |
 | #17/#48/#49 Repair and clean broken round emails | Operational | Quality gate and repair tooling exist | Needs live QB/Gmail inspection and cleanup, not repo-only code. |
@@ -45,7 +45,7 @@ issue after verification or continue with the remaining follow-up.
 1. Close or comment the "ready to close" issues after a release smoke confirms
    the linked browser/MCP behavior.
 2. For #75, add first provider-specific source fetchers on top of the registry.
-3. For #79, add optional public read-only links and richer role policy around
-   `RoundShare`.
+3. For #79, add richer role policy around `RoundShare` and shared-round
+   operational actions.
 5. For #126/#12, continue with live deployment configuration only through the
    existing 1Password-backed secret flow and credential-safe Kubernetes checks.

--- a/docs/developer-guide/database-schema.md
+++ b/docs/developer-guide/database-schema.md
@@ -225,7 +225,7 @@ The `RoundShare` table stores explicit round access grants.
 | id         | Integer     | Primary key                          |
 | round_id   | Integer     | Foreign key to Round                 |
 | user_id    | Integer     | Foreign key to shared user           |
-| role       | String(20)  | Share role (viewer, editor)          |
+| role       | String(20)  | Share role (viewer, editor, producer) |
 | created_at | DateTime    | When the share was created           |
 
 ### RoundAccessEvent

--- a/docs/developer-guide/database-schema.md
+++ b/docs/developer-guide/database-schema.md
@@ -202,6 +202,8 @@ The `Round` table stores music quiz rounds.
 | tag                   | String(50)   | Tag of the round (if applicable)                 |
 | user_id               | Integer      | Owning quizmaster, if assigned                   |
 | visibility            | String(20)   | Round visibility (private, shared, public)       |
+| public_token          | String(64)   | Token for read-only public link, when enabled    |
+| public_token_created_at | DateTime   | When the public token was created                |
 | created_at            | DateTime     | Creation timestamp                               |
 | updated_at            | DateTime     | Last update timestamp                            |
 | mp3_generated         | Boolean      | Flag indicating if MP3 has been generated        |
@@ -212,6 +214,7 @@ The `Round` table stores music quiz rounds.
 - `idx_round_created_at` supports recent-round lists.
 - `idx_round_generation_status` supports readiness and repair views.
 - `idx_round_owner_created` supports per-quizmaster round history.
+- `idx_round_public_token` supports token-based public round lookup.
 
 ### RoundShare
 

--- a/docs/developer-guide/mcp.md
+++ b/docs/developer-guide/mcp.md
@@ -51,7 +51,7 @@ The MCP server exposes these tools:
 | `compile_round` | Create a named round from explicit song IDs or selection criteria. |
 | `rename_round` | Set or clear a round name. |
 | `set_round_owner` | Assign or clear the quizmaster owner for a round. |
-| `share_round` | Share a round with another quizmaster as viewer or editor via system automation. |
+| `share_round` | Share a round with another quizmaster as viewer, editor, or producer via system automation. |
 | `list_round_shares` | List explicit share grants for a round. |
 | `revoke_round_share` | Remove a user's share grant from a round via system automation. |
 | `list_round_access_events` | List recent ownership and sharing audit events for a round; requires an owner/admin requester. |

--- a/docs/developer-guide/mcp.md
+++ b/docs/developer-guide/mcp.md
@@ -55,6 +55,9 @@ The MCP server exposes these tools:
 | `list_round_shares` | List explicit share grants for a round. |
 | `revoke_round_share` | Remove a user's share grant from a round via system automation. |
 | `list_round_access_events` | List recent ownership and sharing audit events for a round; requires an owner/admin requester. |
+| `enable_round_public_link` | Enable a token-based read-only public link for a round. |
+| `disable_round_public_link` | Disable a token-based read-only public link for a round. |
+| `get_public_round` | Fetch read-only round data for an active public round token. |
 | `register_seed_source` | Create or update a chart, festival, editorial, curated, or playlist seed source. |
 | `list_seed_sources` | List configured catalog seed sources for agent planning. |
 | `record_seed_source_run` | Record seed-source read/import attempts and outcomes. |

--- a/migrations/add_round_collaboration_and_audio_scripts.py
+++ b/migrations/add_round_collaboration_and_audio_scripts.py
@@ -23,14 +23,15 @@ def _index_exists(inspector, table_name, index_name):
     return any(index.get("name") == index_name for index in inspector.get_indexes(table_name))
 
 
-def _create_index(conn, inspector, table_name, index_name, columns):
+def _create_index(conn, inspector, table_name, index_name, columns, *, unique=False):
     if _index_exists(inspector, table_name, index_name):
         return False
     preparer = conn.dialect.identifier_preparer
     quoted_table = _quote(table_name, preparer)
     quoted_index = _quote(index_name, preparer)
     quoted_columns = ", ".join(_quote(column, preparer) for column in columns)
-    conn.execute(text(f"CREATE INDEX {quoted_index} ON {quoted_table} ({quoted_columns})"))
+    unique_sql = "UNIQUE " if unique else ""
+    conn.execute(text(f"CREATE {unique_sql}INDEX {quoted_index} ON {quoted_table} ({quoted_columns})"))
     return True
 
 
@@ -60,6 +61,12 @@ def run_migration():
                         "ADD COLUMN visibility VARCHAR(20) DEFAULT 'private' NOT NULL"
                     )
                 )
+                changes_made = True
+            if "public_token" not in round_columns:
+                conn.execute(text(f"ALTER TABLE {round_table} ADD COLUMN public_token VARCHAR(64)"))
+                changes_made = True
+            if "public_token_created_at" not in round_columns:
+                conn.execute(text(f"ALTER TABLE {round_table} ADD COLUMN public_token_created_at DATETIME"))
                 changes_made = True
 
             if not _table_exists(inspector, "round_share"):
@@ -166,6 +173,17 @@ def run_migration():
                 existing_columns = _columns(inspector, table_name)
                 if all(column in existing_columns for column in columns):
                     changes_made = _create_index(conn, inspector, table_name, index_name, columns) or changes_made
+
+            inspector = inspect(db.engine)
+            if _table_exists(inspector, "round") and "public_token" in _columns(inspector, "round"):
+                changes_made = _create_index(
+                    conn,
+                    inspector,
+                    "round",
+                    "idx_round_public_token",
+                    ["public_token"],
+                    unique=True,
+                ) or changes_made
 
             if changes_made:
                 conn.commit()

--- a/musicround/mcp_server.py
+++ b/musicround/mcp_server.py
@@ -344,6 +344,33 @@ def list_round_access_events(
 
 
 @mcp.tool()
+def enable_round_public_link(round_id: int) -> dict[str, Any]:
+    """Enable a token-based read-only public link for a round via system automation."""
+    return _with_app_context(
+        automation.enable_round_public_link,
+        round_id=round_id,
+    )
+
+
+@mcp.tool()
+def disable_round_public_link(round_id: int) -> dict[str, Any]:
+    """Disable a token-based read-only public link for a round via system automation."""
+    return _with_app_context(
+        automation.disable_round_public_link,
+        round_id=round_id,
+    )
+
+
+@mcp.tool()
+def get_public_round(public_token: str) -> dict[str, Any]:
+    """Fetch read-only round data for an active public round token."""
+    return _with_app_context(
+        automation.get_public_round,
+        public_token=public_token,
+    )
+
+
+@mcp.tool()
 def register_seed_source(
     name: str,
     source_type: str,

--- a/musicround/models.py
+++ b/musicround/models.py
@@ -265,6 +265,8 @@ class Round(db.Model):
     tag = db.Column(db.String(50))
     user_id = db.Column(db.Integer, db.ForeignKey('user.id', ondelete='SET NULL'), nullable=True)
     visibility = db.Column(db.String(20), default='private', nullable=False)
+    public_token = db.Column(db.String(64), unique=True, nullable=True)
+    public_token_created_at = db.Column(db.DateTime, nullable=True)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
     updated_at = db.Column(db.DateTime, onupdate=datetime.utcnow)
     mp3_generated = db.Column(db.Boolean, default=False)  # Track if MP3 has been generated
@@ -279,6 +281,7 @@ class Round(db.Model):
         db.Index('idx_round_created_at', 'created_at'),
         db.Index('idx_round_generation_status', 'mp3_generated', 'pdf_generated'),
         db.Index('idx_round_owner_created', 'user_id', 'created_at'),
+        db.Index('idx_round_public_token', 'public_token'),
         db.Index('idx_round_review_status', 'review_status', 'approved_at'),
     )
 

--- a/musicround/routes/rounds.py
+++ b/musicround/routes/rounds.py
@@ -15,7 +15,7 @@ from flask import Blueprint, session, redirect, request, render_template, url_fo
 from flask_login import current_user, login_required
 from sqlalchemy import or_
 from sqlalchemy.orm import contains_eager, joinedload
-from musicround.models import PlannedQuizRound, Round, RoundAccessEvent, RoundAudioScript, RoundExport, RoundShare, Song, User, db
+from musicround.models import PlannedQuizRound, Round, RoundAccessEvent, RoundAudioScript, RoundExport, RoundShare, Song, SystemSetting, User, db
 from pydub import AudioSegment
 from reportlab.lib.pagesizes import A4
 from reportlab.pdfgen import canvas
@@ -234,6 +234,16 @@ def _get_editable_round_or_404(round_id):
     if not _can_edit_round(round_obj):
         abort(403)
     return round_obj
+
+
+@rounds_bp.route('/public/<public_token>')
+def public_round(public_token):
+    """Render a token-based read-only public round view."""
+    try:
+        result = automation.get_public_round(public_token)
+    except AutomationError:
+        abort(404)
+    return render_template('public_round.html', round=result['round'])
 
 
 def _storage_failure_response(round_id, storage_health, status_code=503):
@@ -524,6 +534,7 @@ def round_detail(round_id):
             round_shares=round_shares,
             can_manage_shares=can_manage_shares,
             round_access_events=round_access_events,
+            public_rounds_enabled=SystemSetting.get('enable_public_rounds', 'false') == 'true',
         )
     else:
         return 'Round not found'
@@ -646,6 +657,29 @@ def delete_round_share(round_id, user_id):
         flash(str(exc), 'error')
     else:
         flash('Round share removed.', 'success')
+    return redirect(url_for('rounds.round_detail', round_id=round_id))
+
+
+@rounds_bp.route('/<int:round_id>/public-link', methods=['POST'])
+@login_required
+def update_public_round_link(round_id):
+    """Enable or disable a token-based public read-only link."""
+    rnd = _get_visible_round_or_404(round_id)
+    if not _can_manage_round_shares(rnd):
+        abort(403)
+
+    action = (request.form.get('action') or 'enable').strip().lower()
+    try:
+        if action == 'disable':
+            automation.disable_round_public_link(round_id, actor_user_id=current_user.id)
+            flash('Public round link disabled.', 'success')
+        elif action == 'enable':
+            automation.enable_round_public_link(round_id, actor_user_id=current_user.id)
+            flash('Public round link enabled.', 'success')
+        else:
+            flash('Unknown public link action.', 'error')
+    except AutomationError as exc:
+        flash(str(exc), 'error')
     return redirect(url_for('rounds.round_detail', round_id=round_id))
 
 

--- a/musicround/routes/rounds.py
+++ b/musicround/routes/rounds.py
@@ -42,6 +42,9 @@ ROUND_QUALITY_SESSION_REPORT_MAX_CHARS = 2000
 ROUND_MP3_STATUS_EXISTS = 'exists'
 ROUND_MP3_STATUS_GENERATED = 'generated'
 ROUND_MP3_STATUS_REGENERATED = 'regenerated'
+ROUND_SHARE_VALID_ROLES = {'viewer', 'editor', 'producer'}
+ROUND_SHARE_EDIT_ROLES = {'editor', 'producer'}
+ROUND_SHARE_PRODUCE_ROLES = {'producer'}
 
 
 def _int_arg(name, default=None, minimum=None, maximum=None):
@@ -205,15 +208,36 @@ def _can_view_round(round_obj):
     return round_obj.shares.filter_by(user_id=current_user.id).first() is not None
 
 
-def _can_edit_round(round_obj):
+def _can_operate_owned_round(round_obj):
     if current_user.is_admin:
         return True
     if round_obj.user_id is None:
         return True
-    if round_obj.user_id == current_user.id:
+    return round_obj.user_id == current_user.id
+
+
+def _current_user_round_share(round_obj):
+    if not current_user.is_authenticated:
+        return None
+    return round_obj.shares.filter_by(user_id=current_user.id).first()
+
+
+def _can_edit_round(round_obj):
+    if _can_operate_owned_round(round_obj):
         return True
-    share = round_obj.shares.filter_by(user_id=current_user.id).first()
-    return bool(share and share.role == 'editor')
+    share = _current_user_round_share(round_obj)
+    return bool(share and share.role in ROUND_SHARE_EDIT_ROLES)
+
+
+def _can_produce_round(round_obj):
+    if _can_operate_owned_round(round_obj):
+        return True
+    share = _current_user_round_share(round_obj)
+    return bool(share and share.role in ROUND_SHARE_PRODUCE_ROLES)
+
+
+def _can_delete_round(round_obj):
+    return _can_operate_owned_round(round_obj)
 
 
 def _can_manage_round_shares(round_obj):
@@ -232,6 +256,20 @@ def _get_visible_round_or_404(round_id):
 def _get_editable_round_or_404(round_id):
     round_obj = _get_visible_round_or_404(round_id)
     if not _can_edit_round(round_obj):
+        abort(403)
+    return round_obj
+
+
+def _get_producible_round_or_404(round_id):
+    round_obj = _get_visible_round_or_404(round_id)
+    if not _can_produce_round(round_obj):
+        abort(403)
+    return round_obj
+
+
+def _get_deletable_round_or_404(round_id):
+    round_obj = _get_visible_round_or_404(round_id)
+    if not _can_delete_round(round_obj):
         abort(403)
     return round_obj
 
@@ -617,8 +655,8 @@ def add_round_share(round_id):
 
     user_query = (request.form.get('user_query') or '').strip()
     role = (request.form.get('role') or 'viewer').strip().lower()
-    if role not in {'viewer', 'editor'}:
-        flash('Share role must be viewer or editor.', 'error')
+    if role not in ROUND_SHARE_VALID_ROLES:
+        flash('Share role must be viewer, editor, or producer.', 'error')
         return redirect(url_for('rounds.round_detail', round_id=round_id))
     if not user_query:
         flash('Enter a username or email address to share with.', 'error')
@@ -872,7 +910,7 @@ def round_mp3(round_id):
         if not current_user.is_authenticated:
             return jsonify({'success': False, 'error': 'Authentication required'}), 401
 
-    round = _get_editable_round_or_404(round_id)
+    round = _get_producible_round_or_404(round_id)
     song_ids = round.song_id_list
     if not song_ids:
         error_msg = 'Round contains no songs. Please add songs before generating an MP3.'
@@ -1263,9 +1301,7 @@ def generate_pdf(round_id):
 @login_required
 def round_pdf(round_id):
     """Generate a PDF file for a round"""
-    rnd = db.session.get(Round, round_id)
-    if not rnd:
-        return jsonify({'success': False, 'error': 'Round not found'})
+    rnd = _get_producible_round_or_404(round_id)
     if not rnd.song_id_list:
         return jsonify({
             'success': False,
@@ -1341,7 +1377,7 @@ def send_email(round_id):
             return jsonify({'error': 'Authentication required'}), 401
     
     # Check if the round exists
-    rnd = _get_editable_round_or_404(round_id)
+    rnd = _get_producible_round_or_404(round_id)
 
     storage = check_round_artifact_storage(include_mp3=True, include_pdf=True)
     if not storage['ok']:
@@ -1481,7 +1517,7 @@ def send_email(round_id):
 @login_required
 def delete_round(round_id):
     """Delete a round and its associated files"""
-    rnd = _get_editable_round_or_404(round_id)
+    rnd = _get_deletable_round_or_404(round_id)
     
     try:
         # Delete associated MP3 file if it exists
@@ -1514,7 +1550,7 @@ def export_to_dropbox(round_id):
     Export a round to the user's Dropbox account, including metadata and optionally MP3 files
     """
     current_app.logger.info(f"Starting Dropbox export for round ID {round_id} by user {current_user.username}")
-    round_obj = _get_visible_round_or_404(round_id)
+    round_obj = _get_producible_round_or_404(round_id)
     
     # Properly parse boolean parameters from form data
     include_mp3s = request.form.get('include_mp3s', 'true').lower() == 'true'

--- a/musicround/services/automation.py
+++ b/musicround/services/automation.py
@@ -6,6 +6,7 @@ import os
 import re
 import csv
 import math
+import secrets
 import tempfile
 from datetime import datetime, timedelta, timezone
 from typing import Any, Iterable
@@ -46,6 +47,7 @@ from musicround.models import (
     SeedSource,
     SeedSourceRun,
     Song,
+    SystemSetting,
     Tag,
     User,
 )
@@ -245,6 +247,27 @@ def _validate_round_access_requester(round_obj: Round, requester_user_id: int | 
     raise AutomationError("Only the round owner or an admin can view round access events.")
 
 
+def _validate_round_manager(round_obj: Round, actor_user_id: int | None) -> int | None:
+    actor_id = _validate_round_access_actor(actor_user_id)
+    if actor_id is None:
+        return None
+    actor = db.session.get(User, actor_id)
+    if actor and (actor.is_admin or round_obj.user_id == actor.id):
+        return actor.id
+    raise AutomationError("Only the round owner or an admin can manage public links.")
+
+
+def _public_round_links_enabled() -> bool:
+    return SystemSetting.get("enable_public_rounds", "false") == "true"
+
+
+def _new_public_round_token() -> str:
+    while True:
+        token = secrets.token_urlsafe(24)
+        if not Round.query.filter_by(public_token=token).first():
+            return token
+
+
 def _round_summary(round_obj: Round) -> dict[str, Any]:
     ids = _round_song_ids(round_obj)
     ordered = _ordered_round_songs(round_obj)
@@ -254,6 +277,8 @@ def _round_summary(round_obj: Round) -> dict[str, Any]:
         "owner_user_id": round_obj.user_id,
         "owner": _user_summary(round_obj.owner),
         "visibility": round_obj.visibility,
+        "public_link_enabled": bool(round_obj.public_token),
+        "public_token_created_at": _datetime_payload(round_obj.public_token_created_at),
         "round_type": round_obj.round_type,
         "criteria": round_obj.round_criteria_used,
         "song_ids": ids,
@@ -264,6 +289,19 @@ def _round_summary(round_obj: Round) -> dict[str, Any]:
         "last_generated_at": (
             round_obj.last_generated_at.isoformat() if round_obj.last_generated_at else None
         ),
+    }
+
+
+def _public_round_summary(round_obj: Round) -> dict[str, Any]:
+    return {
+        "id": round_obj.id,
+        "name": round_obj.name,
+        "round_type": round_obj.round_type,
+        "criteria": round_obj.round_criteria_used,
+        "created_at": _datetime_payload(round_obj.created_at),
+        "song_count": len(_round_song_ids(round_obj)),
+        "songs": [_song_summary(song) for song in _ordered_round_songs(round_obj)],
+        "owner": _user_summary(round_obj.owner),
     }
 
 
@@ -1101,6 +1139,75 @@ def list_round_access_events(
         "count": len(events),
         "events": [_round_access_event_summary(event) for event in events],
     }
+
+
+def enable_round_public_link(
+    round_id: int,
+    actor_user_id: int | None = None,
+) -> dict[str, Any]:
+    """Enable a token-based read-only public link for a round."""
+    if not _public_round_links_enabled():
+        raise AutomationError("Public round links are disabled in system settings.")
+    round_obj = db.session.get(Round, round_id)
+    if not round_obj:
+        raise AutomationError(f"Round {round_id} was not found.")
+    actor_id = _validate_round_manager(round_obj, actor_user_id)
+    created = not bool(round_obj.public_token)
+    if not round_obj.public_token:
+        round_obj.public_token = _new_public_round_token()
+        round_obj.public_token_created_at = datetime.utcnow()
+    round_obj.updated_at = datetime.utcnow()
+    event = _record_round_access_event(
+        round_obj,
+        "public_link_enabled" if created else "public_link_refreshed",
+        actor_user_id=actor_id,
+    )
+    db.session.commit()
+    return {
+        "created": created,
+        "public_token": round_obj.public_token,
+        "public_url_path": f"/rounds/public/{round_obj.public_token}",
+        "public_token_created_at": _datetime_payload(round_obj.public_token_created_at),
+        "access_event": _round_access_event_summary(event),
+        "round": _round_summary(round_obj),
+    }
+
+
+def disable_round_public_link(
+    round_id: int,
+    actor_user_id: int | None = None,
+) -> dict[str, Any]:
+    """Disable a token-based read-only public link for a round."""
+    round_obj = db.session.get(Round, round_id)
+    if not round_obj:
+        raise AutomationError(f"Round {round_id} was not found.")
+    actor_id = _validate_round_manager(round_obj, actor_user_id)
+    had_public_link = bool(round_obj.public_token)
+    round_obj.public_token = None
+    round_obj.public_token_created_at = None
+    round_obj.updated_at = datetime.utcnow()
+    event = _record_round_access_event(
+        round_obj,
+        "public_link_disabled",
+        actor_user_id=actor_id,
+    )
+    db.session.commit()
+    return {
+        "disabled": had_public_link,
+        "access_event": _round_access_event_summary(event),
+        "round": _round_summary(round_obj),
+    }
+
+
+def get_public_round(public_token: str) -> dict[str, Any]:
+    """Return read-only round data for an active public token."""
+    token = (public_token or "").strip()
+    if not token:
+        raise AutomationError("public_token is required.")
+    round_obj = Round.query.filter_by(public_token=token).first()
+    if not round_obj:
+        raise AutomationError("Public round link was not found.")
+    return {"round": _public_round_summary(round_obj)}
 
 
 def register_seed_source(

--- a/musicround/services/automation.py
+++ b/musicround/services/automation.py
@@ -68,6 +68,7 @@ AUTOMATION_MP3_GENERATION_ERROR = "MP3 generation failed. Check the server logs.
 AUTOMATION_SCHEDULED_EMAIL_ERROR = "Scheduled round email failed. Check the server logs."
 DEFAULT_MP3_DURATION_TOLERANCE_SECONDS = 30.0
 MIN_MP3_DURATION_MISMATCH_BLOCK_SECONDS = 40.0
+ROUND_SHARE_ROLES = {"viewer", "editor", "producer"}
 MP3_DURATION_MISSING_SLOT_FACTOR = 0.75
 
 
@@ -1028,8 +1029,8 @@ def share_round(
     actor_user_id: int | None = None,
 ) -> dict[str, Any]:
     """Grant a user access to a round for future collaboration workflows."""
-    if role not in {"viewer", "editor"}:
-        raise AutomationError("role must be viewer or editor.")
+    if role not in ROUND_SHARE_ROLES:
+        raise AutomationError("role must be viewer, editor, or producer.")
 
     round_obj = db.session.get(Round, round_id)
     if not round_obj:

--- a/musicround/templates/public_round.html
+++ b/musicround/templates/public_round.html
@@ -1,0 +1,47 @@
+{% extends 'base.html' %}
+
+{% block title %}{{ round.name or 'Public Music Round' }} - Quizzical Beats{% endblock %}
+
+{% block content %}
+<div class="max-w-5xl mx-auto px-4 py-8">
+    <div class="bg-white shadow-md rounded-lg p-6 mb-6">
+        <div class="flex flex-col md:flex-row md:items-start md:justify-between gap-4">
+            <div>
+                <h1 class="text-3xl font-bold text-navy-800 font-montserrat mb-2">{{ round.name or 'Music Round' }}</h1>
+                <p class="text-gray-700">
+                    <span class="font-semibold text-teal-700">Type:</span> {{ round.round_type }}
+                    <span class="mx-2 text-gray-300">|</span>
+                    <span class="font-semibold text-teal-700">Songs:</span> {{ round.song_count }}
+                </p>
+                <p class="text-gray-700 mt-1"><span class="font-semibold text-teal-700">Criteria:</span> {{ round.criteria }}</p>
+                {% if round.owner %}
+                <p class="text-sm text-gray-500 mt-2">Shared by {{ round.owner.username }}</p>
+                {% endif %}
+            </div>
+            <span class="inline-flex items-center px-3 py-1 rounded-full bg-teal-100 text-teal-800 text-sm font-semibold">
+                Read-only
+            </span>
+        </div>
+    </div>
+
+    <div class="bg-white shadow-md rounded-lg overflow-hidden">
+        <div class="px-6 py-4 border-b border-gray-200">
+            <h2 class="text-xl font-bold text-navy-800 font-montserrat">Round Songs</h2>
+        </div>
+        <div class="divide-y divide-gray-200">
+            {% for song in round.songs %}
+            <div class="px-6 py-4 flex flex-col md:flex-row md:items-center md:justify-between gap-2">
+                <div>
+                    <div class="font-semibold text-gray-900">{{ loop.index }}. {{ song.title }}</div>
+                    <div class="text-sm text-gray-600">{{ song.artist }}</div>
+                </div>
+                <div class="text-sm text-gray-500">
+                    {% if song.year %}{{ song.year }}{% endif %}
+                    {% if song.genre %}{% if song.year %} · {% endif %}{{ song.genre }}{% endif %}
+                </div>
+            </div>
+            {% endfor %}
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/musicround/templates/round_detail.html
+++ b/musicround/templates/round_detail.html
@@ -83,7 +83,7 @@
         <div class="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-6">
             <div class="flex-1">
                 <h2 class="text-2xl font-bold text-navy-800 font-montserrat mb-2">Sharing</h2>
-                <p class="text-sm text-gray-600 mb-4">Give another quizmaster read-only or edit access to this round.</p>
+                <p class="text-sm text-gray-600 mb-4">Give another quizmaster read-only, edit, or production access to this round.</p>
                 {% if round_shares %}
                 <div class="space-y-2">
                     {% for share in round_shares %}
@@ -95,7 +95,7 @@
                             {% endif %}
                         </div>
                         <div class="flex items-center gap-3">
-                            <span class="px-2 py-1 text-xs font-semibold rounded-full {% if share.role == 'editor' %}bg-blue-100 text-blue-800{% else %}bg-gray-100 text-gray-800{% endif %}">
+                            <span class="px-2 py-1 text-xs font-semibold rounded-full {% if share.role == 'producer' %}bg-purple-100 text-purple-800{% elif share.role == 'editor' %}bg-blue-100 text-blue-800{% else %}bg-gray-100 text-gray-800{% endif %}">
                                 {{ share.role|capitalize }}
                             </span>
                             {% if can_manage_shares %}
@@ -126,6 +126,7 @@
                     <select id="share_role" name="role" class="px-3 py-2 border border-gray-300 rounded-md w-full">
                         <option value="viewer">Viewer</option>
                         <option value="editor">Editor</option>
+                        <option value="producer">Producer</option>
                     </select>
                 </div>
                 <button type="submit" class="w-full bg-teal-500 hover:bg-teal-600 text-white py-2 px-4 rounded transition-colors font-semibold">

--- a/musicround/templates/round_detail.html
+++ b/musicround/templates/round_detail.html
@@ -136,6 +136,37 @@
         </div>
         {% if can_manage_shares %}
         <div class="mt-6 border-t border-gray-200 pt-4">
+            <h3 class="text-lg font-semibold text-navy-800 mb-3">Public Read-only Link</h3>
+            {% if public_rounds_enabled %}
+                {% if round.public_token %}
+                <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-3">
+                    <a href="{{ url_for('rounds.public_round', public_token=round.public_token) }}" target="_blank" class="text-sm text-blue-600 hover:underline break-all">
+                        {{ url_for('rounds.public_round', public_token=round.public_token, _external=True) }}
+                    </a>
+                    <form method="POST" action="{{ url_for('rounds.update_public_round_link', round_id=round.id) }}">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+                        <input type="hidden" name="action" value="disable"/>
+                        <button type="submit" class="inline-flex items-center px-3 py-2 bg-gray-700 hover:bg-gray-800 text-white rounded-md text-sm font-semibold">
+                            <i class="fas fa-link-slash mr-2"></i>Disable Link
+                        </button>
+                    </form>
+                </div>
+                {% else %}
+                <form method="POST" action="{{ url_for('rounds.update_public_round_link', round_id=round.id) }}">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+                    <input type="hidden" name="action" value="enable"/>
+                    <button type="submit" class="inline-flex items-center px-3 py-2 bg-teal-500 hover:bg-teal-600 text-white rounded-md text-sm font-semibold">
+                        <i class="fas fa-link mr-2"></i>Create Public Link
+                    </button>
+                </form>
+                {% endif %}
+            {% else %}
+            <p class="text-sm text-gray-500">Public round links are disabled by an admin setting.</p>
+            {% endif %}
+        </div>
+        {% endif %}
+        {% if can_manage_shares %}
+        <div class="mt-6 border-t border-gray-200 pt-4">
             <h3 class="text-lg font-semibold text-navy-800 mb-3">Access History</h3>
             {% if round_access_events %}
             <div class="space-y-2">

--- a/tests/test_automation_service.py
+++ b/tests/test_automation_service.py
@@ -25,6 +25,7 @@ from musicround.models import (
     SeedSourceRun,
     Song,
     SongTag,
+    SystemSetting,
     Tag,
     User,
     UserPreferences,
@@ -555,6 +556,52 @@ class TestRoundAutomation:
 
             assert owner_events["count"] == 1
             assert admin_events["count"] == 1
+
+    def test_round_public_link_lifecycle_requires_enabled_setting_and_manager(self, app):
+        with app.app_context():
+            owner = _create_user(username="owner", email="owner@example.test")
+            viewer = _create_user(username="viewer", email="viewer@example.test")
+            admin = _create_user(username="admin", email="admin@example.test")
+            admin.is_admin = True
+            song = _create_song(title="Public Song", artist="Artist", genre="Pop", year=1999)
+            round_id = automation.create_round(
+                name="Public Link Round",
+                round_type="manual",
+                song_ids=[song.id],
+                user_id=owner.id,
+            )["round"]["id"]
+
+            with pytest.raises(automation.AutomationError, match="disabled"):
+                automation.enable_round_public_link(round_id, actor_user_id=owner.id)
+
+            SystemSetting.set("enable_public_rounds", "true")
+            with pytest.raises(automation.AutomationError, match="owner or an admin"):
+                automation.enable_round_public_link(round_id, actor_user_id=viewer.id)
+
+            enabled = automation.enable_round_public_link(round_id, actor_user_id=owner.id)
+            public = automation.get_public_round(enabled["public_token"])
+            refreshed = automation.enable_round_public_link(round_id, actor_user_id=admin.id)
+            disabled = automation.disable_round_public_link(round_id, actor_user_id=owner.id)
+
+            assert enabled["created"] is True
+            assert enabled["public_url_path"].startswith("/rounds/public/")
+            assert enabled["round"]["public_link_enabled"] is True
+            assert public["round"]["name"] == "Public Link Round"
+            assert public["round"]["songs"][0]["title"] == "Public Song"
+            assert refreshed["created"] is False
+            assert refreshed["public_token"] == enabled["public_token"]
+            assert refreshed["access_event"]["action"] == "public_link_refreshed"
+            assert disabled["disabled"] is True
+            assert disabled["round"]["public_link_enabled"] is False
+            with pytest.raises(automation.AutomationError, match="not found"):
+                automation.get_public_round(enabled["public_token"])
+
+            actions = [event.action for event in RoundAccessEvent.query.order_by(RoundAccessEvent.id).all()]
+            assert actions == [
+                "public_link_enabled",
+                "public_link_refreshed",
+                "public_link_disabled",
+            ]
 
 
 class TestAssetInspection:

--- a/tests/test_automation_service.py
+++ b/tests/test_automation_service.py
@@ -511,6 +511,13 @@ class TestRoundAutomation:
             assert RoundAccessEvent.query.count() == 2
             assert db.session.get(Round, round_id).visibility == "private"
 
+            producer_share = automation.share_round(round_id, viewer.id, role="producer", actor_user_id=owner.id)
+
+            assert producer_share["created"] is True
+            assert producer_share["share"]["role"] == "producer"
+            assert RoundAccessEvent.query.count() == 3
+            assert db.session.get(Round, round_id).visibility == "shared"
+
     def test_share_round_rejects_invalid_actor_user_id(self, app):
         with app.app_context():
             owner = _create_user(username="owner", email="owner@example.test")

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -253,8 +253,9 @@ def test_add_round_collaboration_and_audio_scripts_to_legacy_database(tmp_path):
         assert add_round_collaboration_and_audio_scripts.run_migration() is None
 
     round_columns = set(_column_names(database_path, "round"))
-    assert {"user_id", "visibility"}.issubset(round_columns)
+    assert {"user_id", "visibility", "public_token", "public_token_created_at"}.issubset(round_columns)
     assert "idx_round_owner_created" in _index_names(database_path, "round")
+    assert "idx_round_public_token" in _index_names(database_path, "round")
     assert "round_share" in _table_names(database_path)
     assert "round_access_event" in _table_names(database_path)
     assert "round_audio_script" in _table_names(database_path)
@@ -294,6 +295,7 @@ def test_add_round_collaboration_and_audio_scripts_to_legacy_database(tmp_path):
         (row[2], row[3], row[4], row[6]) for row in access_event_foreign_keys
     }
     assert "user_id" in Round.__table__.columns.keys()
+    assert "public_token" in Round.__table__.columns.keys()
     assert RoundShare.__tablename__ == "round_share"
     assert RoundAccessEvent.__tablename__ == "round_access_event"
     assert RoundAudioScript.__tablename__ == "round_audio_script"

--- a/tests/test_rounds_routes.py
+++ b/tests/test_rounds_routes.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from unittest.mock import patch, mock_open
 from flask import jsonify
 from pydub import AudioSegment
-from musicround.models import db, PlannedQuizRound, User, Song, Round, RoundAccessEvent, RoundAudioScript, RoundExport, RoundShare
+from musicround.models import db, PlannedQuizRound, User, Song, Round, RoundAccessEvent, RoundAudioScript, RoundExport, RoundShare, SystemSetting
 from musicround.routes.rounds import ROUND_QUALITY_SESSION_REPORT_MAX_CHARS, _session_quality_report
 
 
@@ -593,6 +593,93 @@ class TestRoundDetailRoute:
         assert b'share_admin_editor' in detail.data
         assert b'share_admin_editor@example.com' not in detail.data
         assert blocked.status_code == 403
+
+    def test_round_owner_can_enable_and_disable_public_readonly_link(self, app, client):
+        """Owners can publish and revoke a token-based read-only round link."""
+        _login(app, client, username='public_owner', email='public_owner@example.com')
+        song_id = _create_song(app, title='Public Route Song', artist='Public Artist')
+        owner_id = _user_id(app, 'public_owner')
+        round_id = _create_round(app, [song_id], name='Public Route Round')
+        with app.app_context():
+            SystemSetting.set('enable_public_rounds', 'true')
+            round_ = db.session.get(Round, round_id)
+            round_.user_id = owner_id
+            round_.visibility = 'private'
+            db.session.commit()
+
+        enable_response = client.post(
+            f'/rounds/{round_id}/public-link',
+            data={'action': 'enable'},
+            follow_redirects=True,
+        )
+
+        assert enable_response.status_code == 200
+        assert b'Public round link enabled.' in enable_response.data
+        assert b'Public Read-only Link' in enable_response.data
+        assert b'Disable Link' in enable_response.data
+        with app.app_context():
+            public_token = db.session.get(Round, round_id).public_token
+            assert public_token
+            assert RoundAccessEvent.query.filter_by(
+                round_id=round_id,
+                action='public_link_enabled',
+                actor_user_id=owner_id,
+            ).count() == 1
+
+        client.get('/users/logout')
+        public_response = client.get(f'/rounds/public/{public_token}')
+
+        assert public_response.status_code == 200
+        assert b'Public Route Round' in public_response.data
+        assert b'Public Route Song' in public_response.data
+        assert b'Read-only' in public_response.data
+        assert b'Delete Quiz' not in public_response.data
+
+        _login(app, client, username='public_owner', email='public_owner@example.com')
+        disable_response = client.post(
+            f'/rounds/{round_id}/public-link',
+            data={'action': 'disable'},
+            follow_redirects=True,
+        )
+        disabled_public_response = client.get(f'/rounds/public/{public_token}')
+
+        assert disable_response.status_code == 200
+        assert b'Public round link disabled.' in disable_response.data
+        assert disabled_public_response.status_code == 404
+
+    def test_public_round_link_honors_admin_setting_and_permissions(self, app, client):
+        """Public link management should require both the system flag and ownership."""
+        _login(app, client, username='public_owner_two', email='public_owner_two@example.com')
+        _login(app, client, username='public_other', email='public_other@example.com')
+        song_id = _create_song(app, title='Public Disabled Song')
+        owner_id = _user_id(app, 'public_owner_two')
+        _login(app, client, username='public_owner_two', email='public_owner_two@example.com')
+        round_id = _create_round(app, [song_id], name='Public Disabled Round')
+        with app.app_context():
+            round_ = db.session.get(Round, round_id)
+            round_.user_id = owner_id
+            db.session.commit()
+
+        disabled_response = client.post(
+            f'/rounds/{round_id}/public-link',
+            data={'action': 'enable'},
+            follow_redirects=True,
+        )
+
+        assert disabled_response.status_code == 200
+        assert b'Public round links are disabled' in disabled_response.data
+
+        with app.app_context():
+            SystemSetting.set('enable_public_rounds', 'true')
+        client.get('/users/logout')
+        _login(app, client, username='public_other', email='public_other@example.com')
+
+        forbidden_response = client.post(
+            f'/rounds/{round_id}/public-link',
+            data={'action': 'enable'},
+        )
+
+        assert forbidden_response.status_code == 404
 
     def test_update_round_review_marks_approval(self, app, client):
         """Review route should persist approved state and notes."""

--- a/tests/test_rounds_routes.py
+++ b/tests/test_rounds_routes.py
@@ -504,6 +504,117 @@ class TestRoundDetailRoute:
         with app.app_context():
             assert db.session.get(Round, round_id).name == 'Editor Updated Round'
 
+    def test_shared_editor_cannot_produce_assets_or_delete_round(self, app, client):
+        """Editor shares should not grant production, delivery, export, or delete rights."""
+        _login(app, client, username='producer_block_owner', email='producer_block_owner@example.com')
+        _login(app, client, username='producer_block_editor', email='producer_block_editor@example.com')
+        song_id = _create_song(app, title='Editor Block Song')
+        owner_id = _user_id(app, 'producer_block_owner')
+        editor_id = _user_id(app, 'producer_block_editor')
+        client.get('/users/logout')
+        _login(app, client, username='producer_block_editor', email='producer_block_editor@example.com')
+        round_id = _create_round(app, [song_id], name='Editor Production Block Round')
+        with app.app_context():
+            round_ = db.session.get(Round, round_id)
+            round_.user_id = owner_id
+            round_.visibility = 'shared'
+            db.session.add(RoundShare(round_id=round_id, user_id=editor_id, role='editor'))
+            db.session.commit()
+
+        update = client.post(
+            f'/rounds/{round_id}/update-name',
+            data={'round_name': 'Editor Still Can Edit'},
+        )
+        mp3 = client.post(
+            f'/rounds/round/{round_id}/mp3',
+            headers={'X-Requested-With': 'XMLHttpRequest'},
+        )
+        pdf = client.post(
+            f'/rounds/{round_id}/pdf',
+            headers={'X-Requested-With': 'XMLHttpRequest'},
+        )
+        mail = client.post(
+            f'/rounds/{round_id}/mail',
+            headers={'X-Requested-With': 'XMLHttpRequest'},
+        )
+        dropbox = client.post(f'/rounds/{round_id}/export-to-dropbox')
+        delete = client.post(f'/rounds/{round_id}/delete')
+
+        assert update.status_code == 302
+        assert mp3.status_code == 403
+        assert pdf.status_code == 403
+        assert mail.status_code == 403
+        assert dropbox.status_code == 403
+        assert delete.status_code == 403
+        with app.app_context():
+            assert db.session.get(Round, round_id).name == 'Editor Still Can Edit'
+
+    def test_shared_producer_can_generate_pdf_but_not_manage_or_delete(self, app, client):
+        """Producer shares can create artifacts without owner-level administration."""
+        _login(app, client, username='producer_owner', email='producer_owner@example.com')
+        _login(app, client, username='producer_user', email='producer_user@example.com')
+        _login(app, client, username='producer_target', email='producer_target@example.com')
+        song_id = _create_song(app, title='Producer Song')
+        owner_id = _user_id(app, 'producer_owner')
+        producer_id = _user_id(app, 'producer_user')
+        client.get('/users/logout')
+        _login(app, client, username='producer_user', email='producer_user@example.com')
+        round_id = _create_round(app, [song_id], name='Producer Shared Round')
+        with app.app_context():
+            round_ = db.session.get(Round, round_id)
+            round_.user_id = owner_id
+            round_.visibility = 'shared'
+            db.session.add(RoundShare(round_id=round_id, user_id=producer_id, role='producer'))
+            db.session.commit()
+
+        update = client.post(
+            f'/rounds/{round_id}/update-name',
+            data={'round_name': 'Producer Updated Round'},
+        )
+        with patch('musicround.routes.rounds.generate_pdf', return_value=b'%PDF-1.4 test'):
+            pdf = client.post(
+                f'/rounds/{round_id}/pdf',
+                headers={'X-Requested-With': 'XMLHttpRequest'},
+            )
+        share = client.post(
+            f'/rounds/{round_id}/shares',
+            data={'user_query': 'producer_target', 'role': 'viewer'},
+        )
+        delete = client.post(f'/rounds/{round_id}/delete')
+
+        assert update.status_code == 302
+        assert pdf.status_code == 200
+        assert pdf.get_json()['success'] is True
+        assert share.status_code == 403
+        assert delete.status_code == 403
+        with app.app_context():
+            assert db.session.get(Round, round_id).name == 'Producer Updated Round'
+            assert db.session.get(Round, round_id).pdf_generated is True
+
+    def test_private_round_pdf_generation_requires_visibility(self, app, client):
+        """A logged-in user should not generate PDFs for another user's private round."""
+        _login(app, client, username='private_pdf_owner', email='private_pdf_owner@example.com')
+        _login(app, client, username='private_pdf_other', email='private_pdf_other@example.com')
+        song_id = _create_song(app, title='Private PDF Song')
+        owner_id = _user_id(app, 'private_pdf_owner')
+        client.get('/users/logout')
+        _login(app, client, username='private_pdf_owner', email='private_pdf_owner@example.com')
+        round_id = _create_round(app, [song_id], name='Private PDF Round')
+        with app.app_context():
+            round_ = db.session.get(Round, round_id)
+            round_.user_id = owner_id
+            round_.visibility = 'private'
+            db.session.commit()
+
+        client.get('/users/logout')
+        _login(app, client, username='private_pdf_other', email='private_pdf_other@example.com')
+        response = client.post(
+            f'/rounds/{round_id}/pdf',
+            headers={'X-Requested-With': 'XMLHttpRequest'},
+        )
+
+        assert response.status_code == 404
+
     def test_round_owner_can_share_and_revoke_from_detail(self, app, client):
         """Owners should be able to manage explicit round shares in the browser."""
         _login(app, client, username='share_owner_ui', email='share_owner_ui@example.com')


### PR DESCRIPTION
## Summary
- add token-based public read-only round links for owner/admin controlled sharing
- add a producer share role for asset generation/export/send without owner-level admin rights
- tighten shared-round permissions so editors cannot generate/export/send/delete and private PDF generation requires visibility
- update MCP/docs/backlog/changelog and add focused route/automation coverage

## Validation
- `git diff --check`
- `.venv/bin/python -m py_compile musicround/routes/rounds.py musicround/services/automation.py tests/test_rounds_routes.py tests/test_automation_service.py`
- `SECRET_KEY=test-secret-key-for-testing-only AUTOMATION_TOKEN=test-automation-token-for-testing SQLALCHEMY_DATABASE_URI=sqlite:////tmp/qb-public-role-pytest.db PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest tests/test_rounds_routes.py::TestRoundDetailRoute::test_round_owner_can_share_and_revoke_from_detail tests/test_rounds_routes.py::TestRoundDetailRoute::test_shared_editor_cannot_manage_round_shares tests/test_rounds_routes.py::TestRoundDetailRoute::test_round_owner_can_enable_and_disable_public_readonly_link tests/test_rounds_routes.py::TestRoundDetailRoute::test_public_round_link_honors_admin_setting_and_permissions tests/test_rounds_routes.py::TestRoundDetailRoute::test_shared_editor_cannot_produce_assets_or_delete_round tests/test_rounds_routes.py::TestRoundDetailRoute::test_shared_producer_can_generate_pdf_but_not_manage_or_delete tests/test_rounds_routes.py::TestRoundDetailRoute::test_private_round_pdf_generation_requires_visibility tests/test_automation_service.py::TestRoundAutomation::test_share_round_lifecycle tests/test_automation_service.py::TestRoundAutomation::test_round_public_link_lifecycle_requires_enabled_setting_and_manager -q`
