### PR TITLE
Keep JSON database diagnostics side-effect free

### DIFF
--- a/run.py
+++ b/run.py
@@ -33,6 +33,7 @@ def _configured_database_uri_without_fallback(app):
         return configured_uri
     return database_uri_from_postgres_env(os.environ)
 
+
 def main():
     # Create argument parser
     parser = argparse.ArgumentParser(description='Quizzical Beats Management Script')

--- a/run.py
+++ b/run.py
@@ -21,6 +21,18 @@ def _create_database_cli_app():
     db.init_app(app)
     return app
 
+
+def _configured_database_uri_without_fallback(app):
+    """Resolve explicit database config without creating the local fallback."""
+    from musicround.helpers.database_config import database_uri_from_postgres_env
+
+    configured_uri = os.environ.get("SQLALCHEMY_DATABASE_URI") or app.config.get(
+        "SQLALCHEMY_DATABASE_URI"
+    )
+    if configured_uri:
+        return configured_uri
+    return database_uri_from_postgres_env(os.environ)
+
 def main():
     # Create argument parser
     parser = argparse.ArgumentParser(description='Quizzical Beats Management Script')
@@ -164,20 +176,39 @@ def main():
         configured_managed_required = bool(app.config.get('DATABASE_REQUIRE_MANAGED'))
         preflight_requires_managed = args.database_action == 'preflight' and not allow_sqlite
         diagnostic_managed_required = preflight_requires_managed or configured_managed_required
-        if json_output and diagnostic_managed_required:
-            app.config['DATABASE_REQUIRE_MANAGED'] = False
-        elif args.database_action == 'preflight':
-            app.config['DATABASE_REQUIRE_MANAGED'] = preflight_requires_managed
-        try:
-            _configure_database_uri(app)
-        except RuntimeError as exc:
-            print(f"Database configuration error: {exc}", file=sys.stderr)
-            return 78
-        db_uri = app.config.get('SQLALCHEMY_DATABASE_URI')
+        if json_output:
+            try:
+                db_uri = _configured_database_uri_without_fallback(app)
+            except ValueError as exc:
+                print(f"Database configuration error: {exc}", file=sys.stderr)
+                return 78
+            if db_uri:
+                app.config['SQLALCHEMY_DATABASE_URI'] = db_uri
+        else:
+            if args.database_action == 'preflight':
+                app.config['DATABASE_REQUIRE_MANAGED'] = preflight_requires_managed
+            try:
+                _configure_database_uri(app)
+            except RuntimeError as exc:
+                print(f"Database configuration error: {exc}", file=sys.stderr)
+                return 78
+            db_uri = app.config.get('SQLALCHEMY_DATABASE_URI')
         summary = database_summary(db_uri)
         readiness = postgres_env_readiness(os.environ)
         issues = []
-        if diagnostic_managed_required and summary["backend"] == "sqlite":
+        if diagnostic_managed_required and summary["backend"] == "unconfigured":
+            issues.append(
+                {
+                    "code": "managed_database_requirement_failed",
+                    "severity": "error",
+                    "message": "managed database is required but no database is configured",
+                    "hint": (
+                        "configure a managed SQL URI or complete PG* credentials "
+                        "via secrets for production"
+                    ),
+                }
+            )
+        elif diagnostic_managed_required and summary["backend"] == "sqlite":
             issues.append(
                 {
                     "code": "managed_database_requirement_failed",

--- a/tests/test_run_cli.py
+++ b/tests/test_run_cli.py
@@ -66,6 +66,68 @@ def test_database_status_json_reports_legacy_sqlite_safely(monkeypatch, capsys):
     assert "/data/song_data.db" not in captured.out
 
 
+def test_database_status_json_reports_unconfigured_without_fallback(
+    monkeypatch,
+    capsys,
+    tmp_path,
+):
+    """JSON status should not create or reveal the local SQLite fallback path."""
+    import run
+
+    data_dir = tmp_path / "data"
+    monkeypatch.setenv("SECRET_KEY", "test-secret-key-for-testing-only")
+    monkeypatch.setenv("AUTOMATION_TOKEN", "test-automation-token-for-testing")
+    monkeypatch.delenv("SQLALCHEMY_DATABASE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_REQUIRE_MANAGED", raising=False)
+    monkeypatch.setenv("DATA_DIR", str(data_dir))
+    monkeypatch.setattr(sys, "argv", ["run.py", "database", "status", "--json"])
+
+    exit_code = run.main()
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert exit_code == 0
+    assert payload["ok"] is True
+    assert payload["status"] == "ok"
+    assert payload["database"]["backend"] == "unconfigured"
+    assert payload["database"]["redacted_uri"] == "unconfigured"
+    assert str(data_dir) not in captured.out
+    assert str(data_dir) not in captured.err
+    assert not data_dir.exists()
+
+
+def test_database_preflight_json_blocks_unconfigured_without_fallback(
+    monkeypatch,
+    capsys,
+    tmp_path,
+):
+    """JSON preflight should fail managed cutover without creating SQLite state."""
+    import run
+
+    data_dir = tmp_path / "data"
+    monkeypatch.setenv("SECRET_KEY", "test-secret-key-for-testing-only")
+    monkeypatch.setenv("AUTOMATION_TOKEN", "test-automation-token-for-testing")
+    monkeypatch.delenv("SQLALCHEMY_DATABASE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_REQUIRE_MANAGED", raising=False)
+    monkeypatch.setenv("DATA_DIR", str(data_dir))
+    monkeypatch.setattr(sys, "argv", ["run.py", "database", "preflight", "--json"])
+
+    exit_code = run.main()
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert exit_code == 78
+    assert payload["ok"] is False
+    assert payload["status"] == "error"
+    assert payload["managed_required"] is True
+    assert payload["database"]["backend"] == "unconfigured"
+    assert payload["issues"][0]["code"] == "managed_database_requirement_failed"
+    assert str(data_dir) not in captured.out
+    assert str(data_dir) not in captured.err
+    assert not data_dir.exists()
+    assert "Traceback" not in captured.err
+
+
 def test_database_preflight_json_blocks_legacy_sqlite(monkeypatch, capsys):
     """JSON preflight should keep the same blocking semantics as text output."""
     import run


### PR DESCRIPTION
## Summary
- keep database status/preflight JSON diagnostics from initializing the local SQLite fallback
- report unconfigured managed-preflight state as a safe structured error
- cover unconfigured JSON diagnostics with no path leak and no fallback directory creation

## Validation
- python3 -m py_compile run.py tests/test_run_cli.py
- git diff --check
- python3 -m pytest tests/test_run_cli.py -k "database_status_json_reports_unconfigured_without_fallback or database_preflight_json_blocks_unconfigured_without_fallback or database_status_json_reports_legacy_sqlite_safely or database_preflight_json_blocks_legacy_sqlite" *(blocked locally: system Python has no pytest)*
- direct CLI smoke *(blocked locally before app startup: system Python has no python-dotenv)*