### PR TITLE
Address PR 195 and 196 review follow-ups

### DIFF
--- a/docs/developer-guide/architecture.md
+++ b/docs/developer-guide/architecture.md
@@ -86,6 +86,11 @@ def create_app():
 Configuration is handled in `config.py` using environment variables loaded from a `.env` file:
 
 ```python
+import os
+
+from musicround.helpers.database_config import bool_from_config
+
+
 class Config:
     # Core configuration
     DEBUG = os.getenv("DEBUG", "False") == "True"

--- a/musicround/models.py
+++ b/musicround/models.py
@@ -265,7 +265,7 @@ class Round(db.Model):
     tag = db.Column(db.String(50))
     user_id = db.Column(db.Integer, db.ForeignKey('user.id', ondelete='SET NULL'), nullable=True)
     visibility = db.Column(db.String(20), default='private', nullable=False)
-    public_token = db.Column(db.String(64), unique=True, nullable=True)
+    public_token = db.Column(db.String(64), nullable=True)
     public_token_created_at = db.Column(db.DateTime, nullable=True)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
     updated_at = db.Column(db.DateTime, onupdate=datetime.utcnow)
@@ -281,7 +281,7 @@ class Round(db.Model):
         db.Index('idx_round_created_at', 'created_at'),
         db.Index('idx_round_generation_status', 'mp3_generated', 'pdf_generated'),
         db.Index('idx_round_owner_created', 'user_id', 'created_at'),
-        db.Index('idx_round_public_token', 'public_token'),
+        db.Index('idx_round_public_token', 'public_token', unique=True),
         db.Index('idx_round_review_status', 'review_status', 'approved_at'),
     )
 

--- a/musicround/routes/rounds.py
+++ b/musicround/routes/rounds.py
@@ -260,10 +260,19 @@ def _get_editable_round_or_404(round_id):
     return round_obj
 
 
+def _abort_production_forbidden():
+    response = jsonify({
+        'success': False,
+        'error': 'You do not have permission to produce assets for this round.',
+    })
+    response.status_code = 403
+    abort(response)
+
+
 def _get_producible_round_or_404(round_id):
     round_obj = _get_visible_round_or_404(round_id)
     if not _can_produce_round(round_obj):
-        abort(403)
+        _abort_production_forbidden()
     return round_obj
 
 

--- a/musicround/services/automation.py
+++ b/musicround/services/automation.py
@@ -193,6 +193,16 @@ def _user_summary(user: User | None) -> dict[str, Any] | None:
     }
 
 
+def _public_user_summary(user: User | None) -> dict[str, Any] | None:
+    if not user:
+        return None
+    return {
+        "id": user.id,
+        "username": user.username,
+        "name": " ".join(part for part in (user.first_name, user.last_name) if part) or None,
+    }
+
+
 def _round_share_summary(share: RoundShare) -> dict[str, Any]:
     return {
         "id": share.id,
@@ -355,7 +365,7 @@ def _public_round_summary(round_obj: Round) -> dict[str, Any]:
         "created_at": _datetime_payload(round_obj.created_at),
         "song_count": len(_round_song_ids(round_obj)),
         "songs": [_song_summary(song) for song in _ordered_round_songs(round_obj)],
-        "owner": _user_summary(round_obj.owner),
+        "owner": _public_user_summary(round_obj.owner),
     }
 
 

--- a/run.py
+++ b/run.py
@@ -160,9 +160,14 @@ def main():
         if "SQLALCHEMY_DATABASE_URI" not in os.environ:
             app.config["SQLALCHEMY_DATABASE_URI"] = None
         json_output = bool(getattr(args, "json_output", False))
-        preflight_requires_managed = args.database_action == 'preflight' and not args.allow_sqlite
-        if args.database_action == 'preflight':
-            app.config['DATABASE_REQUIRE_MANAGED'] = preflight_requires_managed and not json_output
+        allow_sqlite = bool(getattr(args, "allow_sqlite", False))
+        configured_managed_required = bool(app.config.get('DATABASE_REQUIRE_MANAGED'))
+        preflight_requires_managed = args.database_action == 'preflight' and not allow_sqlite
+        diagnostic_managed_required = preflight_requires_managed or configured_managed_required
+        if json_output and diagnostic_managed_required:
+            app.config['DATABASE_REQUIRE_MANAGED'] = False
+        elif args.database_action == 'preflight':
+            app.config['DATABASE_REQUIRE_MANAGED'] = preflight_requires_managed
         try:
             _configure_database_uri(app)
         except RuntimeError as exc:
@@ -172,7 +177,19 @@ def main():
         summary = database_summary(db_uri)
         readiness = postgres_env_readiness(os.environ)
         issues = []
-        if is_legacy_data_sqlite_uri(db_uri):
+        if diagnostic_managed_required and summary["backend"] == "sqlite":
+            issues.append(
+                {
+                    "code": "managed_database_requirement_failed",
+                    "severity": "error",
+                    "message": "managed database is required but SQLite is configured",
+                    "hint": (
+                        "configure a managed SQL URI or complete PG* credentials "
+                        "via secrets for production"
+                    ),
+                }
+            )
+        elif is_legacy_data_sqlite_uri(db_uri):
             issues.append(
                 {
                     "code": "legacy_sqlite_data_store",
@@ -185,16 +202,22 @@ def main():
                 }
             )
         diagnostics = {
-            "ok": True,
-            "status": "warning" if issues else "ok",
-            "managed_required": preflight_requires_managed or bool(app.config.get('DATABASE_REQUIRE_MANAGED')),
+            "ok": not any(issue["severity"] == "error" for issue in issues),
+            "status": (
+                "error"
+                if any(issue["severity"] == "error" for issue in issues)
+                else "warning" if issues else "ok"
+            ),
+            "managed_required": diagnostic_managed_required,
             "database": summary,
             "postgres_env": readiness,
             "issues": issues,
         }
         if json_output:
             print(json.dumps(diagnostics, indent=2, sort_keys=True))
-            if args.database_action == 'preflight' and issues and not args.allow_sqlite:
+            if any(issue["severity"] == "error" for issue in issues):
+                return 78
+            if args.database_action == 'preflight' and issues and not allow_sqlite:
                 return 78
             return 0
         print(f"Database backend: {summary['backend']}")

--- a/tests/test_automation_service.py
+++ b/tests/test_automation_service.py
@@ -642,6 +642,12 @@ class TestRoundAutomation:
             assert enabled["round"]["public_link_enabled"] is True
             assert public["round"]["name"] == "Public Link Round"
             assert public["round"]["songs"][0]["title"] == "Public Song"
+            assert public["round"]["owner"] == {
+                "id": owner.id,
+                "username": owner.username,
+                "name": None,
+            }
+            assert "email" not in public["round"]["owner"]
             assert refreshed["created"] is False
             assert refreshed["public_token"] == enabled["public_token"]
             assert refreshed["access_event"]["action"] == "public_link_refreshed"

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -296,6 +296,11 @@ def test_add_round_collaboration_and_audio_scripts_to_legacy_database(tmp_path):
     }
     assert "user_id" in Round.__table__.columns.keys()
     assert "public_token" in Round.__table__.columns.keys()
+    assert Round.__table__.columns["public_token"].unique is not True
+    assert any(
+        index.name == "idx_round_public_token" and index.unique
+        for index in Round.__table__.indexes
+    )
     assert RoundShare.__tablename__ == "round_share"
     assert RoundAccessEvent.__tablename__ == "round_access_event"
     assert RoundAudioScript.__tablename__ == "round_audio_script"

--- a/tests/test_rounds_routes.py
+++ b/tests/test_rounds_routes.py
@@ -542,9 +542,29 @@ class TestRoundDetailRoute:
 
         assert update.status_code == 302
         assert mp3.status_code == 403
+        assert mp3.is_json
+        assert mp3.get_json() == {
+            'success': False,
+            'error': 'You do not have permission to produce assets for this round.',
+        }
         assert pdf.status_code == 403
+        assert pdf.is_json
+        assert pdf.get_json() == {
+            'success': False,
+            'error': 'You do not have permission to produce assets for this round.',
+        }
         assert mail.status_code == 403
+        assert mail.is_json
+        assert mail.get_json() == {
+            'success': False,
+            'error': 'You do not have permission to produce assets for this round.',
+        }
         assert dropbox.status_code == 403
+        assert dropbox.is_json
+        assert dropbox.get_json() == {
+            'success': False,
+            'error': 'You do not have permission to produce assets for this round.',
+        }
         assert delete.status_code == 403
         with app.app_context():
             assert db.session.get(Round, round_id).name == 'Editor Still Can Edit'

--- a/tests/test_run_cli.py
+++ b/tests/test_run_cli.py
@@ -81,9 +81,35 @@ def test_database_preflight_json_blocks_legacy_sqlite(monkeypatch, capsys):
     payload = json.loads(captured.out)
 
     assert exit_code == 78
-    assert payload["ok"] is True
-    assert payload["status"] == "warning"
-    assert payload["issues"][0]["code"] == "legacy_sqlite_data_store"
+    assert payload["ok"] is False
+    assert payload["status"] == "error"
+    assert payload["managed_required"] is True
+    assert payload["issues"][0]["code"] == "managed_database_requirement_failed"
+    assert "/data/song_data.db" not in captured.out
+    assert "Traceback" not in captured.err
+
+
+def test_database_status_json_reports_managed_guard_error(monkeypatch, capsys):
+    """JSON status should expose managed-DB violations without a traceback."""
+    import run
+
+    monkeypatch.setenv("SECRET_KEY", "test-secret-key-for-testing-only")
+    monkeypatch.setenv("AUTOMATION_TOKEN", "test-automation-token-for-testing")
+    monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", "sqlite:////data/song_data.db")
+    monkeypatch.setenv("DATABASE_REQUIRE_MANAGED", "true")
+    from musicround.config import Config
+    monkeypatch.setattr(Config, "DATABASE_REQUIRE_MANAGED", True)
+    monkeypatch.setattr(sys, "argv", ["run.py", "database", "status", "--json"])
+
+    exit_code = run.main()
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert exit_code == 78
+    assert payload["ok"] is False
+    assert payload["status"] == "error"
+    assert payload["managed_required"] is True
+    assert payload["issues"][0]["code"] == "managed_database_requirement_failed"
     assert "/data/song_data.db" not in captured.out
     assert "Traceback" not in captured.err
 


### PR DESCRIPTION
## Summary
- hide public round owner email addresses from token-based public access
- keep public round token uniqueness on the named index only and return JSON 403s for produce actions
- make JSON database diagnostics report managed-DB violations as error states, and document required config imports

## Validation
- python3 -m py_compile run.py musicround/services/automation.py musicround/models.py musicround/routes/rounds.py tests/test_automation_service.py tests/test_migrations.py tests/test_rounds_routes.py tests/test_run_cli.py
- git diff --check

Focused pytest and direct CLI runs could not complete locally because the available old QuizzicalBeats venv hangs while importing Flask-SQLAlchemy/SQLAlchemy before test execution, and system Python lacks the project runtime packages.