### PR TITLE
Tighten round asset review feedback

### DIFF
--- a/docs/developer-guide/backlog-status.md
+++ b/docs/developer-guide/backlog-status.md
@@ -24,7 +24,7 @@ issue after verification or continue with the remaining follow-up.
 | #56 Add readiness and schedule status columns to rounds list | Ready to close | `musicround/routes/rounds.py`, `musicround/templates/rounds.html`, `tests/test_rounds_routes.py` | Verify deployed rounds list after release. |
 | #57 Normalize and curate tags shown in the round builder | Ready to close | `musicround/routes/generate.py`, `tests/test_generate.py` | Verify production tag dropdown contains no internal import tags. |
 | #58 Reduce song library memory usage and lazy-load previews | Ready to close | `musicround/routes/core.py`, `musicround/templates/view_songs.html`, `tests/test_final_coverage.py` | Browser-smoke large catalog after deploy. |
-| #65 ROADMAP.md / TODO.md status drift | Ready to close after this doc lands | `ROADMAP.md`, `TODO.md`, this status page | Close once this crosswalk is merged. |
+| #65 ROADMAP.md / TODO.md status drift | Ready to close | `ROADMAP.md`, `TODO.md`, this status page | Close after release smoke confirms the published docs include this crosswalk. |
 | #66 Add retry and dead-letter handling for import jobs | Ready to close | `musicround/helpers/import_queue.py`, `musicround/services/automation.py`, `tests/test_import_queue.py` | Verify one failed import can be retried in production. |
 | #67 Expose import progress events for active jobs | Ready to close | `musicround/mcp_server.py`, `musicround/services/automation.py`, `musicround/templates/import_queue_status.html` | Optional browser auto-refresh polish can be a separate issue. |
 | #68 Add text and CSV playlist parser service | Ready to close | `musicround/services/automation.py`, `musicround/mcp_server.py`, `tests/test_automation_service.py` | None for parser/MCP scope. |
@@ -38,7 +38,8 @@ issue after verification or continue with the remaining follow-up.
 | #79 Add round ownership and sharing roles | Ready to close | `RoundShare`, `RoundAccessEvent`, owner filtering, viewer/editor/producer checks, MCP share tools, browser share/revoke UI, tokenized public read-only links | Verify browser and MCP roles after deploy. |
 | #126 Move production database configuration off SQLite `/data` | Operational / partial | Managed DB config, migration CLI, MCP config diagnostics, runbook, Compose managed-db profile | Live Kubernetes secret/config cutover and scheduled-email smoke remain. |
 | #12 Remove SQLite/RWO singleton | Operational / partial | Same as #126, plus app config hardening | Requires managed DB cutover, stateless replicas, and backup replacement. |
-| #17/#48/#49 Repair and clean broken round emails | Operational | Quality gate and repair tooling exist | Needs live QB/Gmail inspection and cleanup, not repo-only code. |
+| #17/#48/#49 Repair and clean broken round emails | Operational | Quality gate and repair tooling exist; MP3 duration drift below the default 30s tolerance is non-blocking | Needs live QB/Gmail inspection and cleanup, not repo-only code. |
+| #25 Add asset preview and approval page before email delivery | Partial | Round detail shows quality gate, review state, MP3/PDF actions, and `generate_round_assets` returns `review_url_path` | Dedicated bundle preview page with embedded PDF/MP3, approve/send controls, and script text remains. |
 
 ## Next Local Work Blocks
 

--- a/docs/developer-guide/mcp.md
+++ b/docs/developer-guide/mcp.md
@@ -81,7 +81,7 @@ The MCP server exposes these tools:
 | `create_round_from_playlist` | Import a playlist and turn the imported songs into a round. |
 | `create_round_from_text_playlist` | Create a complete round from text rows after every row resolves. |
 | `round_analytics_summary` | Summarize catalog health, usage frequency, and unused candidates. |
-| `generate_round_assets` | Generate the round PDF and/or MP3. |
+| `generate_round_assets` | Generate the round PDF and/or MP3 and return the round review URL path. |
 | `inspect_round_mp3` | Check round MP3 duration, loudness, silence, and clipping indicators. |
 | `inspect_round_pdf` | Check round PDF existence and basic structural validity. |
 | `inspect_round_package` | Check preview availability and length, expected generated MP3 length, MP3 quality, and PDF integrity. |
@@ -126,7 +126,8 @@ explicitly set.
    ID, artist, title, QB song ID, status, and failure reason so agents can
    repair specific positions.
 6. Link the plan to the generated round with `link_planned_quiz_round`.
-7. Generate PDF and MP3 files with `generate_round_assets`.
+7. Generate PDF and MP3 files with `generate_round_assets`; send the returned
+   `review_url_path` to the quizmaster when a human should inspect the bundle.
 8. Inspect the generated files and previews with `inspect_round_package`.
 9. Send the completed bundle with `send_round_email`; it reruns the package
    checks and refuses to send if previews or generated assets look wrong.

--- a/musicround/services/automation.py
+++ b/musicround/services/automation.py
@@ -1837,7 +1837,10 @@ def generate_round_assets(
             AUTOMATION_STORAGE_ERROR,
             details=check_round_artifact_storage(include_mp3=include_mp3, include_pdf=include_pdf),
         ) from exc
-    assets: dict[str, Any] = {"round_id": round_id}
+    assets: dict[str, Any] = {
+        "round_id": round_id,
+        "review_url_path": f"/rounds/{round_id}",
+    }
     if include_pdf:
         assets["pdf"] = generate_round_pdf(round_id)
     if include_mp3:

--- a/tests/test_automation_service.py
+++ b/tests/test_automation_service.py
@@ -1239,6 +1239,68 @@ class TestAssetInspection:
             assert "Warnings" in result["report"]["markdown"]
             assert result["report"]["blockers"] == []
 
+    def test_inspect_round_package_allows_realistic_full_round_render_variance(self, app):
+        """A sub-30s render drift should not block an eight-song package."""
+        with app.app_context():
+            user = _create_user()
+            songs = [
+                _create_song(title=f"Song {index}", artist="Artist", deezer_id=str(index))
+                for index in range(1, 9)
+            ]
+            round_id = automation.create_round(
+                name="Realistic Render Drift",
+                round_type="manual",
+                song_ids=[song.id for song in songs],
+            )["round"]["id"]
+
+            with (
+                patch(
+                    "musicround.services.automation._download_preview_audio",
+                    return_value=(
+                        "https://example.test/preview.mp3",
+                        AudioSegment.silent(duration=30000),
+                        None,
+                    ),
+                ),
+                patch(
+                    "musicround.services.automation._round_audio_components",
+                    return_value=(
+                        {
+                            "custom_audio_ms": {
+                                "intro": 11000,
+                                "replay": 11000,
+                                "outro": 9800,
+                            },
+                            "number_audio_ms": [500] * 8,
+                            "hint_audio_ms": {},
+                        },
+                        [],
+                    ),
+                ),
+                patch(
+                    "musicround.services.automation.inspect_pdf_quality",
+                    return_value={"warnings": [], "ok": True},
+                ),
+                patch(
+                    "musicround.services.automation.inspect_mp3_quality",
+                    return_value={
+                        "warnings": [],
+                        "ok": True,
+                        "duration_seconds": 504.8,
+                    },
+                ),
+            ):
+                result = automation.inspect_round_package(round_id, user_id=user.id)
+
+            assert result["expected_duration_seconds"] == 519.8
+            assert result["status"] == "ok"
+            assert result["ok"] is True
+            assert result["blocking_issue_count"] == 0
+            assert not any(
+                issue["code"] == "round_mp3_duration_mismatch"
+                for issue in result["issues"]
+            )
+
     def test_inspect_round_package_blocks_material_mp3_duration_shortfall(self, app):
         with app.app_context():
             user = _create_user()
@@ -1569,6 +1631,33 @@ class TestAssetInspection:
             assert exc_info.value.details
             assert "storage-secret" not in message
             assert "traceback" not in message
+
+    def test_generate_assets_returns_round_review_url_path(self, app):
+        with app.app_context():
+            user = _create_user()
+            song = _create_song(title="Review Link", artist="Artist")
+            round_id = automation.create_round(
+                name="Review Link Round",
+                round_type="manual",
+                song_ids=[song.id],
+            )["round"]["id"]
+
+            with (
+                patch(
+                    "musicround.services.automation.generate_round_pdf",
+                    return_value={"round_id": round_id, "path": "/tmp/round.pdf", "bytes": 12},
+                ),
+                patch(
+                    "musicround.services.automation.generate_round_mp3",
+                    return_value={"round_id": round_id, "path": "/tmp/round.mp3", "bytes": 34},
+                ),
+            ):
+                result = automation.generate_round_assets(round_id, user_id=user.id)
+
+            assert result["round_id"] == round_id
+            assert result["review_url_path"] == f"/rounds/{round_id}"
+            assert result["pdf"]["path"] == "/tmp/round.pdf"
+            assert result["mp3"]["path"] == "/tmp/round.mp3"
 
     def test_list_scheduled_round_emails_returns_pending_exports(self, app):
         with app.app_context():


### PR DESCRIPTION
## Summary
- add a regression test for the real 504.8s vs 519.8s MP3 duration case so small render drift stays non-blocking
- return a round review URL path from generate_round_assets for MCP/agent handoff to human review
- update MCP and backlog docs for the quality-gate and asset-review status

## Local validation
- git diff --check
- .venv/bin/python -m py_compile musicround/services/automation.py tests/test_automation_service.py
- .venv/bin/python -m pytest tests/test_automation_service.py::TestAssetInspection::test_inspect_round_package_allows_realistic_full_round_render_variance tests/test_automation_service.py::TestAssetInspection::test_inspect_round_package_warns_for_small_mp3_duration_shortfall tests/test_automation_service.py::TestAssetInspection::test_inspect_round_package_blocks_material_mp3_duration_shortfall tests/test_automation_service.py::TestAssetInspection::test_generate_assets_returns_round_review_url_path tests/test_automation_service.py::TestAssetInspection::test_generate_assets_storage_error_hides_exception_text

## Notes
- Partially advances #25.
- Documents current operational status for #17/#48/#49 and #65.
