### PR TITLE
Add managed database diagnostics for agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   MCP helpers, and access-event audit entries.
 - Added producer sharing roles that can generate/export/send round assets
   without granting owner-level sharing or delete rights.
+- Added credential-safe MCP database configuration diagnostics for managed-DB
+  cutover planning.
+- Added JSON output for database status/preflight CLI diagnostics so automation
+  can gate managed-DB cutovers without scraping logs.
 - Added a chart/festival seed-source registry with run history, Flask-Admin
   views, migrations, and MCP automation helpers.
 - Added a browser round-ops workflow with round calendar, catalog/fatigue analytics, quizmaster planning briefs, round review/approval state, package quality inspection, actionable replacement suggestions, and browser review of announcement and per-track hint script drafts.

--- a/docs/admin-guide/managed-database-migration.md
+++ b/docs/admin-guide/managed-database-migration.md
@@ -27,6 +27,14 @@ database to a managed SQL database without exposing credentials in logs or Git.
    kubectl -n quizzicalbeats exec deploy/quizzicalbeats -c web -- python /app/run.py database status
    ```
 
+   For MCP agents, smoke scripts, or automation, use the equivalent JSON form.
+   It reports only redacted targets and PG* key names, never database passwords
+   or SQLite file paths:
+
+   ```bash
+   kubectl -n quizzicalbeats exec deploy/quizzicalbeats -c web -- python /app/run.py database status --json
+   ```
+
    Before the managed database cutover, run the stricter preflight. It fails
    with exit code `78` while legacy SQLite is still active or the PG*
    configuration is incomplete:
@@ -34,6 +42,9 @@ database to a managed SQL database without exposing credentials in logs or Git.
    ```bash
    kubectl -n quizzicalbeats exec deploy/quizzicalbeats -c web -- python /app/run.py database preflight
    ```
+
+   The preflight command also supports `--json` for automation while preserving
+   the same exit-code semantics.
 
    During early migration work, use `--allow-sqlite` only to collect the same
    diagnostics without blocking on the current SQLite state:

--- a/docs/developer-guide/architecture.md
+++ b/docs/developer-guide/architecture.md
@@ -88,8 +88,10 @@ Configuration is handled in `config.py` using environment variables loaded from 
 ```python
 class Config:
     # Core configuration
-    DEBUG = os.getenv("DEBUG", "True") == "True"
-    SECRET_KEY = os.getenv('SECRET_KEY', 'dev-key-please-change')
+    DEBUG = os.getenv("DEBUG", "False") == "True"
+    SECRET_KEY = os.getenv("SECRET_KEY")
+    if not SECRET_KEY:
+        raise ValueError("SECRET_KEY environment variable must be set.")
     
     # API keys for various services
     OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
@@ -98,7 +100,8 @@ class Config:
     LASTFM_API_KEY = os.getenv("LASTFM_API_KEY")
     
     # Database configuration
-    SQLALCHEMY_DATABASE_URI = os.environ.get('SQLALCHEMY_DATABASE_URI', 'sqlite:///data/song_data.db')
+    SQLALCHEMY_DATABASE_URI = os.environ.get("SQLALCHEMY_DATABASE_URI")
+    DATABASE_REQUIRE_MANAGED = bool_from_config(os.getenv("DATABASE_REQUIRE_MANAGED", "False"))
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     
     # OAuth provider configurations

--- a/docs/developer-guide/backlog-status.md
+++ b/docs/developer-guide/backlog-status.md
@@ -36,7 +36,7 @@ issue after verification or continue with the remaining follow-up.
 | #74 Store and review generated TTS scripts before audio assignment | Ready to close | `RoundAudioScript`, review routes, `generate_tts_from_script` | Verify approved script-to-audio assignment with configured TTS provider. |
 | #75 Add chart and festival seed source registry | Partial | `SeedSource`, `SeedSourceRun`, admin views, MCP registry/run tools | Scrapers/importers for individual chart/festival providers remain separate slices. |
 | #79 Add round ownership and sharing roles | Ready to close | `RoundShare`, `RoundAccessEvent`, owner filtering, viewer/editor/producer checks, MCP share tools, browser share/revoke UI, tokenized public read-only links | Verify browser and MCP roles after deploy. |
-| #126 Move production database configuration off SQLite `/data` | Operational / partial | Managed DB config, migration CLI, runbook, Compose managed-db profile | Live Kubernetes secret/config cutover and scheduled-email smoke remain. |
+| #126 Move production database configuration off SQLite `/data` | Operational / partial | Managed DB config, migration CLI, MCP config diagnostics, runbook, Compose managed-db profile | Live Kubernetes secret/config cutover and scheduled-email smoke remain. |
 | #12 Remove SQLite/RWO singleton | Operational / partial | Same as #126, plus app config hardening | Requires managed DB cutover, stateless replicas, and backup replacement. |
 | #17/#48/#49 Repair and clean broken round emails | Operational | Quality gate and repair tooling exist | Needs live QB/Gmail inspection and cleanup, not repo-only code. |
 

--- a/docs/developer-guide/mcp.md
+++ b/docs/developer-guide/mcp.md
@@ -38,6 +38,7 @@ The MCP server exposes these tools:
 | `find_songs` | Search the existing Quizzical Beats catalog before adding duplicates. |
 | `add_song` | Add or update a catalog song, including platform IDs and tags. |
 | `datastore_schema` | Describe all mapped datastore object types, columns, and primary keys. |
+| `database_configuration_summary` | Report credential-safe database backend, managed-DB guard, and PG* readiness for cutover checks. |
 | `list_datastore_objects` | List persisted objects with optional exact-match filters, ordering, limit, and offset. |
 | `get_datastore_object` | Fetch one persisted object by primary key. |
 | `create_datastore_object` | Create one persisted object from scalar column fields. |

--- a/musicround/mcp_server.py
+++ b/musicround/mcp_server.py
@@ -110,6 +110,12 @@ def datastore_schema() -> dict[str, Any]:
 
 
 @mcp.tool()
+def database_configuration_summary() -> dict[str, Any]:
+    """Return credential-safe database readiness details for cutover planning."""
+    return _with_app_context(automation.database_configuration_summary)
+
+
+@mcp.tool()
 def list_datastore_objects(
     object_type: str,
     filters: dict[str, Any] | None = None,

--- a/musicround/services/automation.py
+++ b/musicround/services/automation.py
@@ -19,6 +19,13 @@ from sqlalchemy import inspect as sa_inspect
 from sqlalchemy import or_
 
 from musicround import db
+from musicround.helpers.database_config import (
+    bool_from_config,
+    database_summary,
+    is_legacy_data_sqlite_uri,
+    managed_database_requirement_error,
+    postgres_env_readiness,
+)
 from musicround.helpers.email_helper import send_email
 from musicround.helpers.import_helper import ImportHelper
 from musicround.helpers.paths import app_data_path
@@ -209,6 +216,52 @@ def _round_access_event_summary(event: RoundAccessEvent) -> dict[str, Any]:
         "actor": _user_summary(event.actor),
         "target_user_id": event.target_user_id,
         "target_user": _user_summary(event.target_user),
+    }
+
+
+def database_configuration_summary() -> dict[str, Any]:
+    """Return credential-safe database readiness details for agent workflows."""
+    db_uri = current_app.config.get("SQLALCHEMY_DATABASE_URI")
+    summary = database_summary(db_uri)
+    managed_required = bool_from_config(current_app.config.get("DATABASE_REQUIRE_MANAGED"))
+    postgres_readiness = postgres_env_readiness(os.environ)
+    managed_error = managed_database_requirement_error(db_uri, managed_required)
+    issues: list[dict[str, Any]] = []
+
+    if managed_error:
+        issues.append(
+            {
+                "code": "managed_database_requirement_failed",
+                "message": managed_error,
+                "severity": "error",
+            }
+        )
+    elif is_legacy_data_sqlite_uri(db_uri):
+        issues.append(
+            {
+                "code": "legacy_sqlite_data_store",
+                "message": "Database is still configured to use the legacy /data SQLite file.",
+                "severity": "warning",
+                "hint": (
+                    "Configure a managed SQL URI or complete PG* credentials via "
+                    "secrets, then enable DATABASE_REQUIRE_MANAGED=true."
+                ),
+            }
+        )
+
+    status = "ok"
+    if any(issue["severity"] == "error" for issue in issues):
+        status = "error"
+    elif issues:
+        status = "warning"
+
+    return {
+        "ok": status != "error",
+        "status": status,
+        "managed_required": managed_required,
+        "database": summary,
+        "postgres_env": postgres_readiness,
+        "issues": issues,
     }
 
 

--- a/run.py
+++ b/run.py
@@ -40,7 +40,16 @@ def main():
 
     database_parser = subparsers.add_parser('database', help='Database diagnostics')
     database_subparsers = database_parser.add_subparsers(dest='database_action', help='Database action to perform')
-    database_subparsers.add_parser('status', help='Print the configured database backend without credentials')
+    status_parser = database_subparsers.add_parser(
+        'status',
+        help='Print the configured database backend without credentials',
+    )
+    status_parser.add_argument(
+        '--json',
+        action='store_true',
+        dest='json_output',
+        help='Print machine-readable credential-safe diagnostics',
+    )
     preflight_parser = database_subparsers.add_parser(
         'preflight',
         help='Validate managed database readiness without printing credentials',
@@ -49,6 +58,12 @@ def main():
         '--allow-sqlite',
         action='store_true',
         help='Report diagnostics without failing on SQLite; useful before cutover work starts',
+    )
+    preflight_parser.add_argument(
+        '--json',
+        action='store_true',
+        dest='json_output',
+        help='Print machine-readable credential-safe diagnostics',
     )
     migrate_parser = database_subparsers.add_parser(
         'migrate-sqlite',
@@ -144,8 +159,10 @@ def main():
         app.config.from_object(Config)
         if "SQLALCHEMY_DATABASE_URI" not in os.environ:
             app.config["SQLALCHEMY_DATABASE_URI"] = None
+        json_output = bool(getattr(args, "json_output", False))
+        preflight_requires_managed = args.database_action == 'preflight' and not args.allow_sqlite
         if args.database_action == 'preflight':
-            app.config['DATABASE_REQUIRE_MANAGED'] = not args.allow_sqlite
+            app.config['DATABASE_REQUIRE_MANAGED'] = preflight_requires_managed and not json_output
         try:
             _configure_database_uri(app)
         except RuntimeError as exc:
@@ -153,10 +170,36 @@ def main():
             return 78
         db_uri = app.config.get('SQLALCHEMY_DATABASE_URI')
         summary = database_summary(db_uri)
+        readiness = postgres_env_readiness(os.environ)
+        issues = []
+        if is_legacy_data_sqlite_uri(db_uri):
+            issues.append(
+                {
+                    "code": "legacy_sqlite_data_store",
+                    "severity": "warning",
+                    "message": "legacy /data SQLite database is configured",
+                    "hint": (
+                        "configure a managed SQL URI or complete PG* credentials "
+                        "via secrets for production"
+                    ),
+                }
+            )
+        diagnostics = {
+            "ok": True,
+            "status": "warning" if issues else "ok",
+            "managed_required": preflight_requires_managed or bool(app.config.get('DATABASE_REQUIRE_MANAGED')),
+            "database": summary,
+            "postgres_env": readiness,
+            "issues": issues,
+        }
+        if json_output:
+            print(json.dumps(diagnostics, indent=2, sort_keys=True))
+            if args.database_action == 'preflight' and issues and not args.allow_sqlite:
+                return 78
+            return 0
         print(f"Database backend: {summary['backend']}")
         print(f"Database target: {summary['redacted_uri']}")
         print(f"Managed database required: {bool(app.config.get('DATABASE_REQUIRE_MANAGED'))}")
-        readiness = postgres_env_readiness(os.environ)
         if readiness["configured"]:
             print(
                 "PostgreSQL env present: "

--- a/tests/test_automation_service.py
+++ b/tests/test_automation_service.py
@@ -539,6 +539,53 @@ class TestRoundAutomation:
 
             assert RoundAccessEvent.query.count() == 1
 
+    def test_database_configuration_summary_warns_for_legacy_sqlite(self, app):
+        """MCP database diagnostics should flag legacy SQLite without leaking paths."""
+        with app.app_context():
+            app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:////data/song_data.db"
+            app.config["DATABASE_BACKEND"] = "sqlite"
+            app.config["DATABASE_REQUIRE_MANAGED"] = False
+
+            result = automation.database_configuration_summary()
+
+        assert result["ok"] is True
+        assert result["status"] == "warning"
+        assert result["database"]["backend"] == "sqlite"
+        assert result["database"]["redacted_uri"] == "sqlite:///[local-file]"
+        assert result["issues"][0]["code"] == "legacy_sqlite_data_store"
+        assert "/data/song_data.db" not in repr(result)
+
+    def test_database_configuration_summary_is_credential_safe_for_pg_env(self, app, monkeypatch):
+        """MCP database diagnostics should expose key names but not secret values."""
+        monkeypatch.setenv("PGHOST", "postgres.internal")
+        monkeypatch.setenv("PGDATABASE", "quizzicalbeats")
+        monkeypatch.setenv("PGUSER", "qb_user")
+        monkeypatch.setenv("PGPASSWORD", "super-secret-password")
+        monkeypatch.setenv("PGSSLMODE", "require")
+        with app.app_context():
+            app.config["SQLALCHEMY_DATABASE_URI"] = (
+                "postgresql://qb_user:super-secret-password@postgres.internal/quizzicalbeats"
+            )
+            app.config["DATABASE_BACKEND"] = "postgresql"
+            app.config["DATABASE_REQUIRE_MANAGED"] = True
+
+            result = automation.database_configuration_summary()
+
+        assert result["ok"] is True
+        assert result["status"] == "ok"
+        assert result["managed_required"] is True
+        assert result["database"]["backend"] == "postgresql"
+        assert result["postgres_env"]["complete"] is True
+        assert result["postgres_env"]["present_required"] == [
+            "PGHOST",
+            "PGDATABASE",
+            "PGUSER",
+            "PGPASSWORD",
+        ]
+        serialized = repr(result)
+        assert "super-secret-password" not in serialized
+        assert "postgresql://qb_user:***@postgres.internal/quizzicalbeats" in serialized
+
     def test_list_round_access_events_requires_owner_or_admin_requester(self, app):
         with app.app_context():
             owner = _create_user(username="owner", email="owner@example.test")

--- a/tests/test_run_cli.py
+++ b/tests/test_run_cli.py
@@ -45,6 +45,49 @@ def test_database_status_warns_for_legacy_data_sqlite(monkeypatch, capsys):
     assert "complete PG* credentials" in output
 
 
+def test_database_status_json_reports_legacy_sqlite_safely(monkeypatch, capsys):
+    """Machine-readable database status should be safe for agent workflows."""
+    import run
+
+    monkeypatch.setenv("SECRET_KEY", "test-secret-key-for-testing-only")
+    monkeypatch.setenv("AUTOMATION_TOKEN", "test-automation-token-for-testing")
+    monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", "sqlite:////data/song_data.db")
+    monkeypatch.delenv("DATABASE_REQUIRE_MANAGED", raising=False)
+    monkeypatch.setattr(sys, "argv", ["run.py", "database", "status", "--json"])
+
+    exit_code = run.main()
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert exit_code == 0
+    assert payload["status"] == "warning"
+    assert payload["database"]["redacted_uri"] == "sqlite:///[local-file]"
+    assert payload["issues"][0]["code"] == "legacy_sqlite_data_store"
+    assert "/data/song_data.db" not in captured.out
+
+
+def test_database_preflight_json_blocks_legacy_sqlite(monkeypatch, capsys):
+    """JSON preflight should keep the same blocking semantics as text output."""
+    import run
+
+    monkeypatch.setenv("SECRET_KEY", "test-secret-key-for-testing-only")
+    monkeypatch.setenv("AUTOMATION_TOKEN", "test-automation-token-for-testing")
+    monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", "sqlite:////data/song_data.db")
+    monkeypatch.delenv("DATABASE_REQUIRE_MANAGED", raising=False)
+    monkeypatch.setattr(sys, "argv", ["run.py", "database", "preflight", "--json"])
+
+    exit_code = run.main()
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert exit_code == 78
+    assert payload["ok"] is True
+    assert payload["status"] == "warning"
+    assert payload["issues"][0]["code"] == "legacy_sqlite_data_store"
+    assert "/data/song_data.db" not in captured.out
+    assert "Traceback" not in captured.err
+
+
 def test_database_status_returns_safe_error_when_managed_guard_fails(monkeypatch, capsys):
     """The database runbook command should fail without a Python traceback."""
     import run


### PR DESCRIPTION
## Summary
- add credential-safe MCP database configuration diagnostics for managed-DB cutover planning
- add `run.py database status/preflight --json` so agents and smoke scripts can gate the cutover without log scraping
- refresh stale architecture documentation that still showed unsafe defaults and implicit production SQLite
- update managed database runbook, backlog status, MCP docs, and changelog

## Validation
- `git diff --check`
- `.venv/bin/python -m py_compile run.py musicround/services/automation.py musicround/mcp_server.py tests/test_automation_service.py tests/test_run_cli.py`
- `SECRET_KEY=test-secret-key-for-testing-only AUTOMATION_TOKEN=test-automation-token-for-testing SQLALCHEMY_DATABASE_URI=sqlite:////tmp/qb-db-diagnostics-pytest.db PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest tests/test_automation_service.py::TestRoundAutomation::test_database_configuration_summary_warns_for_legacy_sqlite tests/test_automation_service.py::TestRoundAutomation::test_database_configuration_summary_is_credential_safe_for_pg_env tests/test_app_factory.py::test_configure_database_uri_builds_from_postgres_env tests/test_run_cli.py::test_database_status_json_reports_legacy_sqlite_safely tests/test_run_cli.py::test_database_preflight_json_blocks_legacy_sqlite tests/test_run_cli.py::test_database_preflight_accepts_complete_pg_env -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added JSON output for database status and preflight checks, making automation and CI gating easier.
  * Added a database configuration summary that reports readiness in a credential-safe way.
* **Bug Fixes**
  * Improved database diagnostics to avoid exposing sensitive paths or credentials in output.
  * Legacy SQLite-backed configurations now report clearer warnings and blocking behavior during preflight.
* **Documentation**
  * Updated migration and developer docs to reflect the new JSON diagnostics and configuration expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->